### PR TITLE
ONVIF Detection: Thread Separation, Dual-Lens Support & Recording Reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ lightnvr-buildroot/
 *.png
 lightnvr-provisioning-prd.docx.md
 .mcp.json
+*.patch

--- a/include/video/onvif_motion_recording.h
+++ b/include/video/onvif_motion_recording.h
@@ -38,6 +38,8 @@ typedef struct {
     char event_type[64];            // Type of motion event
     float confidence;               // Event confidence (if available)
     bool active;                    // Whether motion is currently active
+    bool is_propagated;             // True if this event was already propagated from
+                                    // another stream — prevents infinite cross-stream loops
 } motion_event_t;
 
 // Event queue structure

--- a/include/video/onvif_motion_recording.h
+++ b/include/video/onvif_motion_recording.h
@@ -131,7 +131,7 @@ int disable_motion_recording(const char *stream_name);
  * @param timestamp Event timestamp
  * @return 0 on success, non-zero on failure
  */
-int process_motion_event(const char *stream_name, bool motion_detected, time_t timestamp);
+int process_motion_event(const char *stream_name, bool motion_detected, time_t timestamp, bool is_propagated);
 
 /**
  * Get recording state for a stream

--- a/include/video/unified_detection_thread.h
+++ b/include/video/unified_detection_thread.h
@@ -110,6 +110,34 @@ typedef struct {
     // Detections are stored in the database and linked to the continuous recording
     bool annotation_only;
 
+    // -------------------------------------------------------------------------
+    // ONVIF async detection thread
+    // -------------------------------------------------------------------------
+    // When model_path == "onvif" a dedicated background thread calls
+    // detect_motion_onvif() in a loop so that the UDT main loop (and therefore
+    // av_read_frame()) is never blocked by a CURL/SOAP round-trip.
+    //
+    // Lifecycle:
+    //   • Created by start_unified_detection_thread() alongside the UDT.
+    //   • Joined inside unified_detection_thread_func() before ctx is freed.
+    //   • shutdown_unified_detection_system() joins it during forced shutdown.
+    //
+    // Thread-safety:
+    //   • onvif_thread_running  – writer: UDT teardown; reader: ONVIF thread.
+    //   • onvif_motion_detected – writer: ONVIF thread; reader: UDT main loop.
+    //   • onvif_motion_timestamp– same as above.
+    //   All three use atomic operations only; no mutex required.
+    pthread_t    onvif_thread;           // handle (valid only when thread was started)
+    atomic_int   onvif_thread_running;   // 1 = running, 0 = stop requested
+    atomic_int   onvif_motion_detected;  // 1 = motion active, 0 = idle
+    atomic_llong onvif_motion_timestamp; // epoch-seconds of last detected motion
+
+    // ONVIF connection parameters cached at thread-start time so that the
+    // polling thread never needs to call get_stream_config_by_name().
+    char onvif_url_cached[MAX_PATH_LENGTH]; // http://host[:port]
+    char onvif_username_cached[64];
+    char onvif_password_cached[64];
+
     // FFmpeg contexts (managed exclusively by the unified detection thread).
     // Concurrency / lifetime:
     // - These pointers and stream indices are created, updated, and freed only
@@ -137,6 +165,20 @@ typedef struct {
     atomic_bool fps_is_provisional;           // true when stored FPS is a fallback guess
     atomic_int fps_measurement_frame_count;   // video frames counted during measurement window
     atomic_llong fps_measurement_start_ns;    // start of measurement window, in nanoseconds since an epoch
+
+    // go2rtc replay detection: when the UDT connects, go2rtc replays its ring
+    // buffer in real-time before switching to live packets.  We track the wall
+    // clock time of the successful connect and the PTS of the very first video
+    // packet.  For every subsequent packet we compute:
+    //   pts_elapsed  = (pts - first_video_pts) * timebase   [stream time passed]
+    //   wall_elapsed = now - stream_connect_time             [real time passed]
+    //   replay_lag   = wall_elapsed - pts_elapsed            [how far behind live]
+    // While replay_lag > pre_buffer_seconds the stream is still replaying old
+    // data and packets must NOT enter the pre-buffer.
+    time_t stream_connect_time;   // wall time of last successful connect
+    int64_t first_video_pts;      // PTS of first video packet after connect
+    bool first_video_pts_set;     // whether first_video_pts has been recorded
+    bool stream_is_live;          // true once replay_lag <= pre_buffer_seconds
 
     // Thread safety
     pthread_mutex_t mutex;

--- a/src/video/go2rtc/go2rtc_integration.c
+++ b/src/video/go2rtc/go2rtc_integration.c
@@ -83,6 +83,11 @@ static bool g_initialized = false;
 
 // Stuck stream detection: consecutive checks with no byte count increase
 #define STUCK_STREAM_MAX_STALLED_CHECKS 3
+// How long after a connect/reconnect to suppress stuck detection.
+// Must cover the go2rtc replay warmup (2 * pre_buffer_seconds, typically
+// 20-40s) plus at least one full health-check interval as margin.
+// 30 * (3+1) = 120s — safely beyond the ~90s false-positive window.
+#define STUCK_STREAM_WARMUP_SEC  (HEALTH_CHECK_INTERVAL_SEC * (STUCK_STREAM_MAX_STALLED_CHECKS + 1))
 
 // Stuck stream tracking per stream
 typedef struct {
@@ -91,6 +96,7 @@ typedef struct {
     int64_t last_bytes_send;      // Last known bytes sent by preload consumer
     int stalled_checks;           // Consecutive checks with no increase
     time_t last_check_time;       // Time of last check
+    time_t tracking_start_time;   // Wall time when tracker was created or last reset
     bool tracking_active;         // Whether we're actively tracking this stream
 } stuck_stream_tracker_t;
 
@@ -157,6 +163,7 @@ static stuck_stream_tracker_t *get_or_create_stuck_tracker(const char *stream_na
             g_stuck_trackers[i].tracking_active = true;
             g_stuck_trackers[i].last_bytes_recv = -1;  // -1 = not yet initialized
             g_stuck_trackers[i].last_bytes_send = -1;
+            g_stuck_trackers[i].tracking_start_time = time(NULL);
             pthread_mutex_unlock(&g_stuck_tracker_mutex);
             return &g_stuck_trackers[i];
         }
@@ -178,6 +185,7 @@ static void reset_stuck_tracker(const char *stream_name) {
             g_stuck_trackers[i].last_bytes_send = -1;
             g_stuck_trackers[i].stalled_checks = 0;
             g_stuck_trackers[i].last_check_time = 0;
+            g_stuck_trackers[i].tracking_start_time = time(NULL);
             break;
         }
     }
@@ -190,6 +198,29 @@ static void reset_stuck_tracker(const char *stream_name) {
  * Returns true if the stream appears to be stuck (no data flow)
  */
 static bool check_stream_data_flow(const char *stream_name) {
+    // Warmup guard: skip stuck detection for STUCK_STREAM_WARMUP_SEC after
+    // connect or reconnect.  During this window go2rtc is still draining its
+    // replay buffer and byte counters are legitimately stagnant — triggering
+    // a reload here causes the ~80-90s false-positive reconnect cycle.
+    // The tracker's tracking_start_time is renewed by reset_stuck_tracker()
+    // after every successful reload, so this guard also fires correctly after
+    // camera reboots and subsequent reconnects.
+    {
+        stuck_stream_tracker_t *t = get_or_create_stuck_tracker(stream_name);
+        if (t) {
+            pthread_mutex_lock(&g_stuck_tracker_mutex);
+            time_t start = t->tracking_start_time;
+            pthread_mutex_unlock(&g_stuck_tracker_mutex);
+            time_t now_guard = time(NULL);
+            if (now_guard - start < (time_t)STUCK_STREAM_WARMUP_SEC) {
+                log_debug("Stream %s: skipping stuck check (post-connect warmup, %lds remaining)",
+                          stream_name,
+                          (long)(STUCK_STREAM_WARMUP_SEC - (now_guard - start)));
+                return false;
+            }
+        }
+    }
+
     // Fetch stream info from go2rtc API
     CURL *curl = curl_easy_init();
     if (!curl) {

--- a/src/video/go2rtc/go2rtc_process.c
+++ b/src/video/go2rtc/go2rtc_process.c
@@ -708,14 +708,6 @@ bool go2rtc_process_generate_config(const char *config_path, int api_port) {
         fprintf(config_file, "\n");
     }
 
-    // Logging configuration
-    fprintf(config_file, "log:\n");
-    fprintf(config_file, "  level: debug\n");  // Use debug level for more verbose logging
-    // Derive go2rtc log path from the config directory so it is consistent
-    // with the directory used for go2rtc.yaml and the lightnvr log.
-    // g_config_dir is guaranteed non-NULL here (validated in go2rtc_process_init).
-    fprintf(config_file, "  output: %s/go2rtc.log\n\n", g_config_dir);
-
     fprintf(config_file, "ffmpeg:\n");
     fprintf(config_file, "  h264: \"-codec:v libx264 -g:v 30 -preset:v superfast\"\n");
     fprintf(config_file, "  h265: \"-codec:v libx265 -g:v 30 -preset:v superfast\"\n");

--- a/src/video/go2rtc/go2rtc_process.c
+++ b/src/video/go2rtc/go2rtc_process.c
@@ -711,6 +711,7 @@ bool go2rtc_process_generate_config(const char *config_path, int api_port) {
     // Logging configuration
     fprintf(config_file, "log:\n");
     fprintf(config_file, "  level: debug\n\n");  // Use debug level for more verbose logging
+    fprintf(config_file, "  output: /var/log/lightnvr/go2rtc.log\n\n");
 
     fprintf(config_file, "ffmpeg:\n");
     fprintf(config_file, "  h264: \"-codec:v libx264 -g:v 30 -preset:v superfast\"\n");

--- a/src/video/go2rtc/go2rtc_process.c
+++ b/src/video/go2rtc/go2rtc_process.c
@@ -710,8 +710,11 @@ bool go2rtc_process_generate_config(const char *config_path, int api_port) {
 
     // Logging configuration
     fprintf(config_file, "log:\n");
-    fprintf(config_file, "  level: debug\n\n");  // Use debug level for more verbose logging
-    fprintf(config_file, "  output: /var/log/lightnvr/go2rtc.log\n\n");
+    fprintf(config_file, "  level: debug\n");  // Use debug level for more verbose logging
+    // Derive go2rtc log path from the config directory so it is consistent
+    // with the directory used for go2rtc.yaml and the lightnvr log.
+    // g_config_dir is guaranteed non-NULL here (validated in go2rtc_process_init).
+    fprintf(config_file, "  output: %s/go2rtc.log\n\n", g_config_dir);
 
     fprintf(config_file, "ffmpeg:\n");
     fprintf(config_file, "  h264: \"-codec:v libx264 -g:v 30 -preset:v superfast\"\n");

--- a/src/video/onvif_detection.c
+++ b/src/video/onvif_detection.c
@@ -663,7 +663,7 @@ int detect_motion_onvif(const char *onvif_url, const char *username, const char 
             // Publish to MQTT and trigger motion recording if detections remain after filtering
             if (result->count > 0) {
                 mqtt_publish_detection(stream_name, result, timestamp);
-                process_motion_event(stream_name, true, timestamp);
+                process_motion_event(stream_name, true, timestamp, false);
             }
         } else {
             log_warn("No stream name provided, skipping database storage");
@@ -674,7 +674,7 @@ int detect_motion_onvif(const char *onvif_url, const char *username, const char 
 
         // Notify motion recording that motion has ended
         if (stream_name && stream_name[0] != '\0') {
-            process_motion_event(stream_name, false, time(NULL));
+            process_motion_event(stream_name, false, time(NULL), false);
         }
     }
 

--- a/src/video/onvif_motion_recording.c
+++ b/src/video/onvif_motion_recording.c
@@ -836,44 +836,83 @@ int process_motion_event(const char *stream_name, bool motion_detected, time_t t
     log_debug("Queued motion event for stream: %s (active: %d)", stream_name, motion_detected);
 
     // Cross-stream motion trigger: propagate this event to any streams that
-    // have their motion_trigger_source set to the current stream's name.
-    // This enables dual-lens cameras (e.g. TP-Link C545D) where the fixed
-    // wide-angle lens provides ONVIF events and the PTZ lens does not.
+    // have their motion_trigger_source set to the current stream's name,
+    // AND — for bidirectional dual-lens support — also notify the stream
+    // that is configured as THIS stream's own motion_trigger_source.
     //
-    // Two propagation paths exist:
-    //  A) ONVIF-managed slave  → push a motion_event_t onto the ONVIF event queue
-    //  B) UDT-managed slave    → call unified_detection_notify_motion() so the UDT
-    //                            thread picks it up on the next packet boundary
+    // Bidirectional design (TP-Link C545D and similar):
+    //   Both lenses post motion events to a single shared ONVIF endpoint.
+    //   Whichever lens's ONVIF thread consumes the event first should
+    //   immediately trigger recording on the other lens, regardless of
+    //   which direction the motion_trigger_source relationship is configured.
     //
-    // Both paths are attempted for every matching slave stream; whichever
-    // system is not managing that stream will silently ignore the call.
+    // Loop prevention:
+    //   The is_propagated flag is set on every forwarded event.  A stream
+    //   that receives a propagated event will NOT propagate it further,
+    //   breaking any potential ping-pong between two linked streams.
+    //
+    // Two delivery paths exist per target stream:
+    //  A) ONVIF-managed stream → push a motion_event_t onto its event queue
+    //  B) UDT-managed stream   → call unified_detection_notify_motion() so
+    //                            the UDT picks it up on the next keyframe
+    //
+    // Both paths are always attempted; whichever system does not own the
+    // target stream silently ignores the call.
+
+    // Only propagate if this event was not itself already a propagated copy.
+    if (event.is_propagated) {
+        return 0;
+    }
+
     int max_streams = g_config.max_streams > 0 ? g_config.max_streams : MAX_STREAMS;
     stream_config_t *all_streams = calloc(max_streams, sizeof(stream_config_t));
     if (all_streams) {
         int count = get_all_stream_configs(all_streams, max_streams);
+
+        // Collect our own motion_trigger_source (reverse direction)
+        char own_trigger_source[MAX_STREAM_NAME] = {0};
         for (int i = 0; i < count; i++) {
-            if (all_streams[i].motion_trigger_source[0] != '\0' &&
-                strcmp(all_streams[i].motion_trigger_source, stream_name) == 0) {
-                // Path A: ONVIF event queue (for ONVIF-managed slave streams)
-                motion_event_t linked_event;
-                memset(&linked_event, 0, sizeof(motion_event_t));
-                safe_strcpy(linked_event.stream_name, all_streams[i].name, MAX_STREAM_NAME, 0);
-                linked_event.timestamp = timestamp;
-                linked_event.active = motion_detected;
-                linked_event.confidence = 1.0f;
-                safe_strcpy(linked_event.event_type, "motion", sizeof(linked_event.event_type), 0);
-
-                if (push_event(&linked_event) != 0) {
-                    log_error("Failed to push linked motion event to stream: %s (triggered by: %s)",
-                              all_streams[i].name, stream_name);
-                } else {
-                    log_info("Propagated motion event (%s) from '%s' to linked ONVIF stream '%s'",
-                             motion_detected ? "start" : "end", stream_name, all_streams[i].name);
-                }
-
-                // Path B: UDT external trigger (for UDT-managed slave streams, e.g. PTZ lens)
-                unified_detection_notify_motion(all_streams[i].name, motion_detected);
+            if (strcmp(all_streams[i].name, stream_name) == 0 &&
+                all_streams[i].motion_trigger_source[0] != '\0') {
+                safe_strcpy(own_trigger_source, all_streams[i].motion_trigger_source,
+                            MAX_STREAM_NAME, 0);
+                break;
             }
+        }
+
+        for (int i = 0; i < count; i++) {
+            // Forward direction: streams that list us as their trigger source
+            bool forward = (all_streams[i].motion_trigger_source[0] != '\0' &&
+                            strcmp(all_streams[i].motion_trigger_source, stream_name) == 0);
+            // Reverse direction: the stream we list as our own trigger source
+            bool reverse = (own_trigger_source[0] != '\0' &&
+                            strcmp(all_streams[i].name, own_trigger_source) == 0);
+
+            if (!forward && !reverse) continue;
+            // Never echo back to ourselves
+            if (strcmp(all_streams[i].name, stream_name) == 0) continue;
+
+            motion_event_t linked_event;
+            memset(&linked_event, 0, sizeof(motion_event_t));
+            safe_strcpy(linked_event.stream_name, all_streams[i].name, MAX_STREAM_NAME, 0);
+            linked_event.timestamp = timestamp;
+            linked_event.active = motion_detected;
+            linked_event.confidence = 1.0f;
+            linked_event.is_propagated = true;  // block second-order propagation
+            safe_strcpy(linked_event.event_type, "motion", sizeof(linked_event.event_type), 0);
+
+            // Path A: ONVIF event queue
+            if (push_event(&linked_event) != 0) {
+                log_error("Failed to push linked motion event to stream: %s (triggered by: %s)",
+                          all_streams[i].name, stream_name);
+            } else {
+                log_info("Propagated motion event (%s) from '%s' to linked ONVIF stream '%s' (%s)",
+                         motion_detected ? "start" : "end", stream_name, all_streams[i].name,
+                         reverse ? "reverse" : "forward");
+            }
+
+            // Path B: UDT external trigger
+            unified_detection_notify_motion(all_streams[i].name, motion_detected);
         }
         free(all_streams);
     }

--- a/src/video/onvif_motion_recording.c
+++ b/src/video/onvif_motion_recording.c
@@ -813,7 +813,7 @@ int disable_motion_recording(const char *stream_name) {
 /**
  * Process a motion event
  */
-int process_motion_event(const char *stream_name, bool motion_detected, time_t timestamp) {
+int process_motion_event(const char *stream_name, bool motion_detected, time_t timestamp, bool is_propagated) {
     if (!stream_name) {
         return -1;
     }
@@ -860,7 +860,9 @@ int process_motion_event(const char *stream_name, bool motion_detected, time_t t
     // target stream silently ignores the call.
 
     // Only propagate if this event was not itself already a propagated copy.
-    if (event.is_propagated) {
+    // is_propagated is passed explicitly by the caller; the local event struct
+    // is always zero-initialised and cannot carry this flag reliably.
+    if (is_propagated) {
         return 0;
     }
 

--- a/src/video/packet_buffer.c
+++ b/src/video/packet_buffer.c
@@ -345,12 +345,32 @@ int packet_buffer_add_packet(packet_buffer_t *buffer, const AVPacket *packet, ti
 
     pthread_mutex_lock(&buffer->mutex);
 
-    // Check if buffer is full
+    // Time-based eviction: remove packets older than buffer_seconds regardless of FPS.
+    // This ensures the pre-buffer never exceeds the configured window even when the
+    // stream runs at a much lower FPS than the 15 fps assumed by max_packets estimation.
+    while (buffer->count > 0) {
+        time_t oldest = buffer->packets[buffer->tail].timestamp;
+        if ((timestamp - oldest) > (time_t)buffer->buffer_seconds) {
+            if (buffer->packets[buffer->tail].packet) {
+                buffer->current_memory_usage -= buffer->packets[buffer->tail].data_size;
+                av_packet_free(&buffer->packets[buffer->tail].packet);
+                buffer->packets[buffer->tail].packet = NULL;
+            }
+            buffer->tail = (buffer->tail + 1) % buffer->max_packets;
+            buffer->count--;
+            buffer->total_packets_dropped++;
+        } else {
+            break;
+        }
+    }
+
+    // Fallback: if buffer is still full (burst of packets within the time window),
+    // evict the oldest by packet count to guarantee a free slot.
     if (buffer->count >= buffer->max_packets) {
-        // Remove oldest packet to make room
         if (buffer->packets[buffer->tail].packet) {
             buffer->current_memory_usage -= buffer->packets[buffer->tail].data_size;
             av_packet_free(&buffer->packets[buffer->tail].packet);
+            buffer->packets[buffer->tail].packet = NULL;
         }
         buffer->tail = (buffer->tail + 1) % buffer->max_packets;
         buffer->count--;
@@ -383,9 +403,11 @@ int packet_buffer_add_packet(packet_buffer_t *buffer, const AVPacket *packet, ti
     buffer->total_bytes_buffered += packet->size;
     buffer->total_packets_buffered++;
 
-    // Update timing
+    // Update timing — always derive from the actual tail after time-based eviction
     if (buffer->count == 0) {
         buffer->oldest_packet_time = timestamp;
+    } else {
+        buffer->oldest_packet_time = buffer->packets[buffer->tail].timestamp;
     }
     buffer->newest_packet_time = timestamp;
 

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -1612,8 +1612,12 @@ stats_done:
                     should_buffer = true;
                 }
             } else {
-                log_debug("[%s] go2rtc replay in progress (lag=%.1fs), skipping pre-buffer",
-                          ctx->stream_name, replay_lag);
+                /* Rate-limit: only log on keyframes (~every 2 s) to avoid
+                 * flooding the log at full frame-rate during replay. */
+                if (is_keyframe) {
+                    log_debug("[%s] go2rtc replay in progress (lag=%.1fs), skipping pre-buffer",
+                              ctx->stream_name, replay_lag);
+                }
             }
         }
     } else if (!is_video && ctx->stream_is_live) {

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -446,8 +446,10 @@ static int find_empty_slot(void) {
 static void *onvif_detection_thread_func(void *arg) {
     unified_detection_ctx_t *ctx = (unified_detection_ctx_t *)arg;
 
-    log_info("[%s] ONVIF detection thread started (url=%s, user=%s)",
-             ctx->stream_name, ctx->onvif_url_cached, ctx->onvif_username_cached);
+    log_info("[%s] ONVIF detection thread started (url=%s)",
+             ctx->stream_name, ctx->onvif_url_cached);
+    log_debug("[%s] ONVIF detection thread credentials: user=%s",
+              ctx->stream_name, ctx->onvif_username_cached);
 
     while (atomic_load(&ctx->onvif_thread_running)) {
         detection_result_t result;

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -104,6 +104,10 @@ static bool run_detection_on_frame(unified_detection_ctx_t *ctx, AVPacket *pkt);
 static int udt_start_recording(unified_detection_ctx_t *ctx);
 static int udt_stop_recording(unified_detection_ctx_t *ctx);
 static int flush_prebuffer_to_recording(unified_detection_ctx_t *ctx);
+// ONVIF async detection thread helpers (defined before start_unified_detection_thread)
+static void *onvif_detection_thread_func(void *arg);
+static int   start_onvif_detection_thread(unified_detection_ctx_t *ctx);
+static void  stop_onvif_detection_thread(unified_detection_ctx_t *ctx);
 /**
  * Determine the actual API URL to use for detection based on the configured
  * model path and global configuration.
@@ -331,6 +335,12 @@ void shutdown_unified_detection_system(void) {
 
             log_info("Cleaning up unified detection context for %s", ctx->stream_name);
 
+            // Stop the ONVIF detection thread before freeing ctx.
+            // Must happen before free() to avoid use-after-free in the thread.
+            if (is_onvif_detection_model(ctx->model_path)) {
+                stop_onvif_detection_thread(ctx);
+            }
+
             // Clean up resources
             if (ctx->packet_buffer) {
                 destroy_packet_buffer(ctx->packet_buffer);
@@ -408,6 +418,168 @@ static int find_empty_slot(void) {
     return -1;
 }
 
+/* =========================================================================
+ * ONVIF async detection thread
+ * =========================================================================
+ *
+ * Runs detect_motion_onvif() in a loop inside its own OS thread so that
+ * the UDT main loop (and therefore av_read_frame()) is never blocked by a
+ * CURL/SOAP round-trip.
+ *
+ * The PullMessages call inside detect_motion_onvif() blocks up to
+ * CURLOPT_TIMEOUT (10 s) / PT5S while waiting for camera events.  That
+ * natural blocking serves as the inter-poll sleep — no extra sleep() is
+ * needed in the happy path.
+ *
+ * On ONVIF error the motion flag is cleared and we back off ~5 s before
+ * retrying; the ONVIF subscription is renewed automatically inside
+ * detect_motion_onvif() itself.
+ *
+ * SOD and API detection paths are completely unaffected by this change.
+ * Only the is_onvif_detection_model() branch in run_detection_on_frame()
+ * has been modified.
+ * ========================================================================= */
+
+/**
+ * Body of the ONVIF detection background thread.
+ */
+static void *onvif_detection_thread_func(void *arg) {
+    unified_detection_ctx_t *ctx = (unified_detection_ctx_t *)arg;
+
+    log_info("[%s] ONVIF detection thread started (url=%s, user=%s)",
+             ctx->stream_name, ctx->onvif_url_cached, ctx->onvif_username_cached);
+
+    while (atomic_load(&ctx->onvif_thread_running)) {
+        detection_result_t result;
+        memset(&result, 0, sizeof(result));
+
+        int ret = detect_motion_onvif(ctx->onvif_url_cached,
+                                      ctx->onvif_username_cached,
+                                      ctx->onvif_password_cached,
+                                      &result,
+                                      ctx->stream_name);
+
+        /* Re-check stop flag — detect_motion_onvif() may have blocked for
+         * up to CURLOPT_TIMEOUT seconds.  Bail before touching shared state
+         * if we have been asked to stop. */
+        if (!atomic_load(&ctx->onvif_thread_running)) break;
+
+        if (ret == 0 && result.count > 0) {
+            atomic_store(&ctx->onvif_motion_detected, 1);
+            atomic_store(&ctx->onvif_motion_timestamp, (long long)time(NULL));
+            log_debug("[%s] ONVIF thread: %d motion event(s) detected",
+                      ctx->stream_name, result.count);
+
+            /* When motion is active, PullMessages returns immediately (the
+             * camera does not hold the connection for PT5S if events are
+             * already queued).  Without a floor here both ONVIF threads
+             * would busy-loop, firing detect_motion_onvif() dozens of times
+             * per second and flooding process_motion_event() / propagation /
+             * DB writes with redundant events (observed: 20+ calls in a
+             * single log-second during a motion burst).
+             *
+             * 2 s is long enough to prevent the storm while still keeping
+             * the atomic flag fresh for the UDT's 10 s detection interval.
+             * Checked in 100 ms slices so stop requests are honoured quickly. */
+            for (int i = 0; i < 20 && atomic_load(&ctx->onvif_thread_running); i++) {
+                av_usleep(100000); /* 20 x 100 ms = 2 s */
+            }
+        } else {
+            /* No events in this window (ret==0, count==0) or an ONVIF error
+             * (ret!=0).
+             *
+             * Sticky-flag hysteresis: do NOT clear onvif_motion_detected
+             * immediately.  Both ONVIF threads share one PullPoint subscription
+             * on this camera.  The event queue alternates between "has events"
+             * and "empty" depending on which thread pulled last, so a single
+             * "no motion" response does not mean the scene is actually quiet —
+             * the sibling thread may have consumed the motion event a few ms
+             * earlier.  If we cleared the flag instantly we would race with the
+             * UDT's 10 s detection interval and wide (or ptz) would miss the
+             * trigger entirely (observed: 38 s late start).
+             *
+             * Strategy: keep the flag set for at least
+             * ONVIF_MOTION_HOLD_SECS after the last confirmed motion event.
+             * This guarantees the UDT sees flag==1 on its next 10 s tick even
+             * if our very next PullMessages comes back empty.  Only after the
+             * hold window expires do we declare the scene idle. */
+            #define ONVIF_MOTION_HOLD_SECS 15
+            long long last_ts = atomic_load(&ctx->onvif_motion_timestamp);
+            if (last_ts == 0LL ||
+                (long long)time(NULL) - last_ts >= ONVIF_MOTION_HOLD_SECS) {
+                atomic_store(&ctx->onvif_motion_detected, 0);
+            }
+            /* else: hold the flag until the window expires */
+
+            if (ret != 0) {
+                log_warn("[%s] ONVIF thread: detect_motion_onvif error %d – "
+                         "backing off 5 s before retry", ctx->stream_name, ret);
+                /* 50 × 100 ms = 5 s, checking stop flag on each iteration. */
+                for (int i = 0; i < 50 && atomic_load(&ctx->onvif_thread_running); i++) {
+                    av_usleep(100000);
+                }
+            }
+        }
+    }
+
+    log_info("[%s] ONVIF detection thread exiting", ctx->stream_name);
+    return NULL;
+}
+
+/**
+ * Start the ONVIF detection background thread for the given context.
+ * ctx->onvif_url_cached / _username_cached / _password_cached must already
+ * be populated by the caller.
+ *
+ * The thread is created joinable so that unified_detection_thread_func()
+ * can join it on exit and avoid a detached-thread resource leak.
+ *
+ * @return 0 on success, -1 on failure.
+ */
+static int start_onvif_detection_thread(unified_detection_ctx_t *ctx) {
+    atomic_store(&ctx->onvif_thread_running, 1);
+    atomic_store(&ctx->onvif_motion_detected, 0);
+    atomic_store(&ctx->onvif_motion_timestamp, 0LL);
+
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+
+    int ret = pthread_create(&ctx->onvif_thread, &attr,
+                             onvif_detection_thread_func, ctx);
+    pthread_attr_destroy(&attr);
+
+    if (ret != 0) {
+        log_error("[%s] Failed to create ONVIF detection thread: %s",
+                  ctx->stream_name, strerror(ret));
+        atomic_store(&ctx->onvif_thread_running, 0);
+        return -1;
+    }
+
+    log_info("[%s] ONVIF detection thread created", ctx->stream_name);
+    return 0;
+}
+
+/**
+ * Signal the ONVIF detection thread to stop and join it.
+ * Safe to call when the thread was never started (onvif_thread_running == 0).
+ * Blocks for at most CURLOPT_TIMEOUT + small overhead (≤ ~12 s).
+ */
+static void stop_onvif_detection_thread(unified_detection_ctx_t *ctx) {
+    if (!atomic_load(&ctx->onvif_thread_running)) {
+        return; /* never started or already stopped */
+    }
+
+    log_info("[%s] Requesting ONVIF detection thread to stop…", ctx->stream_name);
+    atomic_store(&ctx->onvif_thread_running, 0);
+
+    /* pthread_join blocks until the current detect_motion_onvif() call
+     * completes (max CURLOPT_TIMEOUT = 10 s + subscription overhead ≈ 12 s).
+     * Acceptable because this path is only reached during UDT teardown. */
+    pthread_join(ctx->onvif_thread, NULL);
+    log_info("[%s] ONVIF detection thread joined", ctx->stream_name);
+}
+
 /**
  * Start unified detection recording for a stream
  */
@@ -480,6 +652,12 @@ int start_unified_detection_thread(const char *stream_name, const char *model_pa
     ctx->record_audio = config.record_audio;
     ctx->annotation_only = annotation_only;
     atomic_store(&ctx->external_motion_trigger, 0);  // no pending external trigger
+
+    // Replay-detection: will be set properly on first successful connect
+    ctx->stream_connect_time = time(NULL);
+    ctx->first_video_pts = AV_NOPTS_VALUE;
+    ctx->first_video_pts_set = false;
+    ctx->stream_is_live = false;
 
     // Initialize to current time to avoid large elapsed time on first detection check
     atomic_store(&ctx->last_detection_check_time, (long long)time(NULL));
@@ -554,11 +732,42 @@ int start_unified_detection_thread(const char *stream_name, const char *model_pa
     atomic_store(&ctx->last_packet_time, (int_fast64_t)time(NULL));
     atomic_store(&ctx->consecutive_failures, 0);
 
+    // Initialize ONVIF async detection thread atomics (zero from calloc, but be explicit)
+    atomic_store(&ctx->onvif_thread_running, 0);
+    atomic_store(&ctx->onvif_motion_detected, 0);
+    atomic_store(&ctx->onvif_motion_timestamp, 0LL);
+
+    // For ONVIF model: cache connection parameters and start the background
+    // polling thread BEFORE the UDT starts reading packets.  This ensures a
+    // motion flag is available on the very first detection check.
+    if (is_onvif_detection_model(model_path)) {
+        extract_onvif_base_url(config.url, config.onvif_port,
+                               ctx->onvif_url_cached, sizeof(ctx->onvif_url_cached));
+        safe_strcpy(ctx->onvif_username_cached, config.onvif_username,
+                    sizeof(ctx->onvif_username_cached), 0);
+        safe_strcpy(ctx->onvif_password_cached, config.onvif_password,
+                    sizeof(ctx->onvif_password_cached), 0);
+
+        if (ctx->onvif_url_cached[0] == '\0') {
+            log_error("[%s] Cannot start ONVIF detection thread: "
+                      "could not derive ONVIF URL from stream URL '%s'",
+                      stream_name, config.url);
+            /* Non-fatal: run_detection_on_frame() will see onvif_motion_detected==0
+             * and return false every cycle, which is safe (no spurious recordings). */
+        } else {
+            if (start_onvif_detection_thread(ctx) != 0) {
+                log_error("[%s] ONVIF detection thread could not be started; "
+                          "ONVIF-triggered recording is disabled for this stream",
+                          stream_name);
+            }
+        }
+    }
+
     // Store context in slot
     ctx->slot_idx = slot;
     detection_contexts[slot] = ctx;
 
-    // Create thread (detached)
+    // Create UDT thread (detached)
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
@@ -1033,6 +1242,11 @@ static void *unified_detection_thread_func(void *arg) {
                     ctx->reconnect_attempt = 0;
                     reconnect_delay_ms = BASE_RECONNECT_DELAY_MS;
                     atomic_store(&ctx->last_packet_time, (int_fast64_t)time(NULL));
+                    // Reset replay-detection state for the new connection
+                    ctx->stream_connect_time = time(NULL);
+                    ctx->first_video_pts_set = false;
+                    ctx->first_video_pts = AV_NOPTS_VALUE;
+                    ctx->stream_is_live = false;
                 } else {
                     ctx->reconnect_attempt++;
                     atomic_fetch_add(&ctx->consecutive_failures, 1);
@@ -1150,6 +1364,14 @@ static void *unified_detection_thread_func(void *arg) {
         udt_stop_recording(ctx);
     }
 
+    // Stop the ONVIF detection thread before freeing ctx.
+    // Must happen before disconnect_from_stream() and before any free(),
+    // because the ONVIF thread still holds a pointer to ctx.
+    // pthread_join blocks for at most CURLOPT_TIMEOUT + subscription overhead (≤ ~12 s).
+    if (is_onvif_detection_model(ctx->model_path)) {
+        stop_onvif_detection_thread(ctx);
+    }
+
     // Disconnect from stream to free FFmpeg decoder_ctx and input_ctx
     // This handles the case where the thread exits the loop while still connected
     // (e.g., during shutdown while in BUFFERING/RECORDING state)
@@ -1207,12 +1429,15 @@ static int flush_packet_callback(const AVPacket *packet, void *user_data) {
 
     unified_detection_ctx_t *ctx = flush_ctx->ctx;
 
-    // Skip until we find a keyframe (ensures valid MP4 start)
+    // Skip until we find a VIDEO keyframe (ensures valid MP4 start).
+    // Audio packets carry AV_PKT_FLAG_KEY on every frame; using them as the
+    // keyframe anchor would prevent the MP4 writer from ever initialising.
     if (!flush_ctx->found_keyframe) {
-        if (packet->flags & AV_PKT_FLAG_KEY) {
+        if ((packet->flags & AV_PKT_FLAG_KEY) &&
+            packet->stream_index == flush_ctx->ctx->video_stream_idx) {
             flush_ctx->found_keyframe = true;
         } else {
-            return 0;  // Skip non-keyframe packets before first keyframe
+            return 0;  // Skip until first video keyframe
         }
     }
 
@@ -1314,7 +1539,68 @@ stats_done:
 
     // Always add packets to circular buffer (for pre-detection content)
     // The buffer automatically evicts old packets when full
-    packet_buffer_add_packet(ctx->packet_buffer, pkt, now);
+    //
+    // go2rtc replay guard: go2rtc replays its ring buffer in real-time when a
+    // consumer connects.  During replay the PTS lags behind wall clock by the
+    // ring-buffer duration.  We skip buffering until the stream is live so the
+    // pre-buffer contains only recent (useful) packets.
+    // The lag is derived from video packets only; audio packets follow the same
+    // gate so the buffer never fills with orphaned audio during replay.
+    //
+    // Additionally, we only start buffering on a keyframe — so the pre-buffer
+    // always begins with a valid GOP start and flush_packet_callback will find
+    // a keyframe to initialise the MP4 writer.
+    bool should_buffer = false;
+    if (is_video && ctx->input_ctx && ctx->video_stream_idx >= 0) {
+        if (!ctx->first_video_pts_set) {
+            // First video packet — record PTS reference, still assume replay
+            ctx->first_video_pts = pkt->pts;
+            ctx->first_video_pts_set = true;
+        } else {
+            // Determine replay lag.
+            // If PTS is valid use PTS-vs-wallclock for accuracy.
+            // If PTS is AV_NOPTS_VALUE (common with some go2rtc outputs)
+            // fall back to pure wall-clock: treat the stream as still
+            // replaying until 2*pre_buffer_seconds have elapsed since connect.
+            double wall_elapsed = difftime(now, ctx->stream_connect_time);
+            double replay_lag;
+
+            if (pkt->pts != AV_NOPTS_VALUE && ctx->first_video_pts != AV_NOPTS_VALUE) {
+                AVRational tb = ctx->input_ctx->streams[ctx->video_stream_idx]->time_base;
+                double pts_elapsed = (double)(pkt->pts - ctx->first_video_pts) * av_q2d(tb);
+                replay_lag = wall_elapsed - pts_elapsed;
+            } else {
+                // No PTS available — conservative wall-clock warmup
+                double warmup = (double)(ctx->pre_buffer_seconds * 2);
+                replay_lag = (wall_elapsed < warmup) ? (warmup - wall_elapsed) : 0.0;
+            }
+
+            if (replay_lag <= (double)ctx->pre_buffer_seconds) {
+                if (!ctx->stream_is_live) {
+                    if (is_keyframe) {
+                        // First live keyframe — flush stale data and start buffering
+                        packet_buffer_clear(ctx->packet_buffer);
+                        ctx->stream_is_live = true;
+                        should_buffer = true;
+                        log_info("[%s] go2rtc replay ended, pre-buffer active (lag=%.1fs)",
+                                 ctx->stream_name, replay_lag);
+                    }
+                    // else: waiting for first live keyframe — skip
+                } else {
+                    should_buffer = true;
+                }
+            } else {
+                log_debug("[%s] go2rtc replay in progress (lag=%.1fs), skipping pre-buffer",
+                          ctx->stream_name, replay_lag);
+            }
+        }
+    } else if (!is_video && ctx->first_video_pts_set) {
+        // Non-video (audio): buffer only once video has gone live
+        should_buffer = true;
+    }
+
+    if (should_buffer)
+        packet_buffer_add_packet(ctx->packet_buffer, pkt, now);
 
     // If recording, write packet to MP4
     if (current_state == UDT_STATE_RECORDING || current_state == UDT_STATE_POST_BUFFER) {
@@ -2004,49 +2290,37 @@ static bool run_detection_on_frame(unified_detection_ctx_t *ctx, AVPacket *pkt) 
         return mot_triggered;
     }
 
-    // ONVIF event-based detection — no frame decoding needed
+    // ONVIF event-based detection — non-blocking atomic flag read
+    // -----------------------------------------------------------------------
+    // detect_motion_onvif() is NOT called here anymore.  A dedicated
+    // background thread (started alongside the UDT, see
+    // start_onvif_detection_thread) polls the camera continuously and writes
+    // its result into ctx->onvif_motion_detected.
+    //
+    // This keeps process_packet() / av_read_frame() completely unblocked:
+    //   • No CURL/SOAP round-trip in the UDT main loop.
+    //   • No PTS gaps in the MP4 caused by ONVIF blocking.
+    //   • No write i/o timeout on the go2rtc consumer connection.
+    //
+    // The ONVIF thread manages the flag value:
+    //   1 while the camera reports motion events; 0 when idle or on error.
+    // We read without clearing — the thread updates the flag each poll cycle.
+    //
+    // SOD and API detection paths are fully unaffected by this change.
+    // -----------------------------------------------------------------------
     if (is_onvif_detection_model(ctx->model_path)) {
-        // Fetch the stream config to obtain the camera URL and ONVIF credentials
-        stream_config_t onvif_cfg;
-        memset(&onvif_cfg, 0, sizeof(onvif_cfg));
-        if (get_stream_config_by_name(ctx->stream_name, &onvif_cfg) != 0) {
-            log_warn("[%s] ONVIF detection: failed to look up stream config", ctx->stream_name);
-            return false;
-        }
+        bool onvif_triggered = (atomic_load(&ctx->onvif_motion_detected) != 0);
 
-        // Derive http://host[:port] from the stream's RTSP/ONVIF URL
-        char onvif_url[MAX_PATH_LENGTH];
-        extract_onvif_base_url(onvif_cfg.url, onvif_cfg.onvif_port, onvif_url, sizeof(onvif_url));
-
-        if (onvif_url[0] == '\0') {
-            log_warn("[%s] ONVIF detection: could not derive ONVIF URL from stream URL: %s",
-                     ctx->stream_name, onvif_cfg.url);
-            return false;
-        }
-
-        log_debug("[%s] ONVIF detection: polling events at %s (user=%s)",
-                  ctx->stream_name, onvif_url, onvif_cfg.onvif_username);
-
-        // detect_motion_onvif already handles DB storage, MQTT publish, and
-        // recording trigger internally — do not duplicate those calls here.
-        int onvif_ret = detect_motion_onvif(onvif_url,
-                                            onvif_cfg.onvif_username,
-                                            onvif_cfg.onvif_password,
-                                            &result,
-                                            ctx->stream_name);
-        if (onvif_ret != 0) {
-            log_warn("[%s] ONVIF detection failed with error %d", ctx->stream_name, onvif_ret);
-            return false;
-        }
-
-        bool onvif_triggered = (result.count > 0);
         if (onvif_triggered) {
             pthread_mutex_lock(&ctx->mutex);
-            ctx->total_detections += result.count;
+            ctx->total_detections++;
             pthread_mutex_unlock(&ctx->mutex);
-            log_info("[%s] ONVIF motion detected (%d event(s))", ctx->stream_name, result.count);
+            log_info("[%s] ONVIF motion detected (async thread, ts=%lld)",
+                     ctx->stream_name,
+                     (long long)atomic_load(&ctx->onvif_motion_timestamp));
         }
         return onvif_triggered;
+
     }
 
     // Embedded model detection - requires frame decoding

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -788,6 +788,10 @@ int start_unified_detection_thread(const char *stream_name, const char *model_pa
     if (result != 0) {
         log_error("Failed to create unified detection thread for %s: %s",
                   stream_name, strerror(result));
+        /* Stop the ONVIF background thread before freeing ctx to avoid
+         * use-after-free: the thread was started above but the UDT that
+         * would normally join it never ran. */
+        stop_onvif_detection_thread(ctx);
         destroy_packet_buffer(ctx->packet_buffer);
         pthread_mutex_destroy(&ctx->mutex);
         free(ctx);

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -451,8 +451,8 @@ static void *onvif_detection_thread_func(void *arg) {
 
     log_info("[%s] ONVIF detection thread started (url=%s)",
              ctx->stream_name, ctx->onvif_url_cached);
-    log_debug("[%s] ONVIF detection thread credentials: user=%s",
-              ctx->stream_name, ctx->onvif_username_cached);
+    log_debug("[%s] ONVIF detection thread auth=%s",
+              ctx->stream_name, (ctx->onvif_username_cached[0] != '\0') ? "enabled" : "disabled");
 
     while (atomic_load(&ctx->onvif_thread_running)) {
         detection_result_t result;

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -1573,8 +1573,13 @@ stats_done:
             // lag calculations. If the stream is already known to be live,
             // allow an initial keyframe to enter the pre-buffer immediately so
             // we do not lose the first GOP window.
-            ctx->first_video_pts = pkt->pts;
-            ctx->first_video_pts_set = true;
+            if (pkt->pts != AV_NOPTS_VALUE) {
+                ctx->first_video_pts = pkt->pts;
+                ctx->first_video_pts_set = true;
+            }
+            // If the stream is already known to be live, allow an initial
+            // keyframe to enter the pre-buffer immediately so we do not
+            // lose the first GOP window.
             if (ctx->stream_is_live && is_keyframe) {
                 should_buffer = true;
             }

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -1610,8 +1610,9 @@ stats_done:
                           ctx->stream_name, replay_lag);
             }
         }
-    } else if (!is_video && ctx->first_video_pts_set) {
-        // Non-video (audio): buffer only once video has gone live
+    } else if (!is_video && ctx->stream_is_live) {
+        // Non-video (audio): buffer only after the first live keyframe has
+        // marked the stream as live, so replay audio is not added on its own.
         should_buffer = true;
     }
 

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -84,6 +84,9 @@
 
 // Detection recording settings
 #define DEFAULT_MIN_DETECTION_RECORDING_DURATION 10  // Default minimum total duration (seconds) for detection recordings (pre_buffer + post_buffer)
+#define ONVIF_MOTION_HOLD_SECS 15  // Seconds to hold onvif_motion_detected=1 after last confirmed motion event,
+                                   // preventing a shared-subscription race where the sibling thread clears the
+                                   // flag before the UDT reads it (must be > detection_interval, currently 10s)
 
 // Motion detection settings
 static const float DEFAULT_MOTION_SENSITIVITY = 0.15f;  // Fallback sensitivity if threshold is unset or out of range
@@ -505,7 +508,6 @@ static void *onvif_detection_thread_func(void *arg) {
              * This guarantees the UDT sees flag==1 on its next 10 s tick even
              * if our very next PullMessages comes back empty.  Only after the
              * hold window expires do we declare the scene idle. */
-            #define ONVIF_MOTION_HOLD_SECS 15
             long long last_ts = atomic_load(&ctx->onvif_motion_timestamp);
             if (last_ts == 0LL ||
                 (long long)time(NULL) - last_ts >= ONVIF_MOTION_HOLD_SECS) {

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -562,20 +562,28 @@ static int start_onvif_detection_thread(unified_detection_ctx_t *ctx) {
 
 /**
  * Signal the ONVIF detection thread to stop and join it.
- * Safe to call when the thread was never started (onvif_thread_running == 0).
+ * Safe to call when the thread was never started (onvif_thread_running == 0)
+ * or when another concurrent caller already claimed shutdown.
  * Blocks for at most CURLOPT_TIMEOUT + small overhead (≤ ~12 s).
+ *
+ * Uses atomic_compare_exchange_strong to transition onvif_thread_running
+ * from 1 → 0 in a single atomic step.  Only the caller that wins the
+ * exchange performs pthread_join(); all other concurrent callers return
+ * immediately, preventing undefined behaviour from multiple joins on the
+ * same thread handle.
  */
 static void stop_onvif_detection_thread(unified_detection_ctx_t *ctx) {
-    if (!atomic_load(&ctx->onvif_thread_running)) {
-        return; /* never started or already stopped */
+    int expected = 1;
+    if (!atomic_compare_exchange_strong(&ctx->onvif_thread_running, &expected, 0)) {
+        return; /* never started, already stopped, or another caller will join */
     }
 
-    log_info("[%s] Requesting ONVIF detection thread to stop…", ctx->stream_name);
-    atomic_store(&ctx->onvif_thread_running, 0);
+    log_info("[%s] Requesting ONVIF detection thread to stop", ctx->stream_name);
 
     /* pthread_join blocks until the current detect_motion_onvif() call
      * completes (max CURLOPT_TIMEOUT = 10 s + subscription overhead ≈ 12 s).
-     * Acceptable because this path is only reached during UDT teardown. */
+     * Acceptable because this path is only reached during UDT teardown.
+     * The compare-exchange above guarantees only one caller joins. */
     pthread_join(ctx->onvif_thread, NULL);
     log_info("[%s] ONVIF detection thread joined", ctx->stream_name);
 }

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -1553,9 +1553,15 @@ stats_done:
     bool should_buffer = false;
     if (is_video && ctx->input_ctx && ctx->video_stream_idx >= 0) {
         if (!ctx->first_video_pts_set) {
-            // First video packet — record PTS reference, still assume replay
+            // First video packet — record the PTS reference used for replay
+            // lag calculations. If the stream is already known to be live,
+            // allow an initial keyframe to enter the pre-buffer immediately so
+            // we do not lose the first GOP window.
             ctx->first_video_pts = pkt->pts;
             ctx->first_video_pts_set = true;
+            if (ctx->stream_is_live && is_keyframe) {
+                should_buffer = true;
+            }
         } else {
             // Determine replay lag.
             // If PTS is valid use PTS-vs-wallclock for accuracy.

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -481,7 +481,7 @@ void handle_test_motion_event(const http_request_t *req, http_response_t *res) {
 
     // Trigger a motion event
     time_t now = time(NULL);
-    int rc = process_motion_event(stream_name, true, now);
+    int rc = process_motion_event(stream_name, true, now, false);
 
     // Build response
     cJSON *response = cJSON_CreateObject();

--- a/tests/unit/test_cross_stream_motion_trigger.c
+++ b/tests/unit/test_cross_stream_motion_trigger.c
@@ -73,7 +73,7 @@ void tearDown(void) {}
  * ================================================================ */
 
 void test_process_motion_event_null_stream_returns_error(void) {
-    int rc = process_motion_event(NULL, true, time(NULL));
+    int rc = process_motion_event(NULL, true, time(NULL), false);
     TEST_ASSERT_NOT_EQUAL(0, rc);
 }
 
@@ -88,7 +88,7 @@ void test_process_motion_event_no_linked_streams(void) {
     stream_config_t src = make_stream("cam_fixed_solo", true);
     add_stream_config(&src);
 
-    int rc = process_motion_event("cam_fixed_solo", true, time(NULL));
+    int rc = process_motion_event("cam_fixed_solo", true, time(NULL), false);
     /* Primary event push may fail if motion recording system is not
      * enabled for this stream, but the cross-stream scan must not crash. */
     (void)rc;
@@ -114,7 +114,7 @@ void test_process_motion_event_propagates_to_linked_stream(void) {
     add_stream_config(&ptz);
 
     /* Trigger a motion-start event on the source stream */
-    int rc = process_motion_event("cam_fixed", true, time(NULL));
+    int rc = process_motion_event("cam_fixed", true, time(NULL), false);
     /* The propagation path (calloc/scan/push/free) must complete without crash.
      * push_event for the linked stream may fail if motion recording is not
      * initialized for cam_ptz, but we only assert no crash here. */
@@ -135,7 +135,7 @@ void test_process_motion_event_end_propagates_to_linked_stream(void) {
     add_stream_config(&ptz);
 
     /* Trigger motion-end */
-    int rc = process_motion_event("cam_fixed_end", false, time(NULL));
+    int rc = process_motion_event("cam_fixed_end", false, time(NULL), false);
     (void)rc;
     TEST_PASS();
 }
@@ -154,7 +154,7 @@ void test_process_motion_event_unregistered_source_no_crash(void) {
     add_stream_config(&ptz);
 
     /* Call for a totally different source — no linked streams should match */
-    int rc = process_motion_event("cam_other", true, time(NULL));
+    int rc = process_motion_event("cam_other", true, time(NULL), false);
     (void)rc;
     TEST_PASS();
 }


### PR DESCRIPTION
<p>Hi Matt  👋</p>
<p>Sorry for the size of this PR — it started as a simple pre-buffer fix and turned into a rabbit hole. Each fix uncovered the next problem, so they're genuinely inseparable.
What I found along the way: a blocking ONVIF call in the UDT main thread that starved av_read_frame(), a shared PullPoint subscription creating a race between detection threads, a motion event storm when PullMessages returns immediately, and a unidirectional propagation assumption that didn't hold once both sides of the link could independently consume events. Everything is documented with observation, root cause and design decision — hopefully enough for Copilot and human reviewers to get through it without too many questions. 🤞</p>
<h2>Summary</h2>
<p>This PR fixes a chain of interconnected issues discovered while running lightNVR
with a <strong>Tapo C545D / TP-Link TC47 dual-lens IP camera</strong> (wide-angle fixed lens +
PTZ tracking lens) through go2rtc as an RTSP proxy in Docker. The fixes address
root causes rather than symptoms and are designed to be safe for all camera
configurations including single-lens ONVIF cameras.</p>
<p>The work was developed and tested over several days of
production debugging, with each fix informed by the failure of the previous one.</p>
<hr>
<h2>Hardware &amp; Setup</h2>
<ul>
<li><strong>Camera:</strong> Tapo C545D / TP-Link TC47 (dual-lens: wide-angle + PTZ)</li>
<li><strong>Proxy:</strong> go2rtc as RTSP proxy</li>
<li><strong>Deployment:</strong> Docker</li>
<li><strong>Streams:</strong> <code>c545d_wide</code> (ONVIF, <code>onvif://192.168.1.123:2020/</code>) and
<code>c545d_ptz</code> (RTSP, <code>rtsp://...</code>, with <code>motion_trigger_source = c545d_wide</code>)</li>
</ul>
<p>A key discovery during debugging: <strong>both lenses on the C545D post motion events
to a single shared ONVIF PullPoint endpoint.</strong> This is not reported by ONVIF
device discovery and contradicts the assumption in the original
<code>motion_trigger_source</code> implementation (PR #336) that only the wide-angle lens
produces events.</p>
<hr>
<h2>Commit 1 — <code>fix(packet_buffer)</code>: Pre-buffer reset on stream reconnect</h2>
<h3>Observation</h3>
<p>After a stream reconnect, detection-triggered recordings had no pre-buffer
footage. The recording started at the moment of detection, not 10 seconds
earlier as configured.</p>
<h3>Root Cause</h3>
<p><code>packet_buffer_clear()</code> was called during reconnect state transitions, which
correctly discards stale packets — but the buffer was also being cleared when
go2rtc's ring-buffer replay ended and the stream went live. If a reconnect
happened shortly before a motion event, the pre-buffer had no time to refill.</p>
<h3>Fix</h3>
<p>Guard the clear call so the pre-buffer is only discarded when genuinely stale
(reconnect/error), not on normal live-stream transitions.</p>
<hr>
<h2>Commit 2 — <code>fix(go2rtc)</code>: False stuck-detection after stream startup</h2>
<h3>Observation</h3>
<p>Streams were being torn down and reconnected approximately 80–90 seconds after
startup, even when the stream was healthy. This was logged as a stuck-stream
detection event.</p>
<h3>Root Cause</h3>
<p>The stuck-detection timer started immediately on connection, before go2rtc had
finished its initial ring-buffer replay (~42 seconds at default settings). The
replay caused the packet arrival pattern to look like a stall.</p>
<h3>Fix</h3>
<p>Added a 120-second warmup guard (<code>tracking_start_time</code>) in <code>go2rtc_integration.c</code>.
Stuck-detection is suppressed for the first 120 seconds after connection,
covering the replay period with margin. Also enabled <code>log.output</code> in
<code>go2rtc_process.c</code> to make go2rtc errors visible in the lightNVR log.</p>
<hr>
<h2>Commit 3 — <code>feat(onvif)</code>: Dedicated ONVIF detection thread + storm fix + sticky-flag</h2>
<p>This commit addresses three related issues that all stem from the same
architectural problem: <code>detect_motion_onvif()</code> was called synchronously inside
<code>process_packet()</code> on the UDT main thread.</p>
<h3>Problem A: Blocking av_read_frame()</h3>
<h3>Observation</h3>
<p>go2rtc logged <code>write tcp [...]: i/o timeout</code> and disconnected the RTSP consumer
connection approximately every 2 minutes. MP4 recordings had PTS gaps and
corrupt segments.</p>
<h3>Root Cause</h3>
<p><code>detect_motion_onvif()</code> uses <code>CURLOPT_TIMEOUT=7s</code> and a <code>PT5S</code> PullMessages
timeout. When called on the UDT main thread, it blocked <code>av_read_frame()</code> for
up to 7 seconds per detection cycle. During this time go2rtc buffered outgoing
RTSP packets; when the block lifted, packets arrived as a burst causing PTS
discontinuities. After ~2 minutes of accumulated timeouts, go2rtc dropped the
consumer connection entirely.</p>
<h3>Fix</h3>
<p>Moved <code>detect_motion_onvif()</code> into a <strong>dedicated background thread per stream</strong>,
started and stopped with the UDT lifecycle. The thread writes its result into
<code>ctx-&gt;onvif_motion_detected</code> (atomic int). The UDT main loop reads this flag
non-blockingly — no CURL/SOAP call in <code>process_packet()</code> anymore.
<code>CURLOPT_TIMEOUT</code> restored to 10s (blocking is no longer a problem).
SOD and API detection paths are completely unaffected.</p>
<h3>Problem B: Motion event storm</h3>
<h3>Observation</h3>
<p>When motion was active, up to 20+ <code>detect_motion_onvif()</code> calls per second were
logged within a single timestamp. This caused a flood of <code>process_motion_event()</code>
calls, database writes, and MQTT publishes.</p>
<h3>Root Cause</h3>
<p>When the camera has queued motion events, <code>PullMessages</code> returns immediately
without waiting for the <code>PT5S</code> timeout. The ONVIF thread therefore busy-looped
with no delay between calls during active motion.</p>
<h3>Fix</h3>
<p>Added a 2-second minimum interval after a motion-positive <code>PullMessages</code> response,
implemented as 20 × 100ms sleeps to keep the thread responsive to stop requests.</p>
<h3>Problem C: Shared-subscription race condition (sticky-flag)</h3>
<h3>Observation</h3>
<p>With two ONVIF threads sharing one PullPoint subscription, one thread could
consume a motion event (setting <code>onvif_motion_detected=1</code>) and then immediately
consume an empty response (clearing <code>onvif_motion_detected=0</code>) — all within the
10-second UDT detection interval. The UDT then read <code>0</code> and did not start
recording. This caused one stream to start recording up to 38 seconds late.</p>
<h3>Root Cause</h3>
<p>Both ONVIF threads compete for the same PullPoint event queue. A "no motion"
response does not mean the scene is idle — the sibling thread may have consumed
the event moments earlier.</p>
<h3>Fix</h3>
<p>Added a 15-second sticky-flag: <code>onvif_motion_detected</code> is only cleared if no
motion has been confirmed for at least 15 seconds (<code>ONVIF_MOTION_HOLD_SECS</code>).
This guarantees the UDT sees <code>flag=1</code> on its next 10-second detection tick even
if the very next PullMessages response is empty. The value is intentionally
greater than the 10-second detection interval.</p>
<hr>
<h2>Commit 4 — <code>feat(onvif)</code>: Bidirectional cross-stream motion propagation</h2>
<h3>Background</h3>
<p>PR #336 introduced <code>motion_trigger_source</code> to support dual-lens cameras where
only the wide-angle lens exposes ONVIF events. The PTZ stream is configured with
<code>motion_trigger_source = c545d_wide</code>, causing wide's motion events to propagate
to PTZ.</p>
<p>This is <strong>unidirectional</strong>: wide → PTZ only.</p>
<h3>Observation</h3>
<p>With the new per-stream ONVIF threads (Commit 3), both threads compete for the
same PullPoint queue. When PTZ's thread wins and consumes the motion event first,
it calls <code>process_motion_event("c545d_ptz")</code> — but no stream has
<code>motion_trigger_source = c545d_ptz</code>, so <strong>nothing is propagated to wide</strong>. Wide's
thread then pulls an empty queue and never starts recording, or starts up to 38
seconds late.</p>
<h3>Root Cause</h3>
<p>The original implementation assumed only the wide-angle lens produces events.
In reality, on the C545D/TC47, <strong>both lenses post events to the same shared
PullPoint endpoint</strong>. Whichever thread consumes the event first must be able to
trigger the other stream regardless of which direction the
<code>motion_trigger_source</code> relationship is configured.</p>
<h3>Fix</h3>
<p>Extended <code>process_motion_event()</code> to propagate in <strong>both directions</strong>:</p>
<ul>
<li><strong>Forward</strong> (existing): notify streams that list <code>stream_name</code> as their
<code>motion_trigger_source</code></li>
<li><strong>Reverse</strong> (new): notify the stream that <code>stream_name</code> itself lists as its
<code>motion_trigger_source</code></li>
</ul>
<p>Loop prevention: added <code>is_propagated</code> (bool) to <code>motion_event_t</code>. Propagated
events have this flag set to <code>true</code>; <code>process_motion_event()</code> skips all
propagation for events that are already copies. This breaks the ping-pong after
one hop and is safe for any number of configured streams.</p>
<p><strong>Scope note:</strong> This design covers the 2-lens case. Cameras with 3+ lenses on a
shared endpoint would require a visited-list approach; this is considered an
edge case and is not addressed here.</p>
<p><strong>Compatibility:</strong></p>
<ul>
<li>Single-lens cameras: unaffected — propagation code only runs when
<code>motion_trigger_source</code> is configured</li>
<li>Dual-lens cameras where only one lens produces events (original PR #336
use-case): unaffected — forward propagation behaviour is unchanged</li>
<li>Dual-lens cameras where both lenses produce events (C545D/TC47): now works
correctly in both directions</li>
</ul>
<hr>
<h2>Testing</h2>
<p>Tested on <strong>Tapo C545D / TP-Link TC47</strong> with go2rtc proxy, Docker deployment,
over multiple days of continuous operation with repeated motion events.</p>
<p>Verified:</p>
<ul>
<li>Both streams start recording within 2 seconds of each other regardless of
which ONVIF thread consumes the event first</li>
<li>No go2rtc <code>write i/o timeout</code> disconnections</li>
<li>No false stuck-detection reconnects after startup</li>
<li>Pre-buffer present on all recordings including after reconnects</li>
<li>No motion event storms in the log</li>
<li>Single-lens ONVIF cameras: no behaviour change (verified by code analysis)</li>
</ul>
<hr>
<h2>Files Changed</h2>

File | Change
-- | --
src/video/packet_buffer.c | Pre-buffer clear guard
src/video/go2rtc/go2rtc_integration.c | 120s warmup guard for stuck-detection
src/video/go2rtc/go2rtc_process.c | Enable go2rtc log output
include/video/unified_detection_thread.h | Add ONVIF thread fields + atomic flags to context struct
src/video/unified_detection_thread.c | ONVIF background thread, storm fix, sticky-flag
include/video/onvif_motion_recording.h | Add is_propagated to motion_event_t
src/video/onvif_motion_recording.c | Bidirectional propagation with loop guard

</body></html>