### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/web/js/components/preact/timeline/TimelinePage.jsx
+++ b/web/js/components/preact/timeline/TimelinePage.jsx
@@ -179,7 +179,6 @@ export function TimelinePage() {
   // Load streams using preact-query
   const {
     data: streamsData,
-    isLoading: isLoadingStreams,
     error: streamsError
   } = useQuery('streams', '/api/streams', {
     timeout: 15000, // 15 second timeout


### PR DESCRIPTION
To fix the problem, remove the unused binding from the destructuring of the `useQuery` return value so that only the actually used properties are kept. This preserves all existing behavior while eliminating the unused variable.

Concretely, in `web/js/components/preact/timeline/TimelinePage.jsx` at lines 180–188, `isLoading: isLoadingStreams` is destructured but never used. We should remove that entry from the object pattern, leaving `data: streamsData` and `error: streamsError` intact. No additional imports or helper methods are needed; this is a simple change to the destructuring pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._