### PR TITLE
feat(api): POST /api/motion/trigger for external motion events (#375)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -49,17 +49,21 @@ Also supported as a fallback for tools that only understand basic auth.
 
 ### Roles
 
-Role-based access is enforced per-endpoint:
+Role-based access is enforced per-endpoint. The table below is a high-level
+summary of the intended access model:
 
 | Role     | Can read | Can write | Can administer |
 |----------|:--------:|:---------:|:--------------:|
 | `ADMIN`  | yes      | yes       | yes            |
 | `USER`   | yes      | yes       | no             |
 | `API`    | yes      | yes       | no             |
-| `VIEWER` | yes      | no        | no             |
+| `VIEWER` | yes      | typically no | no          |
 
-Write endpoints (including [`POST /api/motion/trigger`](#trigger-motion-event))
-reject `VIEWER` with 403.
+Write authorization is endpoint-specific. Some write endpoints (including
+[`POST /api/motion/trigger`](#trigger-motion-event)) may reject `VIEWER` with
+`403`, but callers should rely on each endpoint's documented or implemented
+access checks rather than assuming all write endpoints enforce the same role
+restriction.
 
 ## API Endpoints
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,17 +8,57 @@ LightNVR provides a RESTful API that allows you to interact with the system prog
 
 ## Authentication
 
-If authentication is enabled in the configuration file, API requests must include a valid session token. Obtain a session by calling the login endpoint, then include the session cookie in subsequent requests.
+If authentication is enabled in the configuration file, API requests must
+authenticate using one of three mechanisms. All three resolve to the same
+`user_t` and the same role-based access checks, so pick whichever fits the
+caller.
+
+### 1. Session cookie (interactive UI, scripts that log in once)
+
+Obtain a session by calling the login endpoint, then include the session
+cookie on subsequent requests.
 
 ```bash
-# Login to get a session
 curl -c cookies.txt -X POST -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"yourpassword"}' \
   http://your-lightnvr-ip:8080/api/auth/login
 
-# Use session cookie for subsequent requests
 curl -b cookies.txt http://your-lightnvr-ip:8080/api/streams
 ```
+
+### 2. API key (automation, long-lived integrations)
+
+Every user has an `api_key` field. Pass it via either header:
+
+```bash
+# Preferred
+curl -H "X-API-Key: <your-api-key>" http://your-lightnvr-ip:8080/api/streams
+
+# Also accepted
+curl -H "Authorization: Bearer <your-api-key>" http://your-lightnvr-ip:8080/api/streams
+```
+
+For automation (Home Assistant, NodeRED, cron jobs, etc.), create a dedicated
+user with the `USER_ROLE_API` role and use that user's `api_key`. Keep admin
+keys out of automation configs.
+
+### 3. HTTP Basic Auth
+
+Also supported as a fallback for tools that only understand basic auth.
+
+### Roles
+
+Role-based access is enforced per-endpoint:
+
+| Role     | Can read | Can write | Can administer |
+|----------|:--------:|:---------:|:--------------:|
+| `ADMIN`  | yes      | yes       | yes            |
+| `USER`   | yes      | yes       | no             |
+| `API`    | yes      | yes       | no             |
+| `VIEWER` | yes      | no        | no             |
+
+Write endpoints (including [`POST /api/motion/trigger`](#trigger-motion-event))
+reject `VIEWER` with 403.
 
 ## API Endpoints
 
@@ -249,6 +289,97 @@ PUT /api/streams/{name}/ptz/preset
 ```
 
 Creates or updates a PTZ preset.
+
+### Motion
+
+#### Trigger Motion Event
+
+```
+POST /api/motion/trigger
+```
+
+Drives the same motion-recording path that ONVIF events normally drive. Useful
+for cameras whose ONVIF event stream is unreliable or missing — the caller
+(Home Assistant, NodeRED, a shell script, a PIR sensor bridge) can post a
+motion event and the target stream's detection-based recording pipeline
+(pre-buffer → recording → post-buffer) handles the rest.
+
+The target stream must have `detection_based_recording` enabled; otherwise the
+unified detection thread is not running and there is nothing for the trigger
+to drive (409 Conflict).
+
+**Authentication:** See [Authentication](#authentication). For automation use
+a dedicated `USER_ROLE_API` user and its `api_key`; `USER_ROLE_VIEWER` is
+rejected with 403.
+
+**Request body:**
+
+| Field         | Type    | Required | Notes                                                   |
+|---------------|---------|----------|---------------------------------------------------------|
+| `stream`      | string  | yes      | Stream name, as shown in the streams list.              |
+| `action`      | string  | yes      | One of `start`, `stop`, `pulse`.                        |
+| `duration_ms` | integer | no       | Only valid with `pulse`. Default 2000, max 600000 (10m).|
+
+**Actions:**
+
+- `start` — motion began. Equivalent to an ONVIF motion-start event. Recording
+  begins (after the pre-buffer window) and continues until a corresponding
+  `stop` arrives, at which point the UDT transitions into the post-buffer
+  hold and then closes the recording.
+- `stop` — motion ended. Mirror of `start`.
+- `pulse` — convenience: fires `start`, waits `duration_ms`, then fires `stop`.
+  One request produces one complete motion event. Ideal for motion sensors that
+  only report a single edge (e.g. a Home Assistant automation that fires when a
+  PIR sensor goes active but does not send a separate "cleared" webhook).
+
+**Response:** `202 Accepted`
+
+```json
+{
+  "success": true,
+  "stream": "Front Door",
+  "action": "pulse",
+  "duration_ms": 5000
+}
+```
+
+**Errors:**
+
+- `400` — missing/invalid JSON, missing `stream`/`action`, bad `duration_ms`.
+- `401` — auth enabled and caller is not authenticated.
+- `403` — caller is `USER_ROLE_VIEWER`.
+- `404` — `stream` does not match a configured stream.
+- `409` — stream does not have `detection_based_recording` enabled.
+
+**Examples:**
+
+Start/stop (matches how an ONVIF sensor would report):
+```bash
+curl -X POST http://lightnvr:8080/api/motion/trigger \
+  -H "X-API-Key: <key>" -H "Content-Type: application/json" \
+  -d '{"stream":"Front Door","action":"start"}'
+
+# ...later, when motion clears:
+curl -X POST http://lightnvr:8080/api/motion/trigger \
+  -H "X-API-Key: <key>" -H "Content-Type: application/json" \
+  -d '{"stream":"Front Door","action":"stop"}'
+```
+
+One-shot pulse (Home Assistant rest_command with a PIR sensor):
+```yaml
+rest_command:
+  lightnvr_motion:
+    url: "http://lightnvr:8080/api/motion/trigger"
+    method: POST
+    headers:
+      X-API-Key: !secret lightnvr_api_key
+    content_type: "application/json"
+    payload: '{"stream":"{{ stream }}","action":"pulse","duration_ms":{{ duration | default(5000) }}}'
+```
+
+Cross-stream linking (`motion_trigger_source` in stream config) is honoured:
+an API-driven motion event on one stream will also drive recording on any
+stream that lists it as a trigger source, same as an ONVIF-driven event.
 
 ### Recordings
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,9 +8,10 @@ LightNVR provides a RESTful API that allows you to interact with the system prog
 
 ## Authentication
 
-If authentication is enabled in the configuration file, API requests must
-authenticate using one of three mechanisms. All three resolve to the same
-`user_t` and the same role-based access checks, so pick whichever fits the
+If authentication is enabled in the configuration file, endpoints that require
+authentication accept one of three mechanisms. Authentication and role-based
+access checks are enforced per-endpoint. Where authentication is required, all
+three mechanisms resolve to the same `user_t`, so pick whichever fits the
 caller.
 
 ### 1. Session cookie (interactive UI, scripts that log in once)

--- a/include/web/api_handlers_motion.h
+++ b/include/web/api_handlers_motion.h
@@ -1,0 +1,29 @@
+#ifndef LIGHTNVR_API_HANDLERS_MOTION_H
+#define LIGHTNVR_API_HANDLERS_MOTION_H
+
+#include "web/request_response.h"
+
+/**
+ * POST /api/motion/trigger
+ *
+ * External motion trigger endpoint. Lets an authenticated client (Home
+ * Assistant, NodeRED, a shell script, etc.) drive the same motion-recording
+ * path that ONVIF events normally drive. Intended for cameras whose native
+ * ONVIF event stream is broken or missing.
+ *
+ * Request body (application/json):
+ *   {
+ *     "stream":      "<stream name>",          // required
+ *     "action":      "start"|"stop"|"pulse",   // required
+ *     "duration_ms": <int>                      // pulse only, optional; default 2000, max 600000
+ *   }
+ *
+ * Auth: requires an authenticated user (X-API-Key, Authorization: Bearer, or
+ * session cookie). Role must be ADMIN, USER, or API; VIEWER is rejected.
+ *
+ * Target stream must have detection_based_recording enabled — otherwise the
+ * unified detection thread is not running and the trigger has nothing to drive.
+ */
+void handle_post_motion_trigger(const http_request_t *req, http_response_t *res);
+
+#endif /* LIGHTNVR_API_HANDLERS_MOTION_H */

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -21,6 +21,7 @@
 #include <time.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include <cjson/cJSON.h>
 
@@ -47,12 +48,62 @@ typedef enum {
     MOTION_ACTION_PULSE
 } motion_action_t;
 
+/*
+ * Per-stream pulse generation counters.
+ *
+ * Every motion trigger action (start, stop, or pulse) increments the counter
+ * for the target stream.  A pulse worker records the counter value at the
+ * moment it is created and checks it again before emitting the deferred
+ * motion-stop.  If a newer action has arrived in the meantime the counter
+ * will have changed, and the worker silently discards the stop so it cannot
+ * cut short an active recording.
+ */
 typedef struct {
-    char stream_name[MAX_STREAM_NAME];
-    int  duration_ms;
+    char     name[MAX_STREAM_NAME];
+    uint64_t generation;
+} pulse_gen_entry_t;
+
+static pulse_gen_entry_t g_pulse_gen[MAX_STREAMS];
+static int               g_pulse_gen_count = 0;
+static pthread_mutex_t   g_pulse_gen_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Return the current generation for stream_name (0 if not seen before). */
+static uint64_t pulse_gen_get(const char *stream_name) {
+    for (int i = 0; i < g_pulse_gen_count; i++) {
+        if (strcmp(g_pulse_gen[i].name, stream_name) == 0)
+            return g_pulse_gen[i].generation;
+    }
+    return 0;
+}
+
+/* Increment the generation counter for stream_name and return the new value.
+ * Must be called with g_pulse_gen_mutex held. */
+static uint64_t pulse_gen_increment(const char *stream_name) {
+    for (int i = 0; i < g_pulse_gen_count; i++) {
+        if (strcmp(g_pulse_gen[i].name, stream_name) == 0)
+            return ++g_pulse_gen[i].generation;
+    }
+    /* First time we see this stream — add an entry. */
+    if (g_pulse_gen_count < MAX_STREAMS) {
+        int i = g_pulse_gen_count++;
+        safe_strcpy(g_pulse_gen[i].name, stream_name,
+                    sizeof(g_pulse_gen[i].name), 0);
+        g_pulse_gen[i].generation = 1;
+        return 1;
+    }
+    /* Table full (shouldn't happen in practice); return a non-zero sentinel. */
+    log_warn("pulse_gen table full; generation tracking disabled for '%s'", stream_name);
+    return 1;
+}
+
+typedef struct {
+    char     stream_name[MAX_STREAM_NAME];
+    int      duration_ms;
+    uint64_t generation; /* generation at the time the pulse was scheduled */
 } motion_pulse_task_t;
 
-/* Fire motion-start, sleep for duration_ms, fire motion-stop. Runs in a
+/* Fire motion-start, sleep for duration_ms, fire motion-stop — but only if no
+ * newer motion trigger has arrived since the pulse was scheduled.  Runs in a
  * detached worker thread because the HTTP handler must return immediately.
  * Matches the deferred-work idiom already used in api_handlers_streams_modify.c. */
 static void *motion_pulse_worker(void *arg) {
@@ -67,11 +118,23 @@ static void *motion_pulse_worker(void *arg) {
         usec -= chunk;
     }
 
-    time_t now = time(NULL);
-    unified_detection_notify_motion(task->stream_name, false);
-    process_motion_event(task->stream_name, false, now, false);
+    /* Check whether a newer action has superseded this pulse. */
+    pthread_mutex_lock(&g_pulse_gen_mutex);
+    uint64_t current_gen = pulse_gen_get(task->stream_name);
+    bool still_current = (current_gen == task->generation);
+    pthread_mutex_unlock(&g_pulse_gen_mutex);
 
-    log_info("Pulse ended for stream '%s' after %d ms", task->stream_name, task->duration_ms);
+    if (still_current) {
+        time_t now = time(NULL);
+        unified_detection_notify_motion(task->stream_name, false);
+        process_motion_event(task->stream_name, false, now, false);
+        log_info("Pulse ended for stream '%s' after %d ms",
+                 task->stream_name, task->duration_ms);
+    } else {
+        log_info("Pulse for stream '%s' superseded by newer trigger; stop skipped",
+                 task->stream_name);
+    }
+
     free(task);
     return NULL;
 }
@@ -196,6 +259,13 @@ void handle_post_motion_trigger(const http_request_t *req, http_response_t *res)
     time_t now = time(NULL);
     bool active = (action != MOTION_ACTION_STOP);
 
+    /* Increment the per-stream generation counter before dispatching.  This
+     * invalidates any in-flight pulse worker for this stream so it will not
+     * emit a spurious stop that could cut short the new motion activity. */
+    pthread_mutex_lock(&g_pulse_gen_mutex);
+    uint64_t new_gen = pulse_gen_increment(stream_name);
+    pthread_mutex_unlock(&g_pulse_gen_mutex);
+
     unified_detection_notify_motion(stream_name, active);
     process_motion_event(stream_name, active, now, false);
 
@@ -215,6 +285,7 @@ void handle_post_motion_trigger(const http_request_t *req, http_response_t *res)
         }
         safe_strcpy(task->stream_name, stream_name, sizeof(task->stream_name), 0);
         task->duration_ms = duration_ms;
+        task->generation  = new_gen;
 
         pthread_t tid;
         pthread_attr_t attr;

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -7,7 +7,8 @@
  * ONVIF events normally drive. See discussion #375 for motivation.
  *
  * The endpoint:
- *   - authenticates the caller via X-API-Key / Bearer token / session cookie
+ *   - authenticates the caller via httpd_get_authenticated_user() (for example:
+ *     X-API-Key, Bearer token, session cookie, or HTTP Basic auth)
  *   - rejects USER_ROLE_VIEWER
  *   - validates the target stream exists and has detection-based recording on
  *   - sets the UDT external_motion_trigger atomic for the target stream

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -146,11 +146,20 @@ void handle_post_motion_trigger(const http_request_t *req, http_response_t *res)
                 "Field 'duration_ms' must be a positive integer");
             return;
         }
-        int d = (int)j_duration->valuedouble;
-        if (d <= 0 || d > MOTION_PULSE_MAX_MS) {
+
+        double duration_value = j_duration->valuedouble;
+        if (duration_value <= 0 || duration_value > MOTION_PULSE_MAX_MS) {
             cJSON_Delete(body);
             http_response_set_json_error(res, 400,
                 "Field 'duration_ms' must be between 1 and 600000");
+            return;
+        }
+
+        int d = (int)duration_value;
+        if ((double)d != duration_value) {
+            cJSON_Delete(body);
+            http_response_set_json_error(res, 400,
+                "Field 'duration_ms' must be a positive integer");
             return;
         }
         duration_ms = d;

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -1,0 +1,251 @@
+/**
+ * @file api_handlers_motion.c
+ * @brief External motion trigger REST endpoint.
+ *
+ * Exposes POST /api/motion/trigger so external automation (Home Assistant,
+ * NodeRED, shell scripts) can drive the same motion-recording path that
+ * ONVIF events normally drive. See discussion #375 for motivation.
+ *
+ * The endpoint:
+ *   - authenticates the caller via X-API-Key / Bearer token / session cookie
+ *   - rejects USER_ROLE_VIEWER
+ *   - validates the target stream exists and has detection-based recording on
+ *   - sets the UDT external_motion_trigger atomic for the target stream
+ *   - propagates the event to any cross-stream-linked peers
+ *   - for "pulse", schedules a deferred motion-ended via a detached worker
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include <cjson/cJSON.h>
+
+#define LOG_COMPONENT "MotionAPI"
+#include "core/logger.h"
+#include "core/config.h"
+#include "utils/strings.h"
+
+#include "web/api_handlers_motion.h"
+#include "web/request_response.h"
+#include "web/httpd_utils.h"
+
+#include "database/db_auth.h"
+#include "video/stream_manager.h"
+#include "video/cross_stream_motion_trigger.h"
+#include "video/unified_detection_thread.h"
+
+#define MOTION_PULSE_DEFAULT_MS 2000
+#define MOTION_PULSE_MAX_MS     600000   /* 10 minutes; matches UDT sanity bound */
+
+typedef enum {
+    MOTION_ACTION_START,
+    MOTION_ACTION_STOP,
+    MOTION_ACTION_PULSE
+} motion_action_t;
+
+typedef struct {
+    char stream_name[MAX_STREAM_NAME];
+    int  duration_ms;
+} motion_pulse_task_t;
+
+/* Fire motion-start, sleep for duration_ms, fire motion-stop. Runs in a
+ * detached worker thread because the HTTP handler must return immediately.
+ * Matches the deferred-work idiom already used in api_handlers_streams_modify.c. */
+static void *motion_pulse_worker(void *arg) {
+    motion_pulse_task_t *task = (motion_pulse_task_t *)arg;
+    if (!task) return NULL;
+
+    useconds_t usec = (useconds_t)task->duration_ms * 1000u;
+    /* usleep is limited to <1s on some platforms; loop in 500ms chunks. */
+    while (usec > 0) {
+        useconds_t chunk = usec > 500000u ? 500000u : usec;
+        usleep(chunk);
+        usec -= chunk;
+    }
+
+    time_t now = time(NULL);
+    unified_detection_notify_motion(task->stream_name, false);
+    process_motion_event(task->stream_name, false, now, false);
+
+    log_info("Pulse ended for stream '%s' after %d ms", task->stream_name, task->duration_ms);
+    free(task);
+    return NULL;
+}
+
+static int parse_action(const char *s, motion_action_t *out) {
+    if (!s || !out) return -1;
+    if (strcmp(s, "start") == 0) { *out = MOTION_ACTION_START; return 0; }
+    if (strcmp(s, "stop")  == 0) { *out = MOTION_ACTION_STOP;  return 0; }
+    if (strcmp(s, "pulse") == 0) { *out = MOTION_ACTION_PULSE; return 0; }
+    return -1;
+}
+
+void handle_post_motion_trigger(const http_request_t *req, http_response_t *res) {
+    log_info("POST /api/motion/trigger");
+
+    /* ---- Auth ------------------------------------------------------------ */
+    /* The setup-wizard endpoints are deliberately unauthenticated; everything
+     * else in this codebase either respects g_config.web_auth_enabled or is
+     * admin-only. External motion trigger is a write operation from
+     * (potentially) the public network, so require auth unconditionally when
+     * it is globally enabled, and reject read-only viewers. */
+    user_t user;
+    memset(&user, 0, sizeof(user));
+    if (g_config.web_auth_enabled) {
+        if (!httpd_get_authenticated_user(req, &user)) {
+            http_response_set_json_error(res, 401, "Unauthorized");
+            return;
+        }
+        if (user.role == USER_ROLE_VIEWER) {
+            http_response_set_json_error(res, 403,
+                "Viewer role cannot trigger motion events");
+            return;
+        }
+    }
+
+    /* ---- Body parsing ---------------------------------------------------- */
+    cJSON *body = httpd_parse_json_body(req);
+    if (!body) {
+        http_response_set_json_error(res, 400, "Invalid or missing JSON body");
+        return;
+    }
+
+    const cJSON *j_stream   = cJSON_GetObjectItemCaseSensitive(body, "stream");
+    const cJSON *j_action   = cJSON_GetObjectItemCaseSensitive(body, "action");
+    const cJSON *j_duration = cJSON_GetObjectItemCaseSensitive(body, "duration_ms");
+
+    if (!cJSON_IsString(j_stream) || j_stream->valuestring[0] == '\0') {
+        cJSON_Delete(body);
+        http_response_set_json_error(res, 400, "Field 'stream' is required");
+        return;
+    }
+    if (!cJSON_IsString(j_action)) {
+        cJSON_Delete(body);
+        http_response_set_json_error(res, 400,
+            "Field 'action' is required (start|stop|pulse)");
+        return;
+    }
+
+    motion_action_t action;
+    if (parse_action(j_action->valuestring, &action) != 0) {
+        cJSON_Delete(body);
+        http_response_set_json_error(res, 400,
+            "Field 'action' must be one of: start, stop, pulse");
+        return;
+    }
+
+    int duration_ms = MOTION_PULSE_DEFAULT_MS;
+    if (action == MOTION_ACTION_PULSE && j_duration) {
+        if (!cJSON_IsNumber(j_duration)) {
+            cJSON_Delete(body);
+            http_response_set_json_error(res, 400,
+                "Field 'duration_ms' must be a positive integer");
+            return;
+        }
+        int d = (int)j_duration->valuedouble;
+        if (d <= 0 || d > MOTION_PULSE_MAX_MS) {
+            cJSON_Delete(body);
+            http_response_set_json_error(res, 400,
+                "Field 'duration_ms' must be between 1 and 600000");
+            return;
+        }
+        duration_ms = d;
+    }
+
+    char stream_name[MAX_STREAM_NAME];
+    safe_strcpy(stream_name, j_stream->valuestring, sizeof(stream_name), 0);
+    cJSON_Delete(body);
+
+    /* ---- Validate target stream ----------------------------------------- */
+    stream_handle_t handle = get_stream_by_name(stream_name);
+    if (!handle) {
+        http_response_set_json_error(res, 404, "Stream not found");
+        return;
+    }
+
+    stream_config_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    if (get_stream_config(handle, &cfg) != 0) {
+        http_response_set_json_error(res, 500, "Failed to read stream config");
+        return;
+    }
+
+    if (!cfg.detection_based_recording) {
+        /* The UDT is not running for this stream, so the trigger would land
+         * in the void. 409 Conflict surfaces the misconfiguration instead of
+         * silently succeeding. */
+        http_response_set_json_error(res, 409,
+            "Stream does not have detection-based recording enabled");
+        return;
+    }
+
+    /* ---- Dispatch -------------------------------------------------------- */
+    time_t now = time(NULL);
+    bool active = (action != MOTION_ACTION_STOP);
+
+    unified_detection_notify_motion(stream_name, active);
+    process_motion_event(stream_name, active, now, false);
+
+    const char *action_str =
+        (action == MOTION_ACTION_START) ? "start" :
+        (action == MOTION_ACTION_STOP)  ? "stop"  : "pulse";
+
+    if (action == MOTION_ACTION_PULSE) {
+        motion_pulse_task_t *task = calloc(1, sizeof(*task));
+        if (!task) {
+            /* We already armed motion-start; unwind so the stream doesn't
+             * sit in RECORDING until external_motion_trigger is reset. */
+            unified_detection_notify_motion(stream_name, false);
+            process_motion_event(stream_name, false, now, false);
+            http_response_set_json_error(res, 500, "Out of memory");
+            return;
+        }
+        safe_strcpy(task->stream_name, stream_name, sizeof(task->stream_name), 0);
+        task->duration_ms = duration_ms;
+
+        pthread_t tid;
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+        int rc = pthread_create(&tid, &attr, motion_pulse_worker, task);
+        pthread_attr_destroy(&attr);
+
+        if (rc != 0) {
+            unified_detection_notify_motion(stream_name, false);
+            process_motion_event(stream_name, false, now, false);
+            free(task);
+            http_response_set_json_error(res, 500,
+                "Failed to schedule pulse end");
+            return;
+        }
+        log_info("Pulse started for stream '%s' (%d ms)", stream_name, duration_ms);
+    } else {
+        log_info("Motion %s for stream '%s'", action_str, stream_name);
+    }
+
+    /* ---- Response -------------------------------------------------------- */
+    cJSON *resp = cJSON_CreateObject();
+    if (!resp) {
+        http_response_set_json_error(res, 500, "Failed to build response");
+        return;
+    }
+    cJSON_AddBoolToObject(resp, "success", true);
+    cJSON_AddStringToObject(resp, "stream", stream_name);
+    cJSON_AddStringToObject(resp, "action", action_str);
+    if (action == MOTION_ACTION_PULSE) {
+        cJSON_AddNumberToObject(resp, "duration_ms", duration_ms);
+    }
+
+    char *json_str = cJSON_PrintUnformatted(resp);
+    cJSON_Delete(resp);
+    if (!json_str) {
+        http_response_set_json_error(res, 500, "Failed to serialize response");
+        return;
+    }
+    http_response_set_json(res, 202, json_str);
+    free(json_str);
+}

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -93,18 +93,22 @@ static uint64_t pulse_gen_increment(const char *stream_name) {
         g_pulse_gen[i].generation = 1;
         return 1;
     }
-    /* Table full (shouldn't happen with MAX_STREAMS=256 streams).  Return a
-     * sentinel of 1 so the pulse worker will still fire its stop — a
-     * spurious stop on table overflow is safer than a hung recording. */
-    log_warn("pulse_gen table full; pulse stop will not be generation-gated for '%s'",
+    /* Table full (shouldn't happen with MAX_STREAMS=256 streams).
+     * Return 0 — the reserved "generation tracking disabled" sentinel.
+     * The pulse worker treats generation==0 as "always fire the stop",
+     * which is safer than leaving the stream permanently in motion-active. */
+    log_warn("pulse_gen table full; pulse stop for '%s' will fire unconditionally",
              stream_name);
-    return 1;
+    return 0;
 }
 
 typedef struct {
     char     stream_name[MAX_STREAM_NAME];
     int      duration_ms;
-    uint64_t generation; /* generation at the time the pulse was scheduled */
+    /* Generation counter snapshot taken when this pulse was scheduled.
+     * 0 is the reserved sentinel meaning "generation tracking disabled":
+     * the worker will fire the stop unconditionally in that case. */
+    uint64_t generation;
 } motion_pulse_task_t;
 
 /* Fire motion-start, sleep for duration_ms, fire motion-stop — but only if no
@@ -123,11 +127,18 @@ static void *motion_pulse_worker(void *arg) {
         usec -= chunk;
     }
 
-    /* Check whether a newer action has superseded this pulse. */
-    pthread_mutex_lock(&g_pulse_gen_mutex);
-    uint64_t current_gen = pulse_gen_get(task->stream_name);
-    bool still_current = (current_gen == task->generation);
-    pthread_mutex_unlock(&g_pulse_gen_mutex);
+    /* Check whether a newer action has superseded this pulse.
+     * generation==0 means tracking was disabled (table-full fallback);
+     * in that case always fire the stop rather than leave motion active. */
+    bool still_current;
+    if (task->generation == 0) {
+        still_current = true;
+    } else {
+        pthread_mutex_lock(&g_pulse_gen_mutex);
+        uint64_t current_gen = pulse_gen_get(task->stream_name);
+        still_current = (current_gen == task->generation);
+        pthread_mutex_unlock(&g_pulse_gen_mutex);
+    }
 
     if (still_current) {
         time_t now = time(NULL);

--- a/src/web/api_handlers_motion.c
+++ b/src/web/api_handlers_motion.c
@@ -67,7 +67,8 @@ static pulse_gen_entry_t g_pulse_gen[MAX_STREAMS];
 static int               g_pulse_gen_count = 0;
 static pthread_mutex_t   g_pulse_gen_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-/* Return the current generation for stream_name (0 if not seen before). */
+/* Return the current generation for stream_name (0 if not seen before).
+ * Caller MUST hold g_pulse_gen_mutex. */
 static uint64_t pulse_gen_get(const char *stream_name) {
     for (int i = 0; i < g_pulse_gen_count; i++) {
         if (strcmp(g_pulse_gen[i].name, stream_name) == 0)
@@ -77,7 +78,7 @@ static uint64_t pulse_gen_get(const char *stream_name) {
 }
 
 /* Increment the generation counter for stream_name and return the new value.
- * Must be called with g_pulse_gen_mutex held. */
+ * Caller MUST hold g_pulse_gen_mutex. */
 static uint64_t pulse_gen_increment(const char *stream_name) {
     for (int i = 0; i < g_pulse_gen_count; i++) {
         if (strcmp(g_pulse_gen[i].name, stream_name) == 0)
@@ -91,8 +92,11 @@ static uint64_t pulse_gen_increment(const char *stream_name) {
         g_pulse_gen[i].generation = 1;
         return 1;
     }
-    /* Table full (shouldn't happen in practice); return a non-zero sentinel. */
-    log_warn("pulse_gen table full; generation tracking disabled for '%s'", stream_name);
+    /* Table full (shouldn't happen with MAX_STREAMS=256 streams).  Return a
+     * sentinel of 1 so the pulse worker will still fire its stop — a
+     * spurious stop on table overflow is safer than a hung recording. */
+    log_warn("pulse_gen table full; pulse stop will not be generation-gated for '%s'",
+             stream_name);
     return 1;
 }
 

--- a/src/web/libuv_api_handlers.c
+++ b/src/web/libuv_api_handlers.c
@@ -32,6 +32,7 @@
 #include "web/api_handlers_setup.h"
 #include "web/api_handlers_recording_tags.h"
 #include "web/api_handlers_metrics.h"
+#include "web/api_handlers_motion.h"
 #define LOG_COMPONENT "HTTP"
 #include "core/logger.h"
 #include "core/config.h"
@@ -69,6 +70,9 @@ int register_all_libuv_handlers(http_server_handle_t server) {
     // Metrics & Telemetry API
     http_server_register_handler(server, "/api/metrics", "GET", handle_get_metrics);
     http_server_register_handler(server, "/api/telemetry/player", "POST", handle_post_player_telemetry);
+
+    // Motion API — external trigger for automation (Home Assistant etc.)
+    http_server_register_handler(server, "/api/motion/trigger", "POST", handle_post_motion_trigger);
 
     // Streams API
     http_server_register_handler(server, "/api/streams", "GET", handle_get_streams);


### PR DESCRIPTION
## Summary

- Adds `POST /api/motion/trigger` so external automation (Home Assistant, NodeRED, shell scripts, PIR sensor bridges) can drive the same motion-recording path that ONVIF events normally drive. Closes the feature requested in discussion #375.
- Supports `action: start | stop | pulse`; pulse fires start, waits `duration_ms` (default 2000, max 600000) in a detached worker, then fires stop — a single-edge-friendly convenience for automations that only report activation.
- Honours cross-stream `motion_trigger_source` propagation and the existing `X-API-Key` / `Authorization: Bearer` / session auth paths via `httpd_get_authenticated_user`. Rejects `USER_ROLE_VIEWER` with 403. Rejects streams without `detection_based_recording` with 409 instead of silently swallowing the trigger.
- Documents the endpoint in `docs/API.md` and, as a related fix, expands the Authentication section (which previously only mentioned session cookies) to cover API keys, Bearer tokens, and Basic auth plus a role-capabilities table.

## Design notes

- The UI surface for motion control was removed in 50697f7a / 51e68cf7; this PR adds a server-only API replacement, not a UI.
- Pulse uses `pthread_create` with `PTHREAD_CREATE_DETACHED`, matching the deferred-work idiom already used in `api_handlers_streams_modify.c` (no new thread pool or timer subsystem).
- No DB schema change: existing `USER_ROLE_API` role is the scoping mechanism. Create a dedicated API user for automation and use its `api_key`.
- `src/web/*.c` is globbed in `CMakeLists.txt`, so no build-file edit was needed.

## Test plan

- [x] Clean build (\`make -j4\`) passes with no warnings on the new files.
- [x] Targeted tests pass: \`test_detection_model_motion\`, \`test_httpd_utils\`, \`test_external_motion_trigger\`, \`test_cross_stream_motion_trigger\` (4/4).
- [ ] Manual smoke with curl against a running instance: \`start\`, \`stop\`, \`pulse\`, and all four error paths (400/401/403/404/409).
- [ ] Home Assistant \`rest_command\` integration per the example in \`docs/API.md\`.
- [ ] Verify cross-stream propagation: trigger motion on stream A when stream B has \`motion_trigger_source=A\`, confirm B starts recording too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)