### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/web/js/components/preact/timeline/TimelineControls.jsx
+++ b/web/js/components/preact/timeline/TimelineControls.jsx
@@ -340,16 +340,6 @@ export function TimelineControls() {
     }
   };
 
-  // Play a specific segment
-  const playSegment = (index) => {
-    // This function will be implemented in the TimelinePlayer component
-    // Here we just update the state
-    timelineState.setState({
-      currentSegmentIndex: index,
-      isPlaying: true
-    });
-  };
-
   // ── Helper: get the center hour for zoom (cursor position or range midpoint) ──
   const getCenter = () => {
     const s = timelineState.timelineStartHour ?? 0;


### PR DESCRIPTION
In general, to fix an "unused variable/function" issue, either remove the unused symbol or ensure it is actually used where intended. Since `playSegment` is a placeholder that just re-sets state already controlled elsewhere and is not referenced, the best fix without changing existing behavior is to remove the unused `playSegment` definition. This does not affect any current functionality because nothing calls it.

Concretely:
- In `web/js/components/preact/timeline/TimelineControls.jsx`, remove the entire `playSegment` function block (lines 343–351 in the snippet).
- No imports, methods, or definitions elsewhere need to change because `playSegment` is local only.
- This reduces noise and satisfies the CodeQL rule without altering runtime behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._