### PR TITLE
docs: link to Home Assistant add-on repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ Powerful object detection using modern ONNX and TFLite models with zone-aware fi
 
 ### Installation
 
+> **🏠 Running Home Assistant?** Install LightNVR straight from the add-on store —
+> no Docker or command line needed. Add the repository
+> **[opensensor/lightnvr-hassio-addons](https://github.com/opensensor/lightnvr-hassio-addons)**
+> under **Settings → Add-ons → Add-on Store → ⋮ → Repositories**, then install
+> **LightNVR**. See that repo's README for one-click setup.
+
 1. **Build from source**:
    ```bash
    # Clone the repository


### PR DESCRIPTION
Adds a callout at the top of the README **Installation** section pointing Home Assistant users to the dedicated add-on repository, **[opensensor/lightnvr-hassio-addons](https://github.com/opensensor/lightnvr-hassio-addons)**, so they can install LightNVR from the HA add-on store without Docker or the command line.

The add-on repo already cross-references back to this main project. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)