### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -2,7 +2,7 @@
 // Migrated from Snowpack configuration
 
 import { defineConfig } from 'vite';
-import { resolve, join, basename, dirname } from 'path';
+import { resolve, basename, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import legacy from '@vitejs/plugin-legacy';
 import preact from '@preact/preset-vite';


### PR DESCRIPTION
To fix the problem, we should remove the unused `join` identifier from the destructuring import from `'path'` and leave the other imported members intact. This preserves all existing behavior while eliminating the dead import.

Concretely, in `web/vite.config.js`, locate line 5:

```js
import { resolve, join, basename, dirname } from 'path';
```

Edit it so that `join` is no longer imported:

```js
import { resolve, basename, dirname } from 'path';
```

No other changes, methods, or imports are needed, since we are only cleaning up an unused symbol.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._