### PR TITLE
Update go2rtc_integration.c

### DIFF
--- a/src/video/go2rtc/go2rtc_integration.c
+++ b/src/video/go2rtc/go2rtc_integration.c
@@ -1436,7 +1436,7 @@ bool go2rtc_integration_register_all_streams(void) {
                 if (!go2rtc_stream_register(sub_name, streams[i].sub_stream_url,
                                            streams[i].onvif_username[0] != '\0' ? streams[i].onvif_username : NULL,
                                            streams[i].onvif_password[0] != '\0' ? streams[i].onvif_password : NULL,
-                                           false, streams[i].protocol, false,
+                                           false, streams[i].protocol, true,
                                            streams[i].codec)) {
                     log_warn("Failed to register sub-stream %s with go2rtc", sub_name);
                 }
@@ -1551,7 +1551,7 @@ bool go2rtc_sync_streams_from_database(void) {
                 log_info("Registering missing sub-stream %s with go2rtc", sub_name);
                 go2rtc_stream_register(sub_name, db_streams[i].sub_stream_url,
                                        username, password,
-                                       false, db_streams[i].protocol, false,
+                                       false, db_streams[i].protocol, true,
                                        db_streams[i].codec);
             }
         }
@@ -1951,7 +1951,7 @@ bool go2rtc_integration_register_stream(const char *stream_name) {
         go2rtc_stream_register(sub_name, config.sub_stream_url,
                                username[0] != '\0' ? username : NULL,
                                password[0] != '\0' ? password : NULL,
-                               false, config.protocol, false,
+                               false, config.protocol, true,
                                config.codec);
     }
 

--- a/src/video/go2rtc/go2rtc_integration.c
+++ b/src/video/go2rtc/go2rtc_integration.c
@@ -1436,7 +1436,7 @@ bool go2rtc_integration_register_all_streams(void) {
                 if (!go2rtc_stream_register(sub_name, streams[i].sub_stream_url,
                                            streams[i].onvif_username[0] != '\0' ? streams[i].onvif_username : NULL,
                                            streams[i].onvif_password[0] != '\0' ? streams[i].onvif_password : NULL,
-                                           false, streams[i].protocol, true,
+                                           false, streams[i].protocol, streams[i].record_audio,
                                            streams[i].codec)) {
                     log_warn("Failed to register sub-stream %s with go2rtc", sub_name);
                 }


### PR DESCRIPTION
- Updated all go2rtc_stream_register calls for sub‑streams to enable the true flag in the parameter list (previously set to false).
- This adjustment applies consistently across:
   - Registration from streams[i].sub_stream_url
   - Registration from db_streams[i].sub_stream_url
   - Registration from config.sub_stream_url