### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/web/js/components/preact/StreamConfigModal.jsx
+++ b/web/js/components/preact/StreamConfigModal.jsx
@@ -64,7 +64,6 @@ export function StreamConfigModal({
 }) {
   const [showZoneEditor, setShowZoneEditor] = useState(false);
   const [detectionZones, setDetectionZones] = useState(currentStream.detectionZones || []);
-  const [zonesLoading, setZonesLoading] = useState(false);
 
   // Load zones from API when modal opens for existing stream
   useEffect(() => {
@@ -73,7 +72,6 @@ export function StreamConfigModal({
         return;
       }
 
-      setZonesLoading(true);
       try {
         const response = await fetch(`/api/streams/${encodeURIComponent(currentStream.name)}/zones`);
         if (response.ok) {
@@ -89,8 +87,6 @@ export function StreamConfigModal({
         }
       } catch (error) {
         console.error('Error loading zones:', error);
-      } finally {
-        setZonesLoading(false);
       }
     };
 


### PR DESCRIPTION
In general, to fix an unused state variable in a React component, either (1) start actually using it where appropriate (e.g., to display loading UI), or (2) remove the state and all references to it if it is not needed. Since there is no existing use of `zonesLoading` to drive any UI or logic, the least intrusive fix that does not change current functionality is to remove the unused state.

Concretely in `web/js/components/preact/StreamConfigModal.jsx`:

- Remove the `zonesLoading` state declaration on line 67:
  - Delete `const [zonesLoading, setZonesLoading] = useState(false);`
- Remove the two calls to `setZonesLoading` inside the `loadZones` `useEffect`:
  - The `setZonesLoading(true);` before the `try` block.
  - The `setZonesLoading(false);` in the `finally` block.

No new imports, methods, or definitions are required. This keeps the behavior identical: previously there was no UI depending on `zonesLoading`, so removing it does not change what the user sees.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._