### PR TITLE
fix: batch delete cancel button does not work (#171) + CI fix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -306,13 +306,12 @@ jobs:
           echo ""
           echo "=== Running Playwright tests ==="
 
-          # Run Playwright tests with output capture
-          # global-setup.ts starts lightNVR which internally starts go2rtc
-          # global-setup.ts then registers test streams via API
-          set +e
-          npx playwright test --project=ui 2>&1 | tee playwright-output.log
-          RESULT=${PIPESTATUS[0]}
-          set -e
+          # Run Playwright tests with output capture.
+          # Avoid ${PIPESTATUS[0]} — it is bash-only and the container
+          # shell is /bin/sh (dash).  Capture the exit code directly.
+          RESULT=0
+          npx playwright test --project=ui > playwright-output.log 2>&1 || RESULT=$?
+          cat playwright-output.log
 
           if [ $RESULT -ne 0 ]; then
             echo ""

--- a/tests/integration/global-teardown.ts
+++ b/tests/integration/global-teardown.ts
@@ -27,16 +27,33 @@ async function stopLightNVR(): Promise<void> {
         process.kill(pid, 'SIGTERM');
         console.log(`Sent SIGTERM to PID ${pid}`);
 
-        // Wait a bit for graceful shutdown
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        // Wait for graceful shutdown — lightNVR's cleanup can take up to
+        // ~50 seconds (phase 1: 30s + phase 2: 15s + margin).  Poll every
+        // second so we don't wait longer than necessary.
+        const maxWaitMs = 60_000;
+        const pollMs = 1_000;
+        const deadline = Date.now() + maxWaitMs;
+        let alive = true;
+        while (alive && Date.now() < deadline) {
+          await new Promise(resolve => setTimeout(resolve, pollMs));
+          try {
+            process.kill(pid, 0); // throws if process is gone
+          } catch {
+            alive = false;
+          }
+        }
 
-        // Check if still running and force kill
-        try {
-          process.kill(pid, 0); // Check if process exists
-          process.kill(pid, 'SIGKILL');
-          console.log(`Sent SIGKILL to PID ${pid}`);
-        } catch (e) {
-          // Process already dead
+        if (alive) {
+          // Still running after timeout — force kill
+          console.log(`lightNVR still running after ${maxWaitMs / 1000}s, sending SIGKILL`);
+          try {
+            process.kill(pid, 'SIGKILL');
+            console.log(`Sent SIGKILL to PID ${pid}`);
+          } catch {
+            // Process died between check and kill
+          }
+        } else {
+          console.log('lightNVR shut down gracefully');
         }
       } catch (e) {
         console.log(`Process ${pid} already stopped`);


### PR DESCRIPTION
## Summary

Fixes #171 — Cancelling Batch Delete operations does not work.

### Batch Delete Fix

The Cancel button during batch delete only stopped the frontend polling — the backend continued deleting all recordings. This gave users a false sense of control.

**Solution: Two-phase modal**

1. **Confirmation phase** — When the user clicks "Delete Selected" or "Delete All Filtered", a modal appears with:
   - ⚠️ A prominent red warning: *"This action cannot be undone. Once started, this operation cannot be cancelled or reversed."*
   - The count of recordings to be deleted
   - **Cancel** and **Delete** buttons

2. **Progress phase** (non-cancellable) — After the user clicks Delete:
   - Progress bar, succeeded/failed counts
   - No cancel button since the backend operation cannot be stopped
   - Shows "Please wait…" during operation and "Done" when complete

Also:
- Removed browser `confirm()` dialogs (replaced by in-modal confirmation)
- Routed batch operations directly through the modal (skip `DeleteConfirmationModal` for batch modes to avoid double confirm)
- Removed unused `window.showBatchDeleteModal`/`updateBatchDeleteProgress` global functions

### CI Fix

- Replaced bash-only `${PIPESTATUS[0]}` with POSIX-compatible exit code capture (the `debian:sid-slim` container uses `/bin/sh` aka dash)
- Increased global-teardown wait time from 2s to 60s with polling, so lightNVR can shut down gracefully instead of being SIGKILL'd mid-cleanup

Fixes the "Bad substitution" error that caused CI to report exit code 2 even when all 93 tests passed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author