### PR TITLE
fix(udt): declare audio stream before avformat_write_header()

### DIFF
--- a/include/video/mp4_writer.h
+++ b/include/video/mp4_writer.h
@@ -63,6 +63,18 @@ struct mp4_writer {
 
     // Shutdown coordination
     int shutdown_component_id; // ID assigned by the shutdown coordinator
+
+    // Pending audio codec parameters set by udt_start_recording() before the first
+    // packet arrives.  mp4_writer_initialize() consumes this to declare the audio
+    // stream BEFORE avformat_write_header() is called — the only legal window for
+    // adding streams to an MP4 container.  The params reflect the actual output
+    // codec: AAC (transcoded from PCM) or the original MP4-compatible codec
+    // (e.g. native AAC, MP3).  NULL after consumption or on error.
+    AVCodecParameters *pending_audio_codecpar;
+    // Time base of the input audio stream, stored alongside pending_audio_codecpar.
+    // Used by mp4_writer_initialize() instead of reconstructing from sample_rate,
+    // which may be 0 for some pass-through codecs.
+    AVRational pending_audio_time_base;
 };
 
 /**

--- a/src/video/mp4_writer_core.c
+++ b/src/video/mp4_writer_core.c
@@ -75,6 +75,8 @@ mp4_writer_t *mp4_writer_create(const char *output_path, const char *stream_name
     writer->waiting_for_keyframe = 0;
     writer->is_rotating = 0;       // Initialize rotation flag
     writer->shutdown_component_id = -1; // Initialize to -1 to indicate not registered
+    writer->pending_audio_codecpar = NULL; // Populated by udt_start_recording(), consumed by mp4_writer_initialize()
+    writer->pending_audio_time_base = (AVRational){0, 1}; // Set alongside pending_audio_codecpar
 
     // Extract output directory from output path
     safe_strcpy(writer->output_dir, output_path, sizeof(writer->output_dir), 0);
@@ -273,6 +275,11 @@ void mp4_writer_close(mp4_writer_t *writer) {
     }
 
     cleanup_audio_transcoder(writer->stream_name);
+
+    if (writer->pending_audio_codecpar) {
+        avcodec_parameters_free(&writer->pending_audio_codecpar);
+        writer->pending_audio_codecpar = NULL;
+    }
 
     free(writer);
 

--- a/src/video/mp4_writer_utils.c
+++ b/src/video/mp4_writer_utils.c
@@ -1103,10 +1103,62 @@ int mp4_writer_initialize(mp4_writer_t *writer, const AVPacket *pkt, const AVStr
         // Store video stream index
         writer->video_stream_idx = 0;  // First stream is video
 
-        // We don't add an audio stream here - we'll add it when we find an audio stream in the input
-        // This exactly matches rtsp_recorder.c behavior
-        log_info("Video stream initialized for %s. Audio stream will be added when detected.",
-                writer->stream_name ? writer->stream_name : "unknown");
+        // Declare the audio stream NOW, before avformat_write_header().
+        // For MP4 containers all streams must be registered before the header is
+        // written — adding a stream afterwards is illegal and silently produces
+        // video-only files even if the transcoder later initialises successfully.
+        // pending_audio_codecpar is populated by udt_start_recording() via the
+        // stateless transcode_pcm_to_aac(); it is NULL for non-UDT paths (e.g.
+        // record_segment) which handle audio registration themselves.
+        if (writer->has_audio && writer->pending_audio_codecpar) {
+            AVStream *a_stream = avformat_new_stream(writer->output_ctx, NULL);
+            if (a_stream) {
+                int aret = avcodec_parameters_copy(a_stream->codecpar,
+                                                   writer->pending_audio_codecpar);
+                if (aret < 0) {
+                    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+                    av_strerror(aret, errbuf, AV_ERROR_MAX_STRING_SIZE);
+                    log_error("Failed to copy pending audio codec params for %s: %s",
+                              writer->stream_name ? writer->stream_name : "unknown", errbuf);
+                    // The newly created stream is partially configured — leaving it in
+                    // output_ctx would produce an invalid stream table and cause
+                    // avformat_write_header() to fail with an opaque error.
+                    // Treat this as a hard init failure and clean up entirely.
+                    avcodec_parameters_free(&writer->pending_audio_codecpar);
+                    writer->pending_audio_codecpar = NULL;
+                    avformat_free_context(writer->output_ctx);
+                    writer->output_ctx = NULL;
+                    free(dir_path);
+                    return -1;
+                } else {
+                    a_stream->codecpar->codec_tag = 0;
+                    // Use the stored input time_base directly. Reconstructing from
+                    // sample_rate is unsafe: it can be 0 for some pass-through codecs,
+                    // producing an invalid {1,0} time base. Fall back only when needed.
+                    if (writer->pending_audio_time_base.den > 0) {
+                        a_stream->time_base = writer->pending_audio_time_base;
+                    } else if (writer->pending_audio_codecpar->sample_rate > 0) {
+                        a_stream->time_base = (AVRational){1, writer->pending_audio_codecpar->sample_rate};
+                    } else {
+                        a_stream->time_base = (AVRational){1, 48000}; // safe default
+                    }
+                    writer->audio.stream_idx = a_stream->index;
+                    writer->audio.time_base  = a_stream->time_base;
+                    log_info("Audio stream (AAC) declared at index %d before header write for %s",
+                             writer->audio.stream_idx,
+                             writer->stream_name ? writer->stream_name : "unknown");
+                }
+            } else {
+                log_error("Failed to create audio stream for %s — recording video-only",
+                          writer->stream_name ? writer->stream_name : "unknown");
+                writer->has_audio = 0;
+            }
+            avcodec_parameters_free(&writer->pending_audio_codecpar);
+            writer->pending_audio_codecpar = NULL;
+        } else {
+            log_info("Video stream initialized for %s. No pending audio codec params (non-UDT path or audio disabled).",
+                    writer->stream_name ? writer->stream_name : "unknown");
+        }
     }
     else if (input_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
         // Check if the audio codec is compatible with MP4 format

--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -1900,6 +1900,60 @@ static int udt_start_recording(unified_detection_ctx_t *ctx) {
     if (ctx->record_audio && ctx->audio_stream_idx >= 0) {
         mp4_writer_set_audio(ctx->mp4_writer, 1);
         log_info("[%s] Audio recording enabled for detection recording", ctx->stream_name);
+
+        // Eagerly determine the output codec parameters so mp4_writer_initialize()
+        // can declare the audio stream BEFORE avformat_write_header() — the only
+        // legal window for adding streams to an MP4 container.
+        //
+        // The pending params must exactly match what mp4_writer_write_packet() will
+        // later mux:
+        //   * PCM variants  -> transcode to AAC  (mp4_writer_write_packet transcodes)
+        //   * MP4-compatible -> deep-copy as-is  (packets pass through unchanged)
+        //   * anything else -> disable audio     (not supported)
+        AVStream *ain = ctx->input_ctx->streams[ctx->audio_stream_idx];
+        const char *codec_name = "unknown";
+        AVCodecParameters *pending = NULL;
+
+        if (is_pcm_codec(ain->codecpar->codec_id)) {
+            // PCM: probe transcode_pcm_to_aac() for the AAC output parameters.
+            // Stateless call — no global audio_transcoders[] access, does not
+            // interfere with the lazy init_audio_transcoder() during packet processing.
+            if (transcode_pcm_to_aac(ain->codecpar, &ain->time_base,
+                                     ctx->stream_name, &pending) < 0 || !pending) {
+                log_warn("[%s] Failed to prepare AAC codec params — disabling audio for this recording",
+                         ctx->stream_name);
+                mp4_writer_set_audio(ctx->mp4_writer, 0);
+            } else {
+                log_info("[%s] PCM->AAC codec params prepared for MP4 header (eager init)",
+                         ctx->stream_name);
+            }
+        } else if (is_audio_codec_compatible_with_mp4(ain->codecpar->codec_id, &codec_name)) {
+            // Already MP4-compatible (AAC, MP3, AC3, Opus): deep-copy codec params.
+            // Packets will be muxed as-is by mp4_writer_write_packet().
+            pending = avcodec_parameters_alloc();
+            if (!pending || avcodec_parameters_copy(pending, ain->codecpar) < 0) {
+                log_warn("[%s] Failed to copy %s codec params — disabling audio for this recording",
+                         ctx->stream_name, codec_name);
+                if (pending) { avcodec_parameters_free(&pending); pending = NULL; }
+                mp4_writer_set_audio(ctx->mp4_writer, 0);
+            } else {
+                log_info("[%s] %s codec params prepared for MP4 header (eager init)",
+                         ctx->stream_name, codec_name);
+            }
+        } else {
+            // Incompatible and not PCM: cannot mux or transcode.
+            is_audio_codec_compatible_with_mp4(ain->codecpar->codec_id, &codec_name);
+            log_warn("[%s] Audio codec %s is not MP4-compatible and not PCM — disabling audio for this recording",
+                     ctx->stream_name, codec_name);
+            mp4_writer_set_audio(ctx->mp4_writer, 0);
+        }
+
+        if (pending) {
+            ctx->mp4_writer->pending_audio_codecpar = pending;
+            // Store the original input time_base so mp4_writer_initialize() does
+            // not have to reconstruct it from sample_rate (which may be 0).
+            ctx->mp4_writer->pending_audio_time_base = ain->time_base;
+        }
     } else {
         mp4_writer_set_audio(ctx->mp4_writer, 0);
         if (ctx->record_audio && ctx->audio_stream_idx < 0) {


### PR DESCRIPTION


Fixes #352 — Detection-triggered MP4 recordings contain no audio track despite audio being enabled and the transcoder initialising successfully.

---

## Problem

When ONVIF motion detection triggers a recording via the Unified Detection Thread (UDT), the resulting MP4 file contains only a video track. The log shows the audio transcoder initialising correctly, which makes the root cause non-obvious:

```
[Detection] [c545d_wide] Audio recording enabled for detection recording
[Detection] [c545d_wide] Successfully initialized audio transcoder from PCM to AAC
[Detection] [c545d_wide] Sample rate: 8000, Channels: 1, Bit rate: 32000
```

`ffprobe` on the output file confirms the issue:

```
1 streams: ['video']   ← audio missing
```

---

## Root cause

The MP4 container format requires all streams to be declared **before** `avformat_write_header()` is called. Once the header is written the stream table is sealed — any stream added afterwards is ignored by the muxer.

The UDT recording path violated this constraint through a lazy-init design:

```
udt_start_recording()
    mp4_writer_create()          ← writer allocated
    mp4_writer_set_audio(1)      ← has_audio = 1, stream_idx = -1

flush_prebuffer_to_recording()
    flush_packet_callback()
        first video keyframe →  mp4_writer_initialize()
                                    avformat_new_stream()  [video]
                                    avformat_write_header() ← HEADER SEALED (video only)

        first audio packet  →   transcode_audio_packet()  ← transcoder init OK
                                    stream_idx == -1
                                    → packet silently dropped ✗
```

Every subsequent audio packet — from the pre-buffer flush, live recording, and post-buffer — is transcoded correctly but then discarded because `writer->audio.stream_idx` is still `-1`.

This affects only the UDT path (`mp4_writer_initialize`). The scheduled recording path (`record_segment`) already handles audio registration correctly before writing the header and is unaffected.

---

## Solution

Declare the audio stream eagerly — **before** `avformat_write_header()` — by splitting the work into two steps:

**Step 1 — `udt_start_recording()`**: call the stateless `transcode_pcm_to_aac()` immediately after the writer is created to obtain the AAC `AVCodecParameters` (including the MPEG-4 Audio Specific Config / `extradata`). Store the result in a new `pending_audio_codecpar` field on the writer.

**Step 2 — `mp4_writer_initialize()`**: in the video-keyframe branch, check for `pending_audio_codecpar` and register the audio stream via `avformat_new_stream()` before `avio_open` / `avformat_write_header()` are called. Consume and free the pending params immediately after.

```
udt_start_recording()
    mp4_writer_create()
    mp4_writer_set_audio(1)
    transcode_pcm_to_aac()       ← stateless, no side-effects
        → pending_audio_codecpar = AAC params + extradata

flush_prebuffer_to_recording()
    flush_packet_callback()
        first video keyframe →  mp4_writer_initialize()
                                    avformat_new_stream()  [video]
                                    avformat_new_stream()  [audio AAC]  ← NEW
                                    avformat_write_header() ← both streams sealed ✓

        first audio packet  →   transcode_audio_packet()
                                    stream_idx == 1
                                    → av_interleaved_write_frame() ✓
```

`transcode_pcm_to_aac()` is fully stateless (local alloc/free, no global `audio_transcoders[]` access), so calling it here does not interfere with the lazy `init_audio_transcoder()` that runs during packet processing.

---

## Changes

| File | Change |
|---|---|
| `include/video/mp4_writer.h` | Add `AVCodecParameters *pending_audio_codecpar` to `struct mp4_writer` |
| `src/video/mp4_writer_core.c` | Initialise field to `NULL` in `mp4_writer_create()`; free in `mp4_writer_close()` |
| `src/video/unified_detection_thread.c` | Call `transcode_pcm_to_aac()` eagerly in `udt_start_recording()` |
| `src/video/mp4_writer_utils.c` | Register audio stream from `pending_audio_codecpar` before `avformat_write_header()` in `mp4_writer_initialize()` |

No changes to `record_segment`, `mp4_writer_thread`, `mp4_recording_core`, or any other recording path.

---

## Testing

Hardware: Tapo C545D Dual-Lens, go2rtc RTSP proxy, Docker.

```
ffprobe -v quiet -print_format json -show_streams <detection.mp4> | \
  python3 -c "import sys,json; s=json.load(sys.stdin)['streams']; \
  print(f\"{len(s)} streams: {[x['codec_type'] for x in s]}\")"
```

**Before:** `1 streams: ['video']`  
**After:** `2 streams: ['video', 'audio']`

New log entries confirm correct sequencing:

```
[Detection] [c545d_wide] AAC codec params prepared for MP4 header (eager init)
[Detection] [c545d_wide] Audio stream (AAC) declared at index 1 before header write for c545d_wide
```