### PR TITLE
Parse and log SOAP fault details from ONVIF error responses

### DIFF
--- a/include/video/onvif_soap.h
+++ b/include/video/onvif_soap.h
@@ -1,6 +1,8 @@
 #ifndef ONVIF_SOAP_H
 #define ONVIF_SOAP_H
 
+#include <stddef.h>
+
 /**
  * Create a WS-Security SOAP header element for ONVIF digest authentication.
  *
@@ -17,6 +19,23 @@
  *                  The caller is responsible for free()ing the returned string.
  */
 char *onvif_create_security_header(const char *username, const char *password);
+
+/**
+ * Parse a SOAP Fault from an ONVIF error response and log the details.
+ *
+ * Attempts to extract the fault Code, Subcode, and Reason text from a
+ * SOAP 1.2 Fault element in the response body.  Logs whatever information
+ * can be parsed at the error level.  If the XML cannot be parsed at all,
+ * logs the raw response (truncated) as a fallback.
+ *
+ * @param response      The raw XML response body (will be modified by the
+ *                      XML parser — pass a copy if the original is needed).
+ * @param response_len  Length of the response in bytes.
+ * @param context       A short description of the request that failed
+ *                      (e.g. "PullMessages", "CreatePullPointSubscription"),
+ *                      used to prefix the log message.  May be NULL.
+ */
+void onvif_log_soap_fault(char *response, size_t response_len, const char *context);
 
 #endif /* ONVIF_SOAP_H */
 

