### PR TITLE
Fix MQTT publish for built-in motion detections

### DIFF
--- a/src/video/unified_detection_thread.c
+++ b/src/video/unified_detection_thread.c
@@ -38,6 +38,7 @@
 #include "core/config.h"
 #include "core/path_utils.h"
 #include "core/shutdown_coordinator.h"
+#include "core/mqtt_client.h"
 #include "utils/strings.h"
 #include "video/unified_detection_thread.h"
 #include "video/packet_buffer.h"
@@ -2469,6 +2470,14 @@ static bool run_detection_on_frame(unified_detection_ctx_t *ctx, AVPacket *pkt) 
             if (store_detections_in_db(ctx->stream_name, &result, now, rec_id) != 0) {
                 log_warn("[%s] Failed to store motion detections in database", ctx->stream_name);
             }
+
+            // Keep MQTT/Home Assistant motion topics in sync with built-in
+            // motion detections. Other detection backends publish here via
+            // their own pipelines; built-in motion must do the same after
+            // threshold and zone filtering.
+            mqtt_publish_detection(ctx->stream_name, &result, now);
+            mqtt_set_motion_state(ctx->stream_name, &result);
+
             pthread_mutex_lock(&ctx->mutex);
             ctx->total_detections += result.count;
             pthread_mutex_unlock(&ctx->mutex);


### PR DESCRIPTION
## Summary
- publish MQTT detection payloads for built-in motion detections
- update Home Assistant motion and detection count topics from the built-in motion backend
- keep behavior aligned with API and ONVIF detection paths

## Why
The built-in motion detection path stores thresholded detections in the database, but unlike the API detection path it did not call `mqtt_publish_detection()` or `mqtt_set_motion_state()`. As a result, Home Assistant discovery topics were created, snapshots continued to publish, but these state topics did not update for streams using `model=motion`:

- `lightnvr/cameras/<stream>/motion`
- `lightnvr/cameras/<stream>/detection_count`
- `lightnvr/detections/<stream>`

## Testing
- Applied the patch to a clean clone.
- Ran `git diff --check`.
- Built in a Debian sid container with CI-like options:
  ```sh
  cmake .. \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
    -DENABLE_SOD=OFF \
    -DENABLE_GO2RTC=OFF \
    -DBUILD_TESTS=OFF
  cmake --build . -j2
  ```
- Confirmed `build/bin/lightnvr` was produced.
