### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/web/js/components/preact/FullscreenManager.jsx
+++ b/web/js/components/preact/FullscreenManager.jsx
@@ -152,23 +152,6 @@ export function FullscreenManager({ isFullscreen, setIsFullscreen, targetId = 'l
         setIsFullscreen(prev => !prev);
       }
     };
-
-    // Create a wrapper function for exitFullscreenMode
-    const exitFullscreenModeWrapper = (e, setterFunc) => {
-      // If this was called from an event, stop propagation
-      if (e) {
-        e.stopPropagation();
-        e.preventDefault();
-      }
-
-      // If setterFunc is provided, use it (for backward compatibility)
-      if (typeof setterFunc === 'function') {
-        setterFunc(false);
-      } else {
-        // Otherwise use our internal state
-        setIsFullscreen(false);
-      }
-    };
   }, [setIsFullscreen]);
 
   // Render the exit button if in fullscreen mode


### PR DESCRIPTION
To fix the problem, we should remove the unused `exitFullscreenModeWrapper` constant (and its accompanying comment) from the `useEffect` hook so that there are no unused local variables. This preserves all existing behavior because the function is never referenced or invoked.

Concretely, in `web/js/components/preact/FullscreenManager.jsx`, within the `useEffect` that starts around line 139, delete the block starting at the comment `// Create a wrapper function for exitFullscreenMode` through the closing brace of the `exitFullscreenModeWrapper` function. Keep the `useEffect` itself intact, and keep `toggleFullscreenWrapper` as-is unless and until it is also reported as unused.

This change requires no new imports, no new methods, and no other definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._