### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/tests/integration/pages/TimelinePage.ts
+++ b/tests/integration/pages/TimelinePage.ts
@@ -2,7 +2,7 @@
  * Timeline Page Object Model
  */
 
-import { Page, Locator } from '@playwright/test';
+import { Locator } from '@playwright/test';
 import { BasePage } from './BasePage';
 import { CONFIG, sleep } from '../fixtures/test-fixtures';
 


### PR DESCRIPTION
To fix the problem, we should remove the unused `Page` symbol from the import statement while keeping the used `Locator` import intact. This eliminates dead code and satisfies the static analysis rule without affecting functionality.

Concretely, in `tests/integration/pages/TimelinePage.ts`, update the import on line 5 from `import { Page, Locator } from '@playwright/test';` to only import `Locator`. No other lines in this file need to change, and no new methods or additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._