### PR TITLE
Refactor and simplify PID file writing and delete unused code

### DIFF
--- a/include/core/daemon.h
+++ b/include/core/daemon.h
@@ -5,24 +5,9 @@
  * Initialize daemon mode
  *
  * @param pid_file Path to PID file, or NULL for default
- * @return 0 on success, -1 on error
+ * @return Locked PID file descriptor on success, -1 on error
  */
 int init_daemon(const char *pid_file);
-
-/**
- * Cleanup daemon resources
- *
- * @return 0 on success, -1 on error
- */
-int cleanup_daemon(void);
-
-/**
- * Stop running daemon
- *
- * @param pid_file Path to PID file, or NULL for default
- * @return 0 on success, -1 on error
- */
-int stop_daemon(const char *pid_file);
 
 /**
  * Get status of daemon
@@ -32,13 +17,20 @@ int stop_daemon(const char *pid_file);
  */
 int daemon_status(const char *pid_file);
 
+/**
+* Write PID file
+*
+* @param pid_file Path to PID file
+* @return The (locked) PID file descriptor on success, -1 on error
+*/
+int write_pid_file(const char *pid_file);
 
 /**
-* Remove Daemon PID file
+* Unlock and remove PID file
 *
 * @param pid_file Path to PID file
 * @return 0 on success, -1 on error
 */
-int remove_daemon_pid_file(const char *pid_file);
+int remove_pid_file(int fd, const char *pid_file);
 
 #endif /* DAEMON_H */

--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -26,7 +26,6 @@ static char pid_file_path[MAX_PATH_LENGTH] = "/run/lightnvr.pid";
 
 // Forward declarations
 static void daemon_signal_handler(int sig);
-static int write_pid_file(const char *pid_file);
 static int check_running_daemon(const char *pid_file);
 
 // Initialize daemon - simplified version that works on all platforms including Linux 4.4
@@ -118,7 +117,8 @@ int init_daemon(const char *pid_file) {
 
     // Write PID file
     log_info("Writing PID file...");
-    if (write_pid_file(pid_file_path) != 0) {
+    int fd = write_pid_file(pid_file_path);
+    if (fd < 0) {
         log_error("Failed to write PID file, daemon initialization failed");
         return -1;
     }
@@ -128,20 +128,7 @@ int init_daemon(const char *pid_file) {
     // Add a small delay to ensure everything is properly initialized
     usleep(100000); // 100ms
 
-    return 0;
-}
-
-// Cleanup daemon resources
-int cleanup_daemon(void) {
-    log_info("Cleaning up daemon resources");
-    
-    // Remove PID file
-    if (remove_daemon_pid_file(pid_file_path) != 0) {
-        log_warn("Failed to remove PID file during cleanup");
-        // Continue anyway, not a fatal error
-    }
-
-    return 0;
+    return fd;
 }
 
 // Async-signal-safe write helper for daemon signal handler
@@ -207,7 +194,7 @@ static void daemon_signal_handler(int sig) {
 }
 
 // Write PID file
-static int write_pid_file(const char *pid_file) {
+int write_pid_file(const char *pid_file) {
     // Make sure the directory exists
     const char *last_slash = strrchr(pid_file, '/');
     if (last_slash) {
@@ -271,11 +258,16 @@ static int write_pid_file(const char *pid_file) {
     }
     
     log_info("Wrote PID %d to file %s", getpid(), pid_file);
-    return 0;
+    return fd;
 }
 
 // Remove PID file
-int remove_daemon_pid_file(const char *pid_file) {
+int remove_pid_file(int fd, const char *pid_file) {
+    if (fd >= 0) {
+        // Release the lock by closing the file
+        close(fd);
+    }
+
     // Try to remove the file
     if (unlink(pid_file) != 0) {
         if (errno == ENOENT) {
@@ -310,9 +302,8 @@ static int check_running_daemon(const char *pid_file) {
     if (lockf(fd, F_TLOCK, 0) == 0) {
         // We got the lock, which means no other process has it
         // This is a stale PID file
-        close(fd);
         log_warn("Found stale PID file %s (not locked), removing it", pid_file);
-        remove_daemon_pid_file(pid_file);
+        remove_pid_file(fd, pid_file);
         return 0;
     }
     
@@ -348,162 +339,13 @@ static int check_running_daemon(const char *pid_file) {
             // Process is not running, but file is locked?
             // This is unusual, but could happen if the file is locked by another process
             log_warn("Found stale PID file %s (locked but process %d not running), removing it", pid_file, pid);
-            remove_daemon_pid_file(pid_file);
+            remove_pid_file(-1, pid_file);
             return 0;
         } else {
             log_error("Failed to check process status: %s", strerror(errno));
             return -1;
         }
     }
-}
-
-// Stop running daemon
-int stop_daemon(const char *pid_file) {
-    char file_path[MAX_PATH_LENGTH];
-
-    if (pid_file) {
-        safe_strcpy(file_path, pid_file, sizeof(file_path), 0);
-    } else {
-        safe_strcpy(file_path, pid_file_path, sizeof(file_path), 0);
-    }
-
-    // Open and read PID file
-    int fd = open(file_path, O_RDONLY);
-    if (fd < 0) {
-        if (errno == ENOENT) {
-            log_info("PID file %s does not exist, daemon is not running", file_path);
-            return 0;
-        }
-        
-        log_error("Failed to open PID file %s: %s", file_path, strerror(errno));
-        return -1;
-    }
-
-    // Read PID from file
-    char pid_str[16];
-    ssize_t bytes_read = read(fd, pid_str, sizeof(pid_str) - 1);
-    close(fd);
-    
-    if (bytes_read <= 0) {
-        log_error("Failed to read PID from file %s", file_path);
-        return -1;
-    }
-    
-    // Null-terminate the string
-    pid_str[bytes_read] = '\0';
-    
-    // Parse the PID
-    char *end_ptr;
-    long pid_val = strtol(pid_str, &end_ptr, 10);
-    if (end_ptr == pid_str || pid_val <= 0) {
-        log_error("Failed to parse PID from file %s", file_path);
-        return -1;
-    }
-    pid_t pid = (pid_t)pid_val;
-
-    // First try SIGTERM for a graceful shutdown
-    log_info("Sending SIGTERM to process %d", pid);
-    if (kill(pid, SIGTERM) != 0) {
-        if (errno == ESRCH) {
-            // Process has already terminated
-            log_info("Process %d has already terminated", pid);
-            remove_daemon_pid_file(file_path);
-            return 0;
-        } else {
-            log_warn("Failed to send SIGTERM to process %d: %s", pid, strerror(errno));
-            // Continue to try SIGKILL
-        }
-    } else {
-        // Wait for process to terminate after SIGTERM (doubled from 30 to 60 iterations)
-        for (int i = 0; i < 60; i++) {
-            if (kill(pid, 0) != 0) {
-                if (errno == ESRCH) {
-                    // Process has terminated
-                    log_info("Process %d has terminated after SIGTERM", pid);
-                    
-                    // Wait for PID file to be released
-                    for (int j = 0; j < 10; j++) {
-                        // Check if PID file still exists and is locked
-                        int test_fd = open(file_path, O_RDWR);
-                        if (test_fd < 0) {
-                            if (errno == ENOENT) {
-                                // PID file doesn't exist anymore, we're good
-                                log_info("PID file has been removed by the process");
-                                return 0;
-                            }
-                            // Some other error, continue waiting
-                        } else {
-                            // Try to lock the file
-                            if (lockf(test_fd, F_TLOCK, 0) == 0) {
-                                // We got the lock, which means the previous process released it
-                                close(test_fd);
-                                log_info("PID file lock released");
-                                remove_daemon_pid_file(file_path);
-                                return 0;
-                            }
-                            close(test_fd);
-                        }
-                        usleep(100000); // 100ms
-                    }
-                    
-                    // If we get here, the PID file still exists and is locked, or some other issue
-                    log_warn("Process terminated but PID file is still locked or inaccessible");
-                    // Try to remove it anyway
-                    remove_daemon_pid_file(file_path);
-                    return 0;
-                }
-            }
-            // Sleep for 100ms
-            usleep(100000);
-        }
-        
-        log_warn("Process did not terminate after SIGTERM, trying SIGKILL");
-    }
-
-    // If SIGTERM didn't work or timed out, use SIGKILL
-    log_info("Sending SIGKILL to process %d", pid);
-    if (kill(pid, SIGKILL) != 0) {
-        if (errno == ESRCH) {
-            // Process has terminated
-            log_info("Process %d has terminated", pid);
-            remove_daemon_pid_file(file_path);
-            return 0;
-        } else {
-            log_error("Failed to send SIGKILL to process %d: %s", pid, strerror(errno));
-            return -1;
-        }
-    }
-
-    // Wait for process to terminate after SIGKILL
-    for (int i = 0; i < 50; i++) {
-        if (kill(pid, 0) != 0) {
-            if (errno == ESRCH) {
-                // Process has terminated
-                log_info("Process %d has terminated after SIGKILL", pid);
-                
-                // Wait for PID file to be released
-                for (int j = 0; j < 10; j++) {
-                    // Check if PID file still exists
-                    if (access(file_path, F_OK) != 0) {
-                        // PID file doesn't exist anymore, we're good
-                        log_info("PID file has been removed");
-                        return 0;
-                    }
-                    usleep(100000); // 100ms
-                }
-                
-                // If we get here, the PID file still exists
-                log_warn("Process terminated but PID file still exists");
-                remove_daemon_pid_file(file_path);
-                return 0;
-            }
-        }
-        // Sleep for 100ms
-        usleep(100000);
-    }
-
-    log_error("Failed to terminate process %d", pid);
-    return -1;
 }
 
 // Get status of daemon
@@ -532,9 +374,8 @@ int daemon_status(const char *pid_file) {
     if (lockf(fd, F_TLOCK, 0) == 0) {
         // We got the lock, which means no other process has it
         // This is a stale PID file
-        close(fd);
         log_warn("Found stale PID file %s (not locked), removing it", file_path);
-        remove_daemon_pid_file(file_path);
+        remove_pid_file(fd, file_path);
         return 0;
     }
     
@@ -570,7 +411,7 @@ int daemon_status(const char *pid_file) {
             // Process is not running, but file is locked?
             // This is unusual, but could happen if the file is locked by another process
             log_warn("Found stale PID file %s (locked but process %d not running), removing it", file_path, pid);
-            remove_daemon_pid_file(file_path);
+            remove_pid_file(-1, file_path);
             return 0;
         } else {
             log_error("Failed to check process status: %s", strerror(errno));

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -351,91 +351,13 @@ static int check_and_kill_existing_instance(const char *pid_file) {
     return 0;
 }
 
-// Function to create PID file
-static int create_pid_file(const char *pid_file) {
-    char pid_str[16];
-    int fd;
-
-    // Make sure the directory exists
-    const char *last_slash = strrchr(pid_file, '/');
-    if (last_slash) {
-        char dir_path[MAX_PATH_LENGTH];
-        size_t dir_len = (size_t)(last_slash - pid_file);
-        safe_strcpy(dir_path, pid_file, MAX_PATH_LENGTH, dir_len);
-
-        // Create directory if it doesn't exist
-        struct stat st;
-        if (stat(dir_path, &st) != 0) {
-            if (mkdir(dir_path, 0755) != 0 && errno != EEXIST) {
-                log_error("Could not create directory for PID file: %s", strerror(errno));
-                return -1;
-            }
-        }
-    }
-
-    // Try to open the PID file with exclusive creation first
-    fd = open(pid_file, O_RDWR | O_CREAT | O_EXCL, 0644);
-    if (fd < 0 && errno == EEXIST) {
-        // File exists, try to open it normally
-        fd = open(pid_file, O_RDWR | O_CREAT, 0644);
-    }
-
-    if (fd < 0) {
-        log_error("Could not open PID file %s: %s", pid_file, strerror(errno));
-        return -1;
-    }
-
-    // Lock the PID file to prevent multiple instances
-    if (lockf(fd, F_TLOCK, 0) < 0) {
-        log_error("Could not lock PID file %s: %s", pid_file, strerror(errno));
-        close(fd);
-        return -1;
-    }
-
-    // Truncate the file to ensure we overwrite any existing content
-    if (ftruncate(fd, 0) < 0) {
-        log_warn("Could not truncate PID file: %s", strerror(errno));
-        // Continue anyway
-    }
-
-    // Write PID to file
-    sprintf(pid_str, "%d\n", getpid());
-    if (write(fd, pid_str, strlen(pid_str)) != strlen(pid_str)) {
-        log_error("Could not write to PID file %s: %s", pid_file, strerror(errno));
-        close(fd);
-        unlink(pid_file);  // Try to remove the file
-        return -1;
-    }
-
-    // Sync to ensure the PID is written to disk
-    fsync(fd);
-
-    // Keep file open to maintain lock
-    return fd;
-}
-
-// Function to remove PID file
-static void remove_pid_file(int fd, const char *pid_file) {
-    if (fd >= 0) {
-        // Release the lock by closing the file
-        close(fd);
-    }
-
-    // Try to remove the file
-    if (unlink(pid_file) != 0) {
-        log_warn("Failed to remove PID file %s: %s", pid_file, strerror(errno));
-    } else {
-        log_info("Successfully removed PID file %s", pid_file);
-    }
-}
-
 // Function to daemonize the process
 static int daemonize(const char *pid_file) {
-    int result = init_daemon(pid_file);
+    int fd = init_daemon(pid_file);
 
     // If daemon initialization failed, return error
-    if (result != 0) {
-        return result;
+    if (fd < 0) {
+        return -1;
     }
 
     // We're now in the child process, set daemon_mode flag
@@ -444,8 +366,8 @@ static int daemonize(const char *pid_file) {
     // Make sure the running flag is set to true
     running = true;
 
-    // Return success
-    return 0;
+    // Return locked PID fd
+    return fd;
 }
 
 // Function to check and ensure recording is active for streams that have recording enabled
@@ -667,14 +589,14 @@ int main(int argc, char *argv[]) {
     // Daemonize if requested. This needs to happen before launching any threads.
     if (daemon_mode) {
         log_info("Starting in daemon mode");
-        if (daemonize(config.pid_file) != 0) {
+        pid_fd = daemonize(config.pid_file);
+        if (pid_fd < 0) {
             log_error("Failed to daemonize");
             return EXIT_FAILURE;
         }
-        // In daemon mode, the PID file is handled by daemon.c
     } else {
-        // Create PID file (only for non-daemon mode)
-        pid_fd = create_pid_file(config.pid_file);
+        // Create PID file directly (only for non-daemon mode)
+        pid_fd = write_pid_file(config.pid_file);
         if (pid_fd < 0) {
             log_error("Failed to create PID file");
             return EXIT_FAILURE;
@@ -1634,14 +1556,8 @@ cleanup:
         pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
     }
 
-    // Handle PID file cleanup based on mode
-    if (daemon_mode) {
-        // In daemon mode, call cleanup_daemon to handle the PID file
-        cleanup_daemon();
-    } else if (pid_fd >= 0) {
-        // In normal mode, remove the PID file directly
-        remove_pid_file(pid_fd, config.pid_file);
-    }
+    // Close (unlock) and delete the PID file
+    remove_pid_file(pid_fd, config.pid_file);
 
     log_info("Cleanup complete, shutting down");
 


### PR DESCRIPTION
* Adjust `write_pid_file()` in `daemon.c` to return the PID file file descriptor for locking purposes.
* Remove duplicate `create_pid_file()` in `main.c` and call `write_pid_file()` instead.
* Remove unused `stop_daemon()` in daemon.c
* Rename `remove_daemon_pid_file()` to `remove_pid_file()` in `daemon.c` to match `write_pid_file()` and pass in fd to unlock and close PID file
* Modify `daemonize()` to return PID file fd
* Remove `cleanup_daemon()` since it only calls `remove_pid_file()` and consolidate PID file cleanup in `main.c`