### PR TITLE
update docker image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ docker run -d \
   -v ./config:/etc/lightnvr \
   -v ./data:/var/lib/lightnvr/data \
   -e TZ=America/New_York \
-  matteius/lightnvr:latest
+  opensensor/lightnvr:latest
 ```
 
 #### Volume Mounts Explained


### PR DESCRIPTION
Updated Docker image reference from 'matteius/lightnvr:latest' to 'opensensor/lightnvr:latest'.

I guess it was outdated from before but I haven't tested if GitHub redirects it or not, I just saw there was no lightnvr package under matteius