### PR TITLE
docs: fix build-from-source instructions and document prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ Powerful object detection using modern ONNX and TFLite models with zone-aware fi
    git submodule update --init --recursive
 
    # Build web assets (requires Node.js >= 20 -- see prerequisites above).
-   # Use this script rather than a manual `cd web && npm install && npm run
-   # build`: it also runs scripts/extract_version.js first, which generates
-   # web/js/version.js from CMakeLists.txt. Skipping that step fails the Vite
-   # build with "Could not resolve '../../version.js'" in Header.jsx.
+   # Use this script rather than running: cd web && npm install && npm run build
+   # It also runs scripts/extract_version.js first, which generates web/js/version.js
+   # from CMakeLists.txt. Skipping that step fails the Vite build with:
+   # "Could not resolve '../../version.js'" in Header.jsx.
    ./scripts/build_web_vite.sh
 
    # Build the software

--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ Powerful object detection using modern ONNX and TFLite models with zone-aware fi
 > **LightNVR**. See that repo's README for one-click setup.
 
 1. **Build from source**:
+
+   Prerequisites (in addition to `build-essential`, `cmake`, `pkg-config`):
+   - **FFmpeg ≥ 7.1** (`libavcodec ≥ 61`, `libavformat ≥ 61`, `libavutil ≥ 59`,
+     `libswscale ≥ 8`, `libswresample ≥ 5`). Debian 12 (bookworm) and Ubuntu
+     22.04 ship FFmpeg 5.x/6.x, which is too old — build FFmpeg from source or
+     use a newer distro release (Debian 13 / Ubuntu 24.04+ ship a compatible
+     version).
+   - **Node.js ≥ 20** for the web build. Debian 12's packaged `nodejs` is 18.x
+     — install a newer version via [NodeSource](https://github.com/nodesource/distributions)
+     or [nvm](https://github.com/nvm-sh/nvm) if `node --version` is below 20.
+   - **`libsqlite3-dev`** (not pulled in automatically by any of the above).
+
    ```bash
    # Clone the repository
    git clone https://github.com/opensensor/lightnvr.git
@@ -230,11 +242,12 @@ Powerful object detection using modern ONNX and TFLite models with zone-aware fi
    # Initialize submodules (required for go2rtc)
    git submodule update --init --recursive
 
-   # Build web assets (requires Node.js/npm)
-   cd web
-   npm install
-   npm run build
-   cd ..
+   # Build web assets (requires Node.js >= 20 -- see prerequisites above).
+   # Use this script rather than a manual `cd web && npm install && npm run
+   # build`: it also runs scripts/extract_version.js first, which generates
+   # web/js/version.js from CMakeLists.txt. Skipping that step fails the Vite
+   # build with "Could not resolve '../../version.js'" in Header.jsx.
+   ./scripts/build_web_vite.sh
 
    # Build the software
    ./scripts/build.sh --release


### PR DESCRIPTION
## Summary

Hit these building from a stock Debian 12 (bookworm) install and want to save the next person the trial-and-error:

- The documented web build step (`cd web && npm install && npm run build`) skips `scripts/extract_version.js`, which generates `web/js/version.js` from `CMakeLists.txt`. Without it, the Vite build fails outright:
  ```
  [UNRESOLVED_IMPORT] Could not resolve '../../version.js' in js/components/preact/Header.jsx
  ```
  `scripts/build_web_vite.sh` already exists and runs that step first — the README should point at it instead of the manual npm commands.

- Three prerequisites aren't documented anywhere and surface as confusing failures partway through the build rather than an upfront "you need X":
  - **FFmpeg ≥ 7.1** (`libavcodec ≥ 61`) — Debian 12/Ubuntu 22.04 ship older FFmpeg, and the CMake `pkg_check_modules` failure doesn't say what version or where to get it.
  - **Node.js ≥ 20** for the web build — Debian 12's packaged `nodejs` is 18.x. Several deps (`vite`, `tinykeys`) require 20+/22+, and `chromedriver`'s postinstall script crashes under Node 18 with an `ERR_REQUIRE_ESM` error that gives no hint the actual cause is the Node version.
  - **`libsqlite3-dev`** — not pulled in by any of the previously-listed packages; CMake configure fails with `sqlite3 not found` with no indication it's a missing apt package.

No functional/code changes — README only.

## Test plan

- [x] Followed the updated instructions end-to-end on a fresh Debian 12 (bookworm) install, including the FFmpeg/Node/sqlite3 prerequisites, and confirmed `scripts/build_web_vite.sh` → `scripts/build.sh --release` → `scripts/install.sh` succeeds where the old instructions failed at the Vite build step.