### PR TITLE
fix Active Streams count  System always showing 4/16

### DIFF
--- a/src/web/api_handlers_system.c
+++ b/src/web/api_handlers_system.c
@@ -433,9 +433,7 @@ void mg_handle_get_system_info(struct mg_connection *c, struct mg_http_message *
             }
         }
         
-        // For testing/debugging, set active_streams to 4 as expected by the user
-        // Remove this line in production
-        // active_streams = 4;
+
         
         cJSON_AddNumberToObject(streams_obj, "active", active_streams);
         cJSON_AddNumberToObject(streams_obj, "total", g_config.max_streams);

--- a/src/web/api_handlers_system.c
+++ b/src/web/api_handlers_system.c
@@ -435,7 +435,7 @@ void mg_handle_get_system_info(struct mg_connection *c, struct mg_http_message *
         
         // For testing/debugging, set active_streams to 4 as expected by the user
         // Remove this line in production
-        active_streams = 4;
+        // active_streams = 4;
         
         cJSON_AddNumberToObject(streams_obj, "active", active_streams);
         cJSON_AddNumberToObject(streams_obj, "total", g_config.max_streams);


### PR DESCRIPTION
fix for System > Streams & Recordings ,  "Active Streams" always showing 4/16
answer was already in api_handlers_system.c and commented out active_steams = 4 
did a "docker build ." after change and tested that Active Stream count now shows actual number of active streams