--- a/src/video/onvif_detection.c
+++ b/src/video/onvif_detection.c
@@ -170,6 +170,9 @@ static char *send_onvif_request(const char *url, const char *username, const cha
 
     if (http_code != 200) {
         log_error("ONVIF request failed with HTTP code %ld", http_code);
+        if (chunk.size > 0) {
+            onvif_log_soap_fault(chunk.memory, chunk.size, "ONVIF Detection");
+        }
         free(chunk.memory);
         pthread_mutex_unlock(&curl_mutex);
         return NULL;
@@ -229,6 +232,9 @@ static char *send_onvif_request_to_url(const char *full_url, const char *usernam
 
     if (http_code != 200) {
         log_error("ONVIF request to %s failed with HTTP code %ld", full_url, http_code);
+        if (chunk.size > 0) {
+            onvif_log_soap_fault(chunk.memory, chunk.size, "ONVIF Detection");
+        }
         free(chunk.memory);
         pthread_mutex_unlock(&curl_mutex);
         return NULL;

--- a/src/video/onvif_device_management.c
+++ b/src/video/onvif_device_management.c
@@ -110,10 +110,15 @@ static char* send_soap_request(const char *device_url, const char *soap_action, 
     res = curl_easy_perform(curl);
     if (res != CURLE_OK) {
         log_error("CURL failed: %s", curl_easy_strerror(res));
-        
+
         // If the first attempt failed, try with the original envelope format
         log_info("First SOAP format failed, trying alternative format");
-        
+
+        // Reset response buffer for retry
+        free(chunk.memory);
+        chunk.memory = malloc(1);
+        chunk.size = 0;
+
         free(soap_envelope);
         soap_envelope = malloc(strlen(request_body) + strlen(security_header) + 1024);
         sprintf(soap_envelope,
@@ -133,20 +138,33 @@ static char* send_soap_request(const char *device_url, const char *soap_action, 
                 "<SOAP-ENV:Body>%s</SOAP-ENV:Body>"
             "</SOAP-ENV:Envelope>",
             security_header, request_body);
-        
+
         // Retry the request
         res = curl_easy_perform(curl);
         if (res != CURLE_OK) {
             log_error("Both SOAP formats failed: %s", curl_easy_strerror(res));
         } else {
-            response = strdup(chunk.memory);
             log_info("Second SOAP format succeeded");
         }
     } else {
-        response = strdup(chunk.memory);
         log_info("First SOAP format succeeded");
     }
-    
+
+    // Check HTTP response code and parse any SOAP fault
+    if (res == CURLE_OK) {
+        long http_code = 0;
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+        if (http_code != 200) {
+            log_error("ONVIF device management request failed with HTTP code %ld", http_code);
+            if (chunk.size > 0) {
+                onvif_log_soap_fault(chunk.memory, chunk.size, "Device Management");
+            }
+        } else if (chunk.size > 0) {
+            response = strdup(chunk.memory);
+        }
+    }
+
     // Log response if available
     if (response) {
         // Log first 200 characters of response for debugging

--- a/src/video/onvif_ptz.c
+++ b/src/video/onvif_ptz.c
@@ -90,10 +90,22 @@ static char* send_ptz_soap_request(const char *ptz_url, const char *soap_action,
     res = curl_easy_perform(curl);
     if (res != CURLE_OK) {
         log_error("PTZ CURL request failed: %s", curl_easy_strerror(res));
-    } else if (chunk.size > 0) {
-        response = strdup(chunk.memory);
+    } else {
+        // Check HTTP response code
+        long http_code = 0;
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+        if (http_code != 200) {
+            log_error("PTZ request failed with HTTP code %ld", http_code);
+            if (chunk.size > 0) {
+                onvif_log_soap_fault(chunk.memory, chunk.size, "PTZ");
+            }
+        } else if (chunk.size > 0) {
+            response = chunk.memory;
+            chunk.memory = NULL;  // Transfer ownership; caller will free
+        }
     }
-    
+
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
     free(soap_envelope);

--- a/src/video/onvif_soap.c
+++ b/src/video/onvif_soap.c
@@ -1,5 +1,6 @@
 /**
- * onvif_soap.c – shared WS-Security header generation for ONVIF requests.
+ * onvif_soap.c – shared WS-Security header generation and SOAP fault
+ * parsing for ONVIF requests.
  *
  * This is the single canonical implementation of the ONVIF WS-UsernameToken
  * PasswordDigest security header.  All ONVIF subsystems (device management,
@@ -9,6 +10,7 @@
 
 #include "video/onvif_soap.h"
 #include "core/logger.h"
+#include "ezxml.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -132,3 +134,134 @@ char *onvif_create_security_header(const char *username, const char *password) {
     return header;
 }
 
+/* ----------------------------------------------------------------------- *
+ * SOAP Fault parsing                                                       *
+ * ----------------------------------------------------------------------- */
+
+/**
+ * Try to find a child element under multiple namespace prefixes.
+ * Returns the first match, or NULL if none found.
+ */
+static ezxml_t find_with_ns(ezxml_t parent, const char *local_name,
+                            const char **ns_prefixes, int ns_count) {
+    if (!parent) return NULL;
+    for (int i = 0; i < ns_count; i++) {
+        char qname[256];
+        snprintf(qname, sizeof(qname), "%s:%s", ns_prefixes[i], local_name);
+        ezxml_t child = ezxml_child(parent, qname);
+        if (child) return child;
+    }
+    /* Try without namespace prefix as a last resort */
+    return ezxml_child(parent, local_name);
+}
+
+void onvif_log_soap_fault(char *response, size_t response_len, const char *context) {
+    if (!response || response_len == 0) return;
+
+    const char *ctx = context ? context : "ONVIF";
+
+    /* ezxml_parse_str modifies the buffer in-place, so make a copy */
+    char *buf = malloc(response_len + 1);
+    if (!buf) {
+        /* Fallback: just log raw truncated response */
+        char snippet[256];
+        size_t n = response_len < sizeof(snippet) - 1 ? response_len : sizeof(snippet) - 1;
+        memcpy(snippet, response, n);
+        snippet[n] = '\0';
+        log_error("[%s] SOAP fault (raw): %s", ctx, snippet);
+        return;
+    }
+    memcpy(buf, response, response_len);
+    buf[response_len] = '\0';
+
+    ezxml_t xml = ezxml_parse_str(buf, response_len);
+    if (!xml) {
+        /* Could not parse XML at all — log raw snippet */
+        char snippet[512];
+        size_t n = response_len < sizeof(snippet) - 1 ? response_len : sizeof(snippet) - 1;
+        memcpy(snippet, response, n);
+        snippet[n] = '\0';
+        log_error("[%s] SOAP fault response (unparseable): %s", ctx, snippet);
+        free(buf);
+        return;
+    }
+
+    /* Namespace prefixes cameras may use for the SOAP envelope */
+    const char *env_ns[] = {"s", "S", "SOAP-ENV", "soap", "env"};
+    int env_ns_count = sizeof(env_ns) / sizeof(env_ns[0]);
+
+    /* Find Body */
+    ezxml_t body = find_with_ns(xml, "Body", env_ns, env_ns_count);
+
+    /* Find Fault */
+    ezxml_t fault = body ? find_with_ns(body, "Fault", env_ns, env_ns_count) : NULL;
+
+    if (!fault) {
+        /* No Fault element found — log raw snippet */
+        char snippet[512];
+        size_t n = response_len < sizeof(snippet) - 1 ? response_len : sizeof(snippet) - 1;
+        memcpy(snippet, response, n);
+        snippet[n] = '\0';
+        log_error("[%s] SOAP error response (no Fault element): %s", ctx, snippet);
+        ezxml_free(xml);
+        free(buf);
+        return;
+    }
+
+    /* Extract Code > Value */
+    const char *code_str = NULL;
+    const char *subcode_str = NULL;
+    ezxml_t code_elem = find_with_ns(fault, "Code", env_ns, env_ns_count);
+    if (code_elem) {
+        ezxml_t value_elem = find_with_ns(code_elem, "Value", env_ns, env_ns_count);
+        if (value_elem) code_str = ezxml_txt(value_elem);
+
+        ezxml_t subcode_elem = find_with_ns(code_elem, "Subcode", env_ns, env_ns_count);
+        if (subcode_elem) {
+            ezxml_t sub_value = find_with_ns(subcode_elem, "Value", env_ns, env_ns_count);
+            if (sub_value) subcode_str = ezxml_txt(sub_value);
+        }
+    }
+
+    /* Extract Reason > Text */
+    const char *reason_str = NULL;
+    ezxml_t reason_elem = find_with_ns(fault, "Reason", env_ns, env_ns_count);
+    if (reason_elem) {
+        ezxml_t text_elem = find_with_ns(reason_elem, "Text", env_ns, env_ns_count);
+        if (text_elem) reason_str = ezxml_txt(text_elem);
+    }
+
+    /* Also try faultstring (SOAP 1.1 style) if no Reason was found */
+    if (!reason_str || reason_str[0] == '\0') {
+        ezxml_t faultstring = ezxml_child(fault, "faultstring");
+        if (faultstring) reason_str = ezxml_txt(faultstring);
+    }
+
+    /* Build and log the message */
+    if (code_str && code_str[0] != '\0') {
+        if (subcode_str && subcode_str[0] != '\0') {
+            log_error("[%s] SOAP Fault: Code=%s, Subcode=%s, Reason=%s",
+                      ctx,
+                      code_str,
+                      subcode_str,
+                      (reason_str && reason_str[0] != '\0') ? reason_str : "(none)");
+        } else {
+            log_error("[%s] SOAP Fault: Code=%s, Reason=%s",
+                      ctx,
+                      code_str,
+                      (reason_str && reason_str[0] != '\0') ? reason_str : "(none)");
+        }
+    } else if (reason_str && reason_str[0] != '\0') {
+        log_error("[%s] SOAP Fault: %s", ctx, reason_str);
+    } else {
+        /* Could not extract anything useful — log raw */
+        char snippet[512];
+        size_t n = response_len < sizeof(snippet) - 1 ? response_len : sizeof(snippet) - 1;
+        memcpy(snippet, response, n);
+        snippet[n] = '\0';
+        log_error("[%s] SOAP Fault (could not extract details): %s", ctx, snippet);
+    }
+
+    ezxml_free(xml);
+    free(buf);
+}


### PR DESCRIPTION
## Summary

Parses SOAP Fault XML from ONVIF error responses and logs the fault code, subcode, and reason text instead of only logging the HTTP status code.

Closes #339

## Changes

### New: `onvif_log_soap_fault()` in `onvif_soap.c`
- Extracts `Code > Value`, `Code > Subcode > Value`, and `Reason > Text` from SOAP 1.2 Fault elements
- Handles multiple SOAP envelope namespace prefixes (`s:`, `S:`, `SOAP-ENV:`, `soap:`, `env:`)
- Falls back to `faultstring` for SOAP 1.1 style faults
- If XML parsing fails entirely, logs a raw truncated snippet of the response

### Updated: `onvif_detection.c`
- `send_onvif_request()` and `send_onvif_request_to_url()` now call `onvif_log_soap_fault()` when a non-200 HTTP response is received

### Updated: `onvif_ptz.c`
- `send_ptz_soap_request()` now checks the HTTP response code (was missing entirely)
- Logs SOAP fault details on error responses
- Removed unnecessary `strdup()` of the response buffer

### Updated: `onvif_device_management.c`
- `send_soap_request()` now checks the HTTP response code after successful curl perform
- Logs SOAP fault details on non-200 responses

## Example

For the error response from the issue (HTTP 400 with `ter:NotAuthorized`), the log output will now be:

```
[PTZ] SOAP Fault: Code=s:Sender, Subcode=ter:NotAuthorized, Reason=Sender not Authorized. Invalid username or password! You still have 3 attempt(s).
```

Instead of just:

```
PTZ CURL request failed: ...
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author