### PR TITLE
fix: handle timeline boundary loading (#186)

### DIFF
--- a/tests/integration/pages/TimelinePage.ts
+++ b/tests/integration/pages/TimelinePage.ts
@@ -15,7 +15,7 @@ export class TimelinePage extends BasePage {
   }
 
   get timelineContainer(): Locator {
-    return this.page.locator('.timeline-container, .timeline, [data-testid="timeline"]');
+    return this.page.locator('#timeline-container, .timeline-container, .timeline, [data-testid="timeline"]');
   }
 
   get timelineSegments(): Locator {
@@ -43,19 +43,19 @@ export class TimelinePage extends BasePage {
   }
 
   get streamFilter(): Locator {
-    return this.page.locator('select[name="stream"], #stream-filter, [data-testid="stream-filter"]').first();
+    return this.page.locator('#stream-selector, select[name="stream"], #stream-filter, [data-testid="stream-filter"]').first();
   }
 
   get playhead(): Locator {
-    return this.page.locator('.playhead, [data-testid="playhead"]').first();
+    return this.page.locator('#timeline-container .timeline-cursor, .playhead, [data-testid="playhead"]').first();
   }
 
   get timeDisplay(): Locator {
-    return this.page.locator('.time-display, [data-testid="time-display"]').first();
+    return this.page.locator('#time-display, .time-display, [data-testid="time-display"]').first();
   }
 
   get videoPlayer(): Locator {
-    return this.page.locator('video, .video-player, [data-testid="video-player"]').first();
+    return this.page.locator('#video-player video, video, .video-player, [data-testid="video-player"]').first();
   }
 
   get loadingIndicator(): Locator {

--- a/tests/integration/specs/timeline-boundary.ui.spec.ts
+++ b/tests/integration/specs/timeline-boundary.ui.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, Page } from '@playwright/test';
+import { login, USERS } from '../fixtures/test-fixtures';
+import { TimelinePage } from '../pages/TimelinePage';
+
+type Segment = { id: number; stream: string; start_timestamp: number; end_timestamp: number };
+
+function localTimestamp(date: string, time: string): number {
+  const [y, m, d] = date.split('-').map(Number);
+  const [hh, mm, ss] = time.split(':').map(Number);
+  return Math.floor(new Date(y, m - 1, d, hh, mm, ss).getTime() / 1000);
+}
+
+async function mockTimelineApis(page: Page, stream: string, segments: Segment[], tagsById: Record<number, string[]> = {}) {
+  await page.route('**/api/streams', route => route.fulfill({ json: [{ name: stream }] }));
+  await page.route('**/api/timeline/segments?**', route => route.fulfill({ json: { segments } }));
+  await page.route('**/api/detection/results/**', route => route.fulfill({ json: { detections: [] } }));
+  await page.route('**/api/recordings/**', async route => {
+    const pathname = new URL(route.request().url()).pathname;
+    const play = pathname.match(/\/api\/recordings\/play\/(\d+)$/);
+    if (play) return route.fulfill({ status: 204, body: '' });
+
+    const tags = pathname.match(/\/api\/recordings\/(\d+)\/tags$/);
+    if (tags) return route.fulfill({ json: { tags: tagsById[Number(tags[1])] || [] } });
+
+    const info = pathname.match(/\/api\/recordings\/(\d+)$/);
+    if (info) {
+      const segment = segments.find(s => s.id === Number(info[1]));
+      if (segment) {
+        return route.fulfill({ json: {
+          id: segment.id,
+          stream: segment.stream,
+          start_time: new Date(segment.start_timestamp * 1000).toISOString(),
+          end_time: new Date(segment.end_timestamp * 1000).toISOString(),
+          protected: false
+        } });
+      }
+    }
+
+    return route.continue();
+  });
+}
+
+test.describe('Timeline boundary flows @ui @timeline', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, USERS.admin);
+  });
+
+  test('loads the intended recording from Recordings view at a boundary timestamp', async ({ page }) => {
+    const stream = 'front_door';
+    const date = '2026-03-08';
+    const segments: Segment[] = [
+      { id: 101, stream, start_timestamp: localTimestamp(date, '12:00:00'), end_timestamp: localTimestamp(date, '12:10:00') },
+      { id: 102, stream, start_timestamp: localTimestamp(date, '12:10:00'), end_timestamp: localTimestamp(date, '12:20:00') }
+    ];
+
+    await page.addInitScript(() => localStorage.setItem('recordings_view_mode', 'table'));
+    await mockTimelineApis(page, stream, segments, { 102: ['person'] });
+    await page.route('**/api/recordings?**', route => route.fulfill({ json: {
+      recordings: [{ id: 102, stream, start_time_unix: segments[1].start_timestamp, duration: 600, size: '1 MB', protected: false, tags: [] }],
+      pagination: { total: 1, pages: 1, limit: 20 }
+    } }));
+
+    await page.goto('/recordings.html', { waitUntil: 'domcontentloaded' });
+    const link = page.locator('a[title="View in Timeline"]').first();
+    await expect(link).toBeVisible();
+
+    const href = await link.getAttribute('href');
+    const expectedTime = new URL(href!, 'http://localhost').searchParams.get('time');
+
+    await Promise.all([
+      page.waitForURL('**/timeline.html**'),
+      link.click()
+    ]);
+
+    const timelinePage = new TimelinePage(page);
+    await expect(timelinePage.timelineContainer).toBeVisible();
+    await expect(timelinePage.timeDisplay).toHaveText(expectedTime!);
+    await expect(page.locator('button[title="Manage Recording Tags"]')).toContainText('Tags (1)');
+    await expect(timelinePage.videoPlayer).toHaveAttribute('src', /\/api\/recordings\/play\/102(?:\?|$)/);
+  });
+
+  test('renders a recording that spans midnight on the selected day', async ({ page }) => {
+    const stream = 'overnight_drive';
+    const selectedDate = '2026-03-08';
+    const segments: Segment[] = [
+      { id: 201, stream, start_timestamp: localTimestamp('2026-03-07', '23:58:00'), end_timestamp: localTimestamp(selectedDate, '00:05:00') }
+    ];
+
+    await mockTimelineApis(page, stream, segments, { 201: ['night'] });
+    await page.goto(`/timeline.html?stream=${stream}&date=${selectedDate}&time=00:02:00`, { waitUntil: 'domcontentloaded' });
+
+    const timelinePage = new TimelinePage(page);
+    const segmentBar = page.locator('#timeline-container .timeline-segment').first();
+
+    await expect(timelinePage.timelineContainer).toBeVisible();
+    await expect(page.locator('button[title="Manage Recording Tags"]')).toContainText('Tags (1)');
+    await expect(timelinePage.videoPlayer).toHaveAttribute('src', /\/api\/recordings\/play\/201(?:\?|$)/);
+    await expect(segmentBar).toBeVisible();
+    expect((await segmentBar.boundingBox())?.width ?? 0).toBeGreaterThan(0);
+  });
+
+  test('falls back to the nearest recording when the requested time is in a gap', async ({ page }) => {
+    const stream = 'garage';
+    const date = '2026-03-08';
+    const segments: Segment[] = [
+      { id: 301, stream, start_timestamp: localTimestamp(date, '10:00:00'), end_timestamp: localTimestamp(date, '10:05:00') },
+      { id: 302, stream, start_timestamp: localTimestamp(date, '10:10:00'), end_timestamp: localTimestamp(date, '10:15:00') }
+    ];
+
+    await mockTimelineApis(page, stream, segments);
+    await page.goto(`/timeline.html?stream=${stream}&date=${date}&time=10:08:00`, { waitUntil: 'domcontentloaded' });
+
+    const timelinePage = new TimelinePage(page);
+    await expect(timelinePage.timelineContainer).toBeVisible();
+    await expect(timelinePage.timeDisplay).toHaveText('10:10:00');
+    await expect(timelinePage.videoPlayer).toHaveAttribute('src', /\/api\/recordings\/play\/302(?:\?|$)/);
+  });
+});

--- a/web/js/components/preact/timeline/TimelineControls.jsx
+++ b/web/js/components/preact/timeline/TimelineControls.jsx
@@ -6,6 +6,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { timelineState } from './TimelinePage.jsx';
 import { showStatusMessage } from '../ToastContainer.jsx';
+import { findContainingSegmentIndex, findNearestSegmentIndex } from './timelineUtils.js';
 
 /**
  * TimelineControls component
@@ -80,33 +81,23 @@ export function TimelineControls() {
       console.log('TimelineControls: Using current time to find segment:', timelineState.currentTime);
 
       // First try to find a segment that contains the current time
-      for (let i = 0; i < timelineState.timelineSegments.length; i++) {
-        const segment = timelineState.timelineSegments[i];
-        if (timelineState.currentTime >= segment.start_timestamp &&
-            timelineState.currentTime <= segment.end_timestamp) {
-          segmentToPlay = segment;
-          segmentIndex = i;
-          relativeTime = timelineState.currentTime - segment.start_timestamp;
-          console.log(`TimelineControls: Found segment ${i} containing current time, relative time: ${relativeTime}s`);
-          break;
-        }
+      const containingIndex = findContainingSegmentIndex(
+        timelineState.timelineSegments,
+        timelineState.currentTime
+      );
+      if (containingIndex !== -1) {
+        segmentToPlay = timelineState.timelineSegments[containingIndex];
+        segmentIndex = containingIndex;
+        relativeTime = timelineState.currentTime - segmentToPlay.start_timestamp;
+        console.log(`TimelineControls: Found segment ${containingIndex} containing current time, relative time: ${relativeTime}s`);
       }
 
       // If no exact match, find the closest segment
       if (!segmentToPlay) {
-        let closestIndex = 0;
-        let minDistance = Infinity;
-
-        for (let i = 0; i < timelineState.timelineSegments.length; i++) {
-          const segment = timelineState.timelineSegments[i];
-          const midpoint = (segment.start_timestamp + segment.end_timestamp) / 2;
-          const distance = Math.abs(timelineState.currentTime - midpoint);
-
-          if (distance < minDistance) {
-            minDistance = distance;
-            closestIndex = i;
-          }
-        }
+        const closestIndex = findNearestSegmentIndex(
+          timelineState.timelineSegments,
+          timelineState.currentTime
+        );
 
         segmentToPlay = timelineState.timelineSegments[closestIndex];
         segmentIndex = closestIndex;

--- a/web/js/components/preact/timeline/TimelineCursor.jsx
+++ b/web/js/components/preact/timeline/TimelineCursor.jsx
@@ -5,6 +5,11 @@
 
 import { useState, useEffect, useRef } from 'preact/hooks';
 import { timelineState } from './TimelinePage.jsx';
+import {
+  findContainingSegmentIndex,
+  findNearestSegmentIndex,
+  formatTimestampAsClock
+} from './timelineUtils.js';
 
 /**
  * TimelineCursor component
@@ -137,9 +142,8 @@ export function TimelineCursor() {
 
       // Snap-guard: nudge away from segment start to prevent snap-back
       if (timelineState.timelineSegments && timelineState.timelineSegments.length > 0) {
-        const seg = timelineState.timelineSegments.find(s =>
-          timestamp >= s.start_timestamp && timestamp <= s.end_timestamp
-        );
+        const segIndex = findContainingSegmentIndex(timelineState.timelineSegments, timestamp);
+        const seg = segIndex !== -1 ? timelineState.timelineSegments[segIndex] : null;
         if (seg && (timestamp - seg.start_timestamp) < 1.0) {
           timelineState.currentTime = seg.start_timestamp + 1.0;
         }
@@ -151,27 +155,11 @@ export function TimelineCursor() {
 
       // Find the segment at the drop position (exact match or closest)
       const segs = timelineState.timelineSegments || [];
-      let found = false;
-      let closestIdx = -1;
-      let minDist = Infinity;
-
-      for (let i = 0; i < segs.length; i++) {
-        const st = segs[i].start_timestamp;
-        const et = segs[i].end_timestamp;
-        if (timestamp >= st && timestamp <= et) {
-          timelineState.currentSegmentIndex = i;
-          timelineState.setState({});
-          found = true;
-          break;
-        }
-        const dist = Math.abs(timestamp - (st + et) / 2);
-        if (dist < minDist) { minDist = dist; closestIdx = i; }
-      }
-
-      if (!found) {
-        timelineState.currentSegmentIndex = closestIdx >= 0 ? closestIdx : -1;
-        timelineState.setState({});
-      }
+      const containingIndex = findContainingSegmentIndex(segs, timestamp);
+      timelineState.currentSegmentIndex = containingIndex !== -1
+        ? containingIndex
+        : findNearestSegmentIndex(segs, timestamp);
+      timelineState.setState({});
     };
 
     // Add event listeners
@@ -210,15 +198,7 @@ export function TimelineCursor() {
     const timeDisplay = document.getElementById('time-display');
     if (!timeDisplay) return;
 
-    const date = new Date(time * 1000);
-
-    // Format date and time
-    const hours = date.getHours().toString().padStart(2, '0');
-    const minutes = date.getMinutes().toString().padStart(2, '0');
-    const seconds = date.getSeconds().toString().padStart(2, '0');
-
-    // Display time only (HH:MM:SS)
-    timeDisplay.textContent = `${hours}:${minutes}:${seconds}`;
+    timeDisplay.textContent = formatTimestampAsClock(time);
   };
 
   // Initialise cursor on mount (with retries for async data)

--- a/web/js/components/preact/timeline/TimelinePage.jsx
+++ b/web/js/components/preact/timeline/TimelinePage.jsx
@@ -13,6 +13,11 @@ import { CalendarPicker } from './CalendarPicker.jsx';
 import { showStatusMessage } from '../ToastContainer.jsx';
 import { LoadingIndicator } from '../LoadingIndicator.jsx';
 import { useQuery } from '../../../query-client.js';
+import {
+  findContainingSegmentIndex,
+  findNearestSegmentIndex,
+  getClippedSegmentHourRange
+} from './timelineUtils.js';
 
 // Convert fractional hour (0–24) → Unix timestamp (seconds) for the given date
 function timelineHourToTimestamp(hour, selectedDate) {
@@ -401,23 +406,16 @@ export function TimelinePage() {
         const [, h, m, s] = timeParts.map(Number);
         const seekTs = timelineHourToTimestamp(h + m / 60 + s / 3600, selectedDate);
 
-        let found = false;
-        for (let i = 0; i < segmentsCopy.length; i++) {
-          if (seekTs >= segmentsCopy[i].start_timestamp && seekTs <= segmentsCopy[i].end_timestamp) {
-            initialSegmentIndex = i;
-            initialTime = seekTs;
-            found = true;
-            break;
+        const containingIndex = findContainingSegmentIndex(segmentsCopy, seekTs);
+        if (containingIndex !== -1) {
+          initialSegmentIndex = containingIndex;
+          initialTime = seekTs;
+        } else {
+          const nearestIndex = findNearestSegmentIndex(segmentsCopy, seekTs);
+          if (nearestIndex !== -1) {
+            initialSegmentIndex = nearestIndex;
+            initialTime = segmentsCopy[nearestIndex].start_timestamp;
           }
-        }
-        if (!found) {
-          let best = 0, bestDist = Infinity;
-          for (let i = 0; i < segmentsCopy.length; i++) {
-            const d = Math.abs(segmentsCopy[i].start_timestamp - seekTs);
-            if (d < bestDist) { bestDist = d; best = i; }
-          }
-          initialSegmentIndex = best;
-          initialTime = segmentsCopy[best].start_timestamp;
         }
       }
       initialTimeRef.current = '';
@@ -426,19 +424,24 @@ export function TimelinePage() {
     // Compute auto-fit range from segments
     let earliest = 24, latest = 0;
     segmentsCopy.forEach(seg => {
-      const s = new Date(seg.start_timestamp * 1000);
-      const e = new Date(seg.end_timestamp * 1000);
-      earliest = Math.min(earliest, s.getHours() + s.getMinutes() / 60 + s.getSeconds() / 3600);
-      latest   = Math.max(latest,   e.getHours() + e.getMinutes() / 60 + e.getSeconds() / 3600);
+      const visibleRange = getClippedSegmentHourRange(seg, selectedDate);
+      if (!visibleRange) return;
+      earliest = Math.min(earliest, visibleRange.startHour);
+      latest = Math.max(latest, visibleRange.endHour);
     });
-    const span = latest - earliest;
-    const pad  = Math.max(0.5, Math.min(1, span * 0.1));
-    let fitStart = Math.max(0, Math.floor((earliest - pad) * 2) / 2);
-    let fitEnd   = Math.min(24, Math.ceil((latest + pad) * 2) / 2);
-    if (fitEnd - fitStart < 2) {
-      const center = (earliest + latest) / 2;
-      fitStart = Math.max(0, Math.floor((center - 1) * 2) / 2);
-      fitEnd   = Math.min(24, fitStart + 2);
+
+    let fitStart = 0;
+    let fitEnd = 24;
+    if (earliest < 24 && latest > 0) {
+      const span = latest - earliest;
+      const pad = Math.max(0.5, Math.min(1, span * 0.1));
+      fitStart = Math.max(0, Math.floor((earliest - pad) * 2) / 2);
+      fitEnd = Math.min(24, Math.ceil((latest + pad) * 2) / 2);
+      if (fitEnd - fitStart < 2) {
+        const center = (earliest + latest) / 2;
+        fitStart = Math.max(0, Math.floor((center - 1) * 2) / 2);
+        fitEnd = Math.min(24, fitStart + 2);
+      }
     }
 
     // Push to global state

--- a/web/js/components/preact/timeline/TimelinePlayer.jsx
+++ b/web/js/components/preact/timeline/TimelinePlayer.jsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
 import { timelineState } from './TimelinePage.jsx';
+import { formatTimestampAsClock } from './timelineUtils.js';
 import { SpeedControls } from './SpeedControls.jsx';
 import { showStatusMessage } from '../ToastContainer.jsx';
 import { ConfirmDialog } from '../UI.jsx';
@@ -346,6 +347,24 @@ export function TimelinePlayer() {
     const segment = segments[currentSegmentIndex];
     if (!segment) return;
 
+    const desiredTime = timelineState.currentTime;
+    const isInitialPausedSyncEvent =
+      !timelineState.isPlaying &&
+      video.currentTime === 0 &&
+      desiredTime !== null &&
+      desiredTime > segment.start_timestamp &&
+      desiredTime <= segment.end_timestamp;
+
+    if (isInitialPausedSyncEvent) {
+      console.log('TimelinePlayer: Ignoring initial 0s timeupdate before seek position is applied', {
+        segmentId: segment.id,
+        segmentStart: segment.start_timestamp,
+        desiredTime,
+        videoTime: video.currentTime
+      });
+      return;
+    }
+
     // Calculate current timestamp, handling timezone correctly
     const currentTime = segment.start_timestamp + video.currentTime;
 
@@ -397,22 +416,12 @@ export function TimelinePlayer() {
 
     const timeDisplay = document.getElementById('time-display');
     if (!timeDisplay) return;
-
-    // Convert timestamp to timeline hour
-    const hour = timelineState.timestampToTimelineHour(time);
-
-    // Format time
-    const hours = Math.floor(hour).toString().padStart(2, '0');
-    const minutes = Math.floor((hour % 1) * 60).toString().padStart(2, '0');
-    const seconds = Math.floor(((hour % 1) * 60) % 1 * 60).toString().padStart(2, '0');
-
-    // Display time only (HH:MM:SS)
-    timeDisplay.textContent = `${hours}:${minutes}:${seconds}`;
+    const formatted = formatTimestampAsClock(time);
+    timeDisplay.textContent = formatted;
 
     console.log('TimelinePlayer: Updated time display', {
       timestamp: time,
-      hour,
-      formatted: `${hours}:${minutes}:${seconds}`,
+      formatted,
       localTime: new Date(time * 1000).toLocaleString()
     });
   };

--- a/web/js/components/preact/timeline/TimelineSegments.jsx
+++ b/web/js/components/preact/timeline/TimelineSegments.jsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useRef } from 'preact/hooks';
 import { timelineState } from './TimelinePage.jsx';
+import { findContainingSegmentIndex, getClippedSegmentHourRange } from './timelineUtils.js';
 
 /**
  * TimelineSegments component
@@ -119,21 +120,16 @@ export function TimelineSegments({ segments: propSegments }) {
     });
 
     // Find segment that contains this timestamp
-    let foundSegment = false;
-    for (let i = 0; i < segments.length; i++) {
-      const segment = segments[i];
-      const st = segment.start_timestamp;
-      const et = segment.end_timestamp;
+    const foundIndex = findContainingSegmentIndex(segments, clickTimestamp);
+    const foundSegment = foundIndex !== -1;
 
-      if (clickTimestamp >= st && clickTimestamp <= et) {
-        timelineState.setState({ currentSegmentIndex: i });
+    if (foundSegment) {
+      const segment = segments[foundIndex];
+      timelineState.setState({ currentSegmentIndex: foundIndex });
 
-        // Direct click on a segment bar → start playback at that point
-        if (event.target.classList.contains('timeline-segment')) {
-          playSegment(i, clickTimestamp - st);
-        }
-        foundSegment = true;
-        break;
+      // Direct click on a segment bar → start playback at that point
+      if (event.target.classList.contains('timeline-segment')) {
+        playSegment(foundIndex, clickTimestamp - segment.start_timestamp);
       }
     }
 
@@ -230,8 +226,11 @@ export function TimelineSegments({ segments: propSegments }) {
     // Render each merged segment as a positioned bar
     const rendered = [];
     merged.forEach((seg, i) => {
-      const sh = timelineState.timestampToTimelineHour(seg.start_timestamp);
-      const eh = timelineState.timestampToTimelineHour(seg.end_timestamp);
+      const visibleRange = getClippedSegmentHourRange(seg, timelineState.selectedDate);
+      if (!visibleRange) return;
+
+      const sh = visibleRange.startHour;
+      const eh = visibleRange.endHour;
 
       // Clip to visible range
       if (eh <= startHour || sh >= endHour) return;

--- a/web/js/components/preact/timeline/timelineUtils.js
+++ b/web/js/components/preact/timeline/timelineUtils.js
@@ -1,0 +1,110 @@
+/**
+ * Shared timeline helpers for choosing segments and clipping them to a day view.
+ */
+
+export function getLocalDayBounds(selectedDate) {
+  if (!selectedDate || typeof selectedDate !== 'string' || !selectedDate.includes('-')) {
+    return null;
+  }
+
+  const [year, month, day] = selectedDate.split('-').map(Number);
+  if (![year, month, day].every(Number.isFinite)) {
+    return null;
+  }
+
+  const dayStart = new Date(year, month - 1, day, 0, 0, 0, 0);
+  const nextDayStart = new Date(year, month - 1, day + 1, 0, 0, 0, 0);
+
+  return {
+    startTimestamp: Math.floor(dayStart.getTime() / 1000),
+    endTimestamp: Math.floor(nextDayStart.getTime() / 1000)
+  };
+}
+
+export function formatTimestampAsClock(timestamp) {
+  if (timestamp === null || timestamp === undefined) {
+    return '';
+  }
+
+  const date = new Date(timestamp * 1000);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
+
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+export function segmentContainsTimestamp(segment, timestamp) {
+  if (!segment || timestamp === null || timestamp === undefined) return false;
+  return timestamp >= segment.start_timestamp && timestamp <= segment.end_timestamp;
+}
+
+export function findContainingSegmentIndex(segments, timestamp) {
+  if (!Array.isArray(segments) || segments.length === 0) return -1;
+
+  let bestIndex = -1;
+  let bestStart = -Infinity;
+  let bestEnd = Infinity;
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (!segmentContainsTimestamp(segment, timestamp)) continue;
+
+    if (
+      segment.start_timestamp > bestStart ||
+      (segment.start_timestamp === bestStart && segment.end_timestamp < bestEnd)
+    ) {
+      bestIndex = i;
+      bestStart = segment.start_timestamp;
+      bestEnd = segment.end_timestamp;
+    }
+  }
+
+  return bestIndex;
+}
+
+export function findNearestSegmentIndex(segments, timestamp) {
+  if (!Array.isArray(segments) || segments.length === 0) return -1;
+
+  let bestIndex = -1;
+  let bestDistance = Infinity;
+  let bestStart = Infinity;
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    const distance = timestamp < segment.start_timestamp
+      ? segment.start_timestamp - timestamp
+      : timestamp > segment.end_timestamp
+        ? timestamp - segment.end_timestamp
+        : 0;
+
+    if (
+      distance < bestDistance ||
+      (distance === bestDistance && segment.start_timestamp < bestStart)
+    ) {
+      bestIndex = i;
+      bestDistance = distance;
+      bestStart = segment.start_timestamp;
+    }
+  }
+
+  return bestIndex;
+}
+
+export function getClippedSegmentHourRange(segment, selectedDate) {
+  const bounds = getLocalDayBounds(selectedDate);
+  if (!segment || !bounds) return null;
+
+  const visibleStart = Math.max(segment.start_timestamp, bounds.startTimestamp);
+  const visibleEnd = Math.min(segment.end_timestamp, bounds.endTimestamp);
+
+  if (visibleEnd <= visibleStart) {
+    return null;
+  }
+
+  return {
+    startHour: (visibleStart - bounds.startTimestamp) / 3600,
+    endHour: (visibleEnd - bounds.startTimestamp) / 3600
+  };
+}
+

--- a/web/tests/timeline-utils.spec.js
+++ b/web/tests/timeline-utils.spec.js
@@ -1,0 +1,111 @@
+import {
+  findContainingSegmentIndex,
+  findNearestSegmentIndex,
+  formatTimestampAsClock,
+  getClippedSegmentHourRange,
+  getLocalDayBounds
+} from '../js/components/preact/timeline/timelineUtils.js';
+
+describe('timelineUtils', () => {
+  test('prefers the later segment when recordings overlap at the requested time', () => {
+    const segments = [
+      { id: 1, start_timestamp: 100, end_timestamp: 200 },
+      { id: 2, start_timestamp: 190, end_timestamp: 300 }
+    ];
+
+    expect(findContainingSegmentIndex(segments, 190)).toBe(1);
+    expect(findContainingSegmentIndex(segments, 200)).toBe(1);
+  });
+
+  test('prefers the next segment when recordings touch exactly at a boundary', () => {
+    const segments = [
+      { id: 1, start_timestamp: 100, end_timestamp: 200 },
+      { id: 2, start_timestamp: 200, end_timestamp: 260 }
+    ];
+
+    expect(findContainingSegmentIndex(segments, 200)).toBe(1);
+  });
+
+  test('returns -1 when no segment contains the timestamp', () => {
+    const segments = [
+      { id: 1, start_timestamp: 100, end_timestamp: 150 },
+      { id: 2, start_timestamp: 200, end_timestamp: 250 }
+    ];
+
+    expect(findContainingSegmentIndex(segments, 175)).toBe(-1);
+  });
+
+  test('finds the nearest segment when the timestamp falls in a gap', () => {
+    const segments = [
+      { id: 1, start_timestamp: 100, end_timestamp: 150 },
+      { id: 2, start_timestamp: 200, end_timestamp: 250 }
+    ];
+
+    expect(findNearestSegmentIndex(segments, 170)).toBe(0);
+    expect(findNearestSegmentIndex(segments, 195)).toBe(1);
+  });
+
+  test('breaks equal nearest-distance ties toward the earlier segment', () => {
+    const segments = [
+      { id: 1, start_timestamp: 100, end_timestamp: 150 },
+      { id: 2, start_timestamp: 190, end_timestamp: 240 }
+    ];
+
+    expect(findNearestSegmentIndex(segments, 170)).toBe(0);
+  });
+
+  test('clips a boundary-spanning segment to the selected local day', () => {
+    const selectedDate = '2026-03-08';
+    const { startTimestamp } = getLocalDayBounds(selectedDate);
+    const range = getClippedSegmentHourRange(
+      {
+        start_timestamp: startTimestamp - 120,
+        end_timestamp: startTimestamp + 300
+      },
+      selectedDate
+    );
+
+    expect(range).toEqual({
+      startHour: 0,
+      endHour: 300 / 3600
+    });
+  });
+
+  test('clips a segment that continues into the next local day', () => {
+    const selectedDate = '2026-03-08';
+    const { startTimestamp, endTimestamp } = getLocalDayBounds(selectedDate);
+    const range = getClippedSegmentHourRange(
+      {
+        start_timestamp: endTimestamp - 600,
+        end_timestamp: endTimestamp + 180
+      },
+      selectedDate
+    );
+
+    expect(range).toEqual({
+      startHour: (endTimestamp - 600 - startTimestamp) / 3600,
+      endHour: (endTimestamp - startTimestamp) / 3600
+    });
+  });
+
+  test('returns null when a segment is fully outside the selected day', () => {
+    const selectedDate = '2026-03-08';
+    const { startTimestamp, endTimestamp } = getLocalDayBounds(selectedDate);
+
+    expect(getClippedSegmentHourRange({
+      start_timestamp: startTimestamp - 600,
+      end_timestamp: startTimestamp - 1
+    }, selectedDate)).toBeNull();
+
+    expect(getClippedSegmentHourRange({
+      start_timestamp: endTimestamp,
+      end_timestamp: endTimestamp + 600
+    }, selectedDate)).toBeNull();
+  });
+
+  test('formats exact minute boundaries without floating point drift', () => {
+    expect(formatTimestampAsClock(new Date(2026, 2, 8, 12, 10, 0).getTime() / 1000)).toBe('12:10:00');
+    expect(formatTimestampAsClock(new Date(2026, 2, 8, 0, 2, 0).getTime() / 1000)).toBe('00:02:00');
+  });
+});
+


### PR DESCRIPTION
## Summary

Fixes the timeline boundary-loading issues reported in #186.

### What changed
- prefer the correct segment when loading timeline state from a recording URL time
- clip midnight-spanning segments to the selected day when rendering the timeline
- centralize overlap / nearest-segment selection in shared timeline helpers
- fix timeline clock formatting drift at exact minute boundaries
- guard initial paused player sync so it does not overwrite the intended selected time
- add focused unit tests and higher-level Playwright coverage for boundary cases

## Validation
- `npm test -- --runTestsByPath tests/timeline-utils.spec.js`
- `npm run build`
- `npx playwright test tests/integration/specs/timeline-boundary.ui.spec.ts --project=ui --reporter=list`

Fixes #186

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author