### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/web/js/components/preact/system/LogsPoller.jsx
+++ b/web/js/components/preact/system/LogsPoller.jsx
@@ -94,7 +94,7 @@ export function LogsPoller({ logLevel, logCount, pollingInterval = 5000, onLogsR
         console.log(`Received ${filteredLogs.length} logs via HTTP API after filtering`);
         if (filteredLogs.length > logCount) {
           // Shrink to requested size if we received more than expected
-          filteredLogs = filteredLogs.slice(0, logCount)
+          filteredLogs = filteredLogs.slice(0, logCount);
         }
         onLogsReceivedRef.current(filteredLogs);
       } else {


### PR DESCRIPTION
To fix this, add an explicit semicolon at the end of the assignment on line 97 in `web/js/components/preact/system/LogsPoller.jsx`.

Best single fix without changing functionality:
- In the `if (filteredLogs.length > logCount)` block, change:
  - `filteredLogs = filteredLogs.slice(0, logCount)`
  to:
  - `filteredLogs = filteredLogs.slice(0, logCount);`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._