### PR TITLE
fix(build): add go2rtc_disabled stubs for PR #398 override APIs

### DIFF
--- a/src/video/go2rtc/go2rtc_disabled.c
+++ b/src/video/go2rtc/go2rtc_disabled.c
@@ -54,6 +54,24 @@ void go2rtc_process_cleanup(void) {}
 int go2rtc_process_get_rtsp_port(void) { return 0; }
 int go2rtc_process_get_pid(void) { return -1; }
 
+/* Stubs for the override-pipeline APIs added in PR #398.  When go2rtc is
+ * disabled at build time the override file is meaningless, so these are
+ * trivial no-ops that match the success-side return contracts. */
+int go2rtc_process_generate_override_file(const char *override_path) {
+    UNUSED(override_path); return 0;
+}
+const char *go2rtc_process_get_override_path(void) { return NULL; }
+const char *go2rtc_process_get_config_path(void)   { return NULL; }
+void go2rtc_process_clear_override_quarantine(void) {}
+void go2rtc_process_validate_existing_override_on_upgrade(void) {}
+int go2rtc_process_probe_version(const char *path,
+                                 char *version_out,
+                                 size_t version_out_sz) {
+    UNUSED(path);
+    if (version_out && version_out_sz > 0) version_out[0] = '\0';
+    return 0;
+}
+
 bool go2rtc_stream_init(const char *binary_path, const char *config_dir, int api_port) {
     UNUSED(binary_path); UNUSED(config_dir); UNUSED(api_port); return false;
 }


### PR DESCRIPTION
## Summary

Fixes the Sanitizer Build and CodeQL CI failures on \`main\` (sha 3297b745, the merge of #398).

PR #398 added six new public functions to \`include/video/go2rtc/go2rtc_process.h\` but only implemented them in \`go2rtc_process.c\`, which is excluded from the build when \`ENABLE_GO2RTC=OFF\`. The Sanitizer Build and CodeQL jobs both build with go2rtc disabled and so failed at link time:

\`\`\`
undefined reference to \`go2rtc_process_clear_override_quarantine'
undefined reference to \`go2rtc_process_get_config_path'
undefined reference to \`go2rtc_process_get_override_path'
\`\`\`

## Fix

Adds trivial stubs to \`src/video/go2rtc/go2rtc_disabled.c\` for all six new APIs:

| API | Stub returns |
| --- | --- |
| \`go2rtc_process_generate_override_file\` | 0 (success — no override is meaningful when go2rtc is disabled) |
| \`go2rtc_process_get_override_path\` | NULL |
| \`go2rtc_process_get_config_path\` | NULL |
| \`go2rtc_process_clear_override_quarantine\` | void no-op |
| \`go2rtc_process_validate_existing_override_on_upgrade\` | void no-op |
| \`go2rtc_process_probe_version\` | 0 (rejected), zeroes \`version_out\` |

## Verification

Reproduced the failure locally with the same cmake flags CI uses:

\`\`\`
mkdir build-nogortc && cd build-nogortc
cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=OFF \\
         -DENABLE_SOD=OFF -DENABLE_GO2RTC=OFF -DENABLE_MQTT=OFF
make lightnvr   # → [100%] Built target lightnvr
\`\`\`

## Test plan
- [ ] CI: Sanitizer Build green
- [ ] CI: CodeQL green
- [ ] CI: Integration Tests still green (this is an additive change that doesn't touch the go2rtc-enabled build path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)