### PR TITLE
Add missing dependency for rebuild-recordings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,6 +504,7 @@ set(REBUILD_RECORDINGS_SOURCES
     src/tools/rebuild_recordings.c
     src/core/config.c
     src/core/logger.c
+    src/core/path_utils.c
     src/utils/strings.c
     src/database/db_core.c
     src/database/db_streams.c


### PR DESCRIPTION
Trivial compile fix, this snuck through without my notice.