### PR TITLE
feat(auth): add role and grant management APIs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -106,6 +106,74 @@ The response reports `allowed`, the compatibility role or matching policy grant,
 the evaluated policy version, and a concise explanation. Global actions such as
 `users.manage` omit `camera_uuid`.
 
+#### Manage authorization roles
+
+```
+GET    /api/authorization/roles
+POST   /api/authorization/roles
+PUT    /api/authorization/roles/{role_uuid}
+DELETE /api/authorization/roles/{role_uuid}
+```
+
+Administrator-only. The list response includes the current `policy_version` and
+each role's action keys. Built-in roles are readable but immutable. Create,
+update, and delete requests must include the last observed version as
+`expected_policy_version`; stale writes return `409` so concurrent policy edits
+cannot silently overwrite one another.
+
+Create and update bodies use a complete role representation:
+
+```json
+{
+  "expected_policy_version": 12,
+  "name": "Evidence reviewer",
+  "description": "Can replay evidence without exporting it",
+  "actions": ["live.view", "recordings.replay"]
+}
+```
+
+A delete body contains only `expected_policy_version`. A custom role cannot be
+deleted while a grant references it.
+
+#### Manage a user's authorization policy
+
+```
+GET /api/authorization/users/{user_id}
+PUT /api/authorization/users/{user_id}
+```
+
+Administrator-only. `GET` returns the user's mode, complete grants, and a policy
+version. `PUT` atomically replaces the complete grant set and mode, and requires
+that version as `expected_policy_version`. An `all` scope omits its selector; a
+selector scope embeds a Fleet 01 selector:
+
+```json
+{
+  "expected_policy_version": 13,
+  "mode": "policy",
+  "grants": [
+    {
+      "role_uuid": "00000000-0000-4000-8000-000000000003",
+      "scope": {
+        "type": "selector",
+        "selector": {
+          "version": 1,
+          "expression": {
+            "op": "tag_any",
+            "uuids": ["c401035a-a208-4af9-9bf5-e49da3bd4200"]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+The server validates every selector and role before changing anything. It also
+rejects an authenticated administrator's attempt to remove their own effective
+`users.manage` grant. Saving grants in `legacy` mode is supported so an
+administrator can prepare policy before activating default-deny evaluation.
+
 ## API Endpoints
 
 ### Streams

--- a/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
+++ b/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
@@ -83,7 +83,7 @@ they may not trust a client-supplied collection expansion.
 | Routes | Required action | Current enforcement |
 | --- | --- | --- |
 | User list/create/get/update/delete, API-key generation, password lock and lockout clear | `users.manage` | Existing administrator/self-service rules |
-| Authorization action catalog and policy simulation | `users.manage` | Administrator-only foundation endpoint |
+| Authorization action catalog, roles, user grants, and policy simulation | `users.manage` | Central evaluator with optimistic policy-version checks |
 | Settings reads containing secrets | `system.admin` | Existing administrator/redaction behavior |
 | Settings writes and go2rtc configuration validation | `system.admin` | Existing administrator checks |
 | System information/status/log reads | `system.admin` | Existing endpoint checks |

--- a/include/database/db_authorization.h
+++ b/include/database/db_authorization.h
@@ -1,22 +1,84 @@
 #ifndef LIGHTNVR_DB_AUTHORIZATION_H
 #define LIGHTNVR_DB_AUTHORIZATION_H
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "core/config.h"
+#include "database/db_auth.h"
 
 #define AUTHORIZATION_ROLE_NAME_MAX 128
 #define AUTHORIZATION_SCOPE_TYPE_MAX 16
 #define AUTHORIZATION_SELECTOR_MAX 8192
 #define AUTHORIZATION_MAX_USER_GRANTS 256
+#define AUTHORIZATION_ROLE_DESCRIPTION_MAX 256
+
+typedef enum {
+    DB_AUTHORIZATION_OK = 0,
+    DB_AUTHORIZATION_ERROR = -1,
+    DB_AUTHORIZATION_NOT_FOUND = -2,
+    DB_AUTHORIZATION_CONFLICT = -3,
+    DB_AUTHORIZATION_IMMUTABLE = -4,
+    DB_AUTHORIZATION_IN_USE = -5,
+    DB_AUTHORIZATION_STALE = -6,
+    DB_AUTHORIZATION_INVALID = -7
+} db_authorization_result_t;
 
 typedef struct {
     char uuid[CAMERA_UUID_STRING_SIZE];
+    char name[AUTHORIZATION_ROLE_NAME_MAX];
+    char description[AUTHORIZATION_ROLE_DESCRIPTION_MAX];
+    bool is_builtin;
+    uint64_t action_mask;
+    int64_t created_at;
+    int64_t updated_at;
+} authorization_role_t;
+
+typedef struct {
+    char uuid[CAMERA_UUID_STRING_SIZE];
+    int64_t user_id;
     char role_uuid[CAMERA_UUID_STRING_SIZE];
     char role_name[AUTHORIZATION_ROLE_NAME_MAX];
     char scope_type[AUTHORIZATION_SCOPE_TYPE_MAX];
     char selector_json[AUTHORIZATION_SELECTOR_MAX];
+    bool enabled;
+    int64_t created_at;
+    int64_t updated_at;
 } authorization_grant_t;
+
+typedef struct {
+    char role_uuid[CAMERA_UUID_STRING_SIZE];
+    char scope_type[AUTHORIZATION_SCOPE_TYPE_MAX];
+    char selector_json[AUTHORIZATION_SELECTOR_MAX];
+} authorization_grant_input_t;
+
+int db_authorization_role_count(void);
+int db_authorization_role_list(authorization_role_t *roles, int max_count);
+db_authorization_result_t db_authorization_load_roles(
+    authorization_role_t **roles, int *role_count, int64_t *policy_version);
+db_authorization_result_t db_authorization_role_get(
+    const char *uuid, authorization_role_t *role);
+db_authorization_result_t db_authorization_role_create(
+    authorization_role_t *role, int64_t expected_version,
+    int64_t *new_version);
+db_authorization_result_t db_authorization_role_update(
+    const authorization_role_t *role, int64_t expected_version,
+    int64_t *new_version);
+db_authorization_result_t db_authorization_role_delete(
+    const char *uuid, int64_t expected_version, int64_t *new_version);
+
+/* Load all grants for a user, independent of the action evaluator. */
+db_authorization_result_t db_authorization_get_user_policy(
+    int64_t user_id, char mode[USER_AUTHORIZATION_MODE_MAX],
+    authorization_grant_t **grants, int *grant_count,
+    int64_t *policy_version);
+
+/* Atomically replace grants and mode if expected_version is still current. */
+db_authorization_result_t db_authorization_replace_user_policy(
+    int64_t user_id, const char *mode,
+    const authorization_grant_input_t *grants, int grant_count,
+    int64_t expected_version, int64_t *new_version);
 
 /* Load enabled grants whose role contains action_key. The caller owns *grants. */
 int db_authorization_load_user_grants(int64_t user_id, const char *action_key,

--- a/include/web/api_handlers_authorization.h
+++ b/include/web/api_handlers_authorization.h
@@ -7,5 +7,17 @@ void handle_get_authorization_actions(const http_request_t *req,
                                       http_response_t *res);
 void handle_post_authorization_simulate(const http_request_t *req,
                                         http_response_t *res);
+void handle_get_authorization_roles(const http_request_t *req,
+                                    http_response_t *res);
+void handle_post_authorization_role(const http_request_t *req,
+                                    http_response_t *res);
+void handle_put_authorization_role(const http_request_t *req,
+                                   http_response_t *res);
+void handle_delete_authorization_role(const http_request_t *req,
+                                      http_response_t *res);
+void handle_get_user_authorization(const http_request_t *req,
+                                   http_response_t *res);
+void handle_put_user_authorization(const http_request_t *req,
+                                   http_response_t *res);
 
 #endif /* LIGHTNVR_API_HANDLERS_AUTHORIZATION_H */

--- a/src/database/db_authorization.c
+++ b/src/database/db_authorization.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <cjson/cJSON.h>
 
+#include "core/authorization.h"
 #include "core/camera_selector.h"
 #include "core/logger.h"
 #include "database/db_authorization.h"
@@ -188,6 +189,10 @@ static bool finish_policy_change(sqlite3 *db, bool success) {
     return false;
 }
 
+static bool sqlite_constraint_result(int rc) {
+    return (rc & 0xff) == SQLITE_CONSTRAINT;
+}
+
 int db_authorization_create_user_grant(
     int64_t user_id, const char *role_uuid, const char *scope_type,
     const char *selector_json,
@@ -286,4 +291,706 @@ int db_authorization_set_user_mode(int64_t user_id, const char *mode) {
         db, rc == SQLITE_DONE && changed == 1);
     pthread_mutex_unlock(mutex);
     return committed ? 0 : -1;
+}
+
+static int64_t policy_version_locked(sqlite3 *db) {
+    sqlite3_stmt *stmt = NULL;
+    int64_t version = -1;
+    if (sqlite3_prepare_v2(
+            db, "SELECT version FROM authz_policy_state WHERE id = 1;", -1,
+            &stmt, NULL) == SQLITE_OK &&
+        sqlite3_step(stmt) == SQLITE_ROW) {
+        version = sqlite3_column_int64(stmt, 0);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    return version;
+}
+
+static uint64_t action_bit(const char *action_key) {
+    authorization_action_t action = authorization_action_from_key(action_key);
+    return action >= 0 && action < 64 ? UINT64_C(1) << action : 0;
+}
+
+static bool valid_action_mask(uint64_t action_mask) {
+    if (action_mask == 0) return false;
+    uint64_t valid_mask = AUTHZ_ACTION_COUNT == 64
+        ? UINT64_MAX
+        : (UINT64_C(1) << AUTHZ_ACTION_COUNT) - 1;
+    return (action_mask & ~valid_mask) == 0;
+}
+
+static bool load_role_actions_locked(sqlite3 *db, const char *role_uuid,
+                                     uint64_t *action_mask) {
+    const char *sql =
+        "SELECT action_key FROM authz_role_actions WHERE role_uuid = ?;";
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        return false;
+    }
+    sqlite3_bind_text(stmt, 1, role_uuid, -1, SQLITE_TRANSIENT);
+    uint64_t mask = 0;
+    int rc = SQLITE_ROW;
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        const char *key = (const char *)sqlite3_column_text(stmt, 0);
+        uint64_t bit = action_bit(key);
+        if (bit == 0) {
+            sqlite3_finalize(stmt);
+            return false;
+        }
+        mask |= bit;
+    }
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE) return false;
+    *action_mask = mask;
+    return true;
+}
+
+static bool insert_role_actions_locked(sqlite3 *db, const char *role_uuid,
+                                       uint64_t action_mask) {
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(
+            db,
+            "INSERT INTO authz_role_actions (role_uuid,action_key) VALUES (?,?);",
+            -1, &stmt, NULL) != SQLITE_OK) {
+        return false;
+    }
+    int action_count = 0;
+    const authorization_action_metadata_t *catalog =
+        authorization_action_catalog(&action_count);
+    bool success = true;
+    for (int i = 0; i < action_count; i++) {
+        if ((action_mask & (UINT64_C(1) << catalog[i].action)) == 0) continue;
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+        sqlite3_bind_text(stmt, 1, role_uuid, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, catalog[i].key, -1, SQLITE_TRANSIENT);
+        if (sqlite3_step(stmt) != SQLITE_DONE) {
+            success = false;
+            break;
+        }
+    }
+    sqlite3_finalize(stmt);
+    return success;
+}
+
+int db_authorization_role_count(void) {
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return -1;
+    pthread_mutex_lock(mutex);
+    sqlite3_stmt *stmt = NULL;
+    int count = -1;
+    if (sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM authz_roles;", -1,
+                          &stmt, NULL) == SQLITE_OK &&
+        sqlite3_step(stmt) == SQLITE_ROW) {
+        count = sqlite3_column_int(stmt, 0);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    pthread_mutex_unlock(mutex);
+    return count;
+}
+
+int db_authorization_role_list(authorization_role_t *roles, int max_count) {
+    if (!roles || max_count <= 0) return -1;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return -1;
+    const char *sql =
+        "SELECT uuid,name,description,is_builtin,created_at,updated_at "
+        "FROM authz_roles ORDER BY is_builtin DESC,name COLLATE NOCASE LIMIT ?;";
+    pthread_mutex_lock(mutex);
+    sqlite3_stmt *stmt = NULL;
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        pthread_mutex_unlock(mutex);
+        return -1;
+    }
+    sqlite3_bind_int(stmt, 1, max_count);
+    int count = 0;
+    int rc = SQLITE_ROW;
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        authorization_role_t *role = &roles[count];
+        memset(role, 0, sizeof(*role));
+        copy_column(role->uuid, sizeof(role->uuid), stmt, 0);
+        copy_column(role->name, sizeof(role->name), stmt, 1);
+        copy_column(role->description, sizeof(role->description), stmt, 2);
+        role->is_builtin = sqlite3_column_int(stmt, 3) != 0;
+        role->created_at = sqlite3_column_int64(stmt, 4);
+        role->updated_at = sqlite3_column_int64(stmt, 5);
+        count++;
+    }
+    sqlite3_finalize(stmt);
+    bool success = rc == SQLITE_DONE;
+    for (int i = 0; success && i < count; i++) {
+        success = load_role_actions_locked(db, roles[i].uuid,
+                                           &roles[i].action_mask);
+    }
+    pthread_mutex_unlock(mutex);
+    return success ? count : -1;
+}
+
+db_authorization_result_t db_authorization_load_roles(
+    authorization_role_t **roles, int *role_count, int64_t *policy_version) {
+    if (!roles || !role_count || !policy_version) {
+        return DB_AUTHORIZATION_INVALID;
+    }
+    *roles = NULL;
+    *role_count = 0;
+    *policy_version = 0;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    pthread_mutex_lock(mutex);
+    int64_t version = policy_version_locked(db);
+    sqlite3_stmt *stmt = NULL;
+    int count = -1;
+    if (version >= 0 &&
+        sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM authz_roles;", -1,
+                          &stmt, NULL) == SQLITE_OK &&
+        sqlite3_step(stmt) == SQLITE_ROW) {
+        count = sqlite3_column_int(stmt, 0);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    if (count < 0) {
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    authorization_role_t *loaded = count > 0
+        ? calloc((size_t)count, sizeof(*loaded)) : NULL;
+    if (count > 0 && !loaded) {
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    const char *sql =
+        "SELECT uuid,name,description,is_builtin,created_at,updated_at "
+        "FROM authz_roles ORDER BY is_builtin DESC,name COLLATE NOCASE;";
+    stmt = NULL;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    int loaded_count = 0;
+    if (rc == SQLITE_OK) {
+        while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+            if (loaded_count >= count) {
+                rc = SQLITE_TOOBIG;
+                break;
+            }
+            authorization_role_t *role = &loaded[loaded_count++];
+            copy_column(role->uuid, sizeof(role->uuid), stmt, 0);
+            copy_column(role->name, sizeof(role->name), stmt, 1);
+            copy_column(role->description, sizeof(role->description), stmt, 2);
+            role->is_builtin = sqlite3_column_int(stmt, 3) != 0;
+            role->created_at = sqlite3_column_int64(stmt, 4);
+            role->updated_at = sqlite3_column_int64(stmt, 5);
+        }
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    bool success = rc == SQLITE_DONE && loaded_count == count;
+    for (int i = 0; success && i < loaded_count; i++) {
+        success = load_role_actions_locked(db, loaded[i].uuid,
+                                           &loaded[i].action_mask);
+    }
+    pthread_mutex_unlock(mutex);
+    if (!success) {
+        free(loaded);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    *roles = loaded;
+    *role_count = loaded_count;
+    *policy_version = version;
+    return DB_AUTHORIZATION_OK;
+}
+
+db_authorization_result_t db_authorization_role_get(
+    const char *uuid, authorization_role_t *role) {
+    if (!uuid || !role) return DB_AUTHORIZATION_INVALID;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    const char *sql =
+        "SELECT uuid,name,description,is_builtin,created_at,updated_at "
+        "FROM authz_roles WHERE uuid = ?;";
+    pthread_mutex_lock(mutex);
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    db_authorization_result_t result = DB_AUTHORIZATION_ERROR;
+    if (rc == SQLITE_ROW) {
+        memset(role, 0, sizeof(*role));
+        copy_column(role->uuid, sizeof(role->uuid), stmt, 0);
+        copy_column(role->name, sizeof(role->name), stmt, 1);
+        copy_column(role->description, sizeof(role->description), stmt, 2);
+        role->is_builtin = sqlite3_column_int(stmt, 3) != 0;
+        role->created_at = sqlite3_column_int64(stmt, 4);
+        role->updated_at = sqlite3_column_int64(stmt, 5);
+        result = DB_AUTHORIZATION_OK;
+    } else if (rc == SQLITE_DONE) {
+        result = DB_AUTHORIZATION_NOT_FOUND;
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    if (result == DB_AUTHORIZATION_OK &&
+        !load_role_actions_locked(db, uuid, &role->action_mask)) {
+        result = DB_AUTHORIZATION_ERROR;
+    }
+    pthread_mutex_unlock(mutex);
+    return result;
+}
+
+db_authorization_result_t db_authorization_role_create(
+    authorization_role_t *role, int64_t expected_version,
+    int64_t *new_version) {
+    if (!role || !new_version || expected_version < 1 ||
+        role->name[0] == '\0' || !valid_action_mask(role->action_mask)) {
+        return DB_AUTHORIZATION_INVALID;
+    }
+    *new_version = 0;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    const char *sql =
+        "INSERT INTO authz_roles (uuid,name,description,is_builtin) VALUES ("
+        "lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || "
+        "substr(hex(randomblob(2)),2) || '-' || "
+        "substr('89ab',(abs(random()) % 4) + 1,1) || "
+        "substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),?,?,0);";
+    pthread_mutex_lock(mutex);
+    if (!begin_policy_change(db)) {
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    int64_t current_version = policy_version_locked(db);
+    if (current_version != expected_version) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return current_version < 0 ? DB_AUTHORIZATION_ERROR
+                                   : DB_AUTHORIZATION_STALE;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, role->name, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, role->description, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) {
+        sqlite3_finalize(stmt);
+        stmt = NULL;
+    }
+    char uuid[CAMERA_UUID_STRING_SIZE] = {0};
+    if (rc == SQLITE_DONE &&
+        sqlite3_prepare_v2(
+            db, "SELECT uuid FROM authz_roles WHERE rowid=last_insert_rowid();",
+            -1, &stmt, NULL) == SQLITE_OK &&
+        sqlite3_step(stmt) == SQLITE_ROW) {
+        copy_column(uuid, sizeof(uuid), stmt, 0);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    bool success = uuid[0] != '\0' &&
+                   insert_role_actions_locked(db, uuid, role->action_mask);
+    bool committed = finish_policy_change(db, success);
+    pthread_mutex_unlock(mutex);
+    if (!committed) {
+        return sqlite_constraint_result(rc) ? DB_AUTHORIZATION_CONFLICT
+                                            : DB_AUTHORIZATION_ERROR;
+    }
+    safe_strcpy(role->uuid, uuid, sizeof(role->uuid), 0);
+    role->is_builtin = false;
+    *new_version = current_version + 1;
+    return DB_AUTHORIZATION_OK;
+}
+
+db_authorization_result_t db_authorization_role_update(
+    const authorization_role_t *role, int64_t expected_version,
+    int64_t *new_version) {
+    if (!role || !new_version || expected_version < 1 ||
+        role->uuid[0] == '\0' || role->name[0] == '\0' ||
+        !valid_action_mask(role->action_mask)) {
+        return DB_AUTHORIZATION_INVALID;
+    }
+    *new_version = 0;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    pthread_mutex_lock(mutex);
+    if (!begin_policy_change(db)) {
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    int64_t current_version = policy_version_locked(db);
+    if (current_version != expected_version) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return current_version < 0 ? DB_AUTHORIZATION_ERROR
+                                   : DB_AUTHORIZATION_STALE;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db, "SELECT is_builtin FROM authz_roles WHERE uuid=?;", -1, &stmt,
+        NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, role->uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (rc == SQLITE_DONE) {
+        sqlite3_finalize(stmt);
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_NOT_FOUND;
+    }
+    if (rc != SQLITE_ROW || sqlite3_column_int(stmt, 0) != 0) {
+        bool immutable = rc == SQLITE_ROW;
+        sqlite3_finalize(stmt);
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return immutable ? DB_AUTHORIZATION_IMMUTABLE
+                         : DB_AUTHORIZATION_ERROR;
+    }
+    sqlite3_finalize(stmt);
+    stmt = NULL;
+    rc = sqlite3_prepare_v2(
+        db, "UPDATE authz_roles SET name=?,description=?,updated_at="
+            "strftime('%s','now') WHERE uuid=?;", -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, role->name, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, role->description, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 3, role->uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    bool success = rc == SQLITE_DONE;
+    if (success) {
+        stmt = NULL;
+        success = sqlite3_prepare_v2(
+            db, "DELETE FROM authz_role_actions WHERE role_uuid=?;", -1,
+            &stmt, NULL) == SQLITE_OK;
+        if (success) {
+            sqlite3_bind_text(stmt, 1, role->uuid, -1, SQLITE_TRANSIENT);
+            success = sqlite3_step(stmt) == SQLITE_DONE;
+        }
+        if (stmt) sqlite3_finalize(stmt);
+    }
+    if (success) {
+        success = insert_role_actions_locked(db, role->uuid,
+                                             role->action_mask);
+    }
+    bool committed = finish_policy_change(db, success);
+    pthread_mutex_unlock(mutex);
+    if (!committed) {
+        return sqlite_constraint_result(rc) ? DB_AUTHORIZATION_CONFLICT
+                                            : DB_AUTHORIZATION_ERROR;
+    }
+    *new_version = current_version + 1;
+    return DB_AUTHORIZATION_OK;
+}
+
+db_authorization_result_t db_authorization_role_delete(
+    const char *uuid, int64_t expected_version, int64_t *new_version) {
+    if (!uuid || uuid[0] == '\0' || !new_version || expected_version < 1) {
+        return DB_AUTHORIZATION_INVALID;
+    }
+    *new_version = 0;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    pthread_mutex_lock(mutex);
+    if (!begin_policy_change(db)) {
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    int64_t current_version = policy_version_locked(db);
+    if (current_version != expected_version) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return current_version < 0 ? DB_AUTHORIZATION_ERROR
+                                   : DB_AUTHORIZATION_STALE;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db, "SELECT is_builtin FROM authz_roles WHERE uuid=?;", -1, &stmt,
+        NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (rc == SQLITE_DONE) {
+        sqlite3_finalize(stmt);
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_NOT_FOUND;
+    }
+    if (rc != SQLITE_ROW || sqlite3_column_int(stmt, 0) != 0) {
+        bool immutable = rc == SQLITE_ROW;
+        sqlite3_finalize(stmt);
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return immutable ? DB_AUTHORIZATION_IMMUTABLE
+                         : DB_AUTHORIZATION_ERROR;
+    }
+    sqlite3_finalize(stmt);
+    stmt = NULL;
+    rc = sqlite3_prepare_v2(
+        db, "DELETE FROM authz_roles WHERE uuid=?;", -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    bool success = rc == SQLITE_DONE && sqlite3_changes(db) == 1;
+    bool committed = finish_policy_change(db, success);
+    pthread_mutex_unlock(mutex);
+    if (committed) {
+        *new_version = current_version + 1;
+        return DB_AUTHORIZATION_OK;
+    }
+    return sqlite_constraint_result(rc) ? DB_AUTHORIZATION_IN_USE
+                                        : DB_AUTHORIZATION_ERROR;
+}
+
+db_authorization_result_t db_authorization_get_user_policy(
+    int64_t user_id, char mode[USER_AUTHORIZATION_MODE_MAX],
+    authorization_grant_t **grants, int *grant_count,
+    int64_t *policy_version) {
+    if (user_id <= 0 || !mode || !grants || !grant_count || !policy_version) {
+        return DB_AUTHORIZATION_INVALID;
+    }
+    mode[0] = '\0';
+    *grants = NULL;
+    *grant_count = 0;
+    *policy_version = 0;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    pthread_mutex_lock(mutex);
+    *policy_version = policy_version_locked(db);
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db, "SELECT authorization_mode FROM users WHERE id=?;", -1, &stmt,
+        NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, user_id);
+        rc = sqlite3_step(stmt);
+    }
+    if (rc == SQLITE_DONE) {
+        sqlite3_finalize(stmt);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_NOT_FOUND;
+    }
+    if (rc != SQLITE_ROW || *policy_version < 0) {
+        if (stmt) sqlite3_finalize(stmt);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    copy_column(mode, USER_AUTHORIZATION_MODE_MAX, stmt, 0);
+    sqlite3_finalize(stmt);
+    stmt = NULL;
+    const char *sql =
+        "SELECT g.uuid,g.user_id,g.role_uuid,r.name,g.scope_type,"
+        "COALESCE(g.selector_json,''),g.enabled,g.created_at,g.updated_at "
+        "FROM authz_grants g JOIN authz_roles r ON r.uuid=g.role_uuid "
+        "WHERE g.user_id=? ORDER BY g.created_at,g.uuid LIMIT ?;";
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        if (stmt) sqlite3_finalize(stmt);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    sqlite3_bind_int64(stmt, 1, user_id);
+    sqlite3_bind_int(stmt, 2, AUTHORIZATION_MAX_USER_GRANTS + 1);
+    int capacity = 8;
+    authorization_grant_t *loaded = calloc((size_t)capacity, sizeof(*loaded));
+    if (!loaded) {
+        sqlite3_finalize(stmt);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    int count = 0;
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        if (count >= AUTHORIZATION_MAX_USER_GRANTS) {
+            rc = SQLITE_TOOBIG;
+            break;
+        }
+        if (count == capacity) {
+            int next_capacity = capacity * 2;
+            authorization_grant_t *resized = realloc(
+                loaded, (size_t)next_capacity * sizeof(*loaded));
+            if (!resized) {
+                rc = SQLITE_NOMEM;
+                break;
+            }
+            loaded = resized;
+            memset(&loaded[capacity], 0,
+                   (size_t)(next_capacity - capacity) * sizeof(*loaded));
+            capacity = next_capacity;
+        }
+        authorization_grant_t *grant = &loaded[count++];
+        copy_column(grant->uuid, sizeof(grant->uuid), stmt, 0);
+        grant->user_id = sqlite3_column_int64(stmt, 1);
+        copy_column(grant->role_uuid, sizeof(grant->role_uuid), stmt, 2);
+        copy_column(grant->role_name, sizeof(grant->role_name), stmt, 3);
+        copy_column(grant->scope_type, sizeof(grant->scope_type), stmt, 4);
+        const char *selector = (const char *)sqlite3_column_text(stmt, 5);
+        if (selector && strlen(selector) >= sizeof(grant->selector_json)) {
+            rc = SQLITE_TOOBIG;
+            break;
+        }
+        safe_strcpy(grant->selector_json, selector ? selector : "",
+                    sizeof(grant->selector_json), 0);
+        grant->enabled = sqlite3_column_int(stmt, 6) != 0;
+        grant->created_at = sqlite3_column_int64(stmt, 7);
+        grant->updated_at = sqlite3_column_int64(stmt, 8);
+    }
+    sqlite3_finalize(stmt);
+    pthread_mutex_unlock(mutex);
+    if (rc != SQLITE_DONE) {
+        free(loaded);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    if (count == 0) {
+        free(loaded);
+        loaded = NULL;
+    }
+    *grants = loaded;
+    *grant_count = count;
+    return DB_AUTHORIZATION_OK;
+}
+
+static bool duplicate_grant_input(const authorization_grant_input_t *grants,
+                                  int index) {
+    for (int i = 0; i < index; i++) {
+        if (strcmp(grants[i].role_uuid, grants[index].role_uuid) == 0 &&
+            strcmp(grants[i].scope_type, grants[index].scope_type) == 0 &&
+            strcmp(grants[i].selector_json,
+                   grants[index].selector_json) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool valid_grant_input(const authorization_grant_input_t *grant) {
+    if (!grant || grant->role_uuid[0] == '\0') return false;
+    if (strcmp(grant->scope_type, "all") == 0) {
+        return grant->selector_json[0] == '\0';
+    }
+    return strcmp(grant->scope_type, "selector") == 0 &&
+           valid_selector(grant->selector_json);
+}
+
+db_authorization_result_t db_authorization_replace_user_policy(
+    int64_t user_id, const char *mode,
+    const authorization_grant_input_t *grants, int grant_count,
+    int64_t expected_version, int64_t *new_version) {
+    if (user_id <= 0 || !mode || !new_version || expected_version < 1 ||
+        grant_count < 0 || grant_count > AUTHORIZATION_MAX_USER_GRANTS ||
+        (grant_count > 0 && !grants) ||
+        (strcmp(mode, "legacy") != 0 && strcmp(mode, "policy") != 0)) {
+        return DB_AUTHORIZATION_INVALID;
+    }
+    *new_version = 0;
+    for (int i = 0; i < grant_count; i++) {
+        if (!valid_grant_input(&grants[i]) ||
+            duplicate_grant_input(grants, i)) {
+            return DB_AUTHORIZATION_INVALID;
+        }
+    }
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_AUTHORIZATION_ERROR;
+    pthread_mutex_lock(mutex);
+    if (!begin_policy_change(db)) {
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    int64_t current_version = policy_version_locked(db);
+    if (current_version != expected_version) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return current_version < 0 ? DB_AUTHORIZATION_ERROR
+                                   : DB_AUTHORIZATION_STALE;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(db, "SELECT 1 FROM users WHERE id=?;", -1,
+                                &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, user_id);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    if (rc == SQLITE_DONE) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_NOT_FOUND;
+    }
+    if (rc != SQLITE_ROW) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        return DB_AUTHORIZATION_ERROR;
+    }
+    const char *role_sql = "SELECT 1 FROM authz_roles WHERE uuid=?;";
+    for (int i = 0; i < grant_count; i++) {
+        stmt = NULL;
+        rc = sqlite3_prepare_v2(db, role_sql, -1, &stmt, NULL);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, grants[i].role_uuid, -1,
+                              SQLITE_TRANSIENT);
+            rc = sqlite3_step(stmt);
+        }
+        if (stmt) sqlite3_finalize(stmt);
+        if (rc != SQLITE_ROW) {
+            sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+            pthread_mutex_unlock(mutex);
+            return rc == SQLITE_DONE ? DB_AUTHORIZATION_INVALID
+                                     : DB_AUTHORIZATION_ERROR;
+        }
+    }
+    stmt = NULL;
+    rc = sqlite3_prepare_v2(db, "DELETE FROM authz_grants WHERE user_id=?;",
+                            -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, user_id);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    const char *insert_sql =
+        "INSERT INTO authz_grants "
+        "(uuid,user_id,role_uuid,scope_type,selector_json) VALUES ("
+        "lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || "
+        "substr(hex(randomblob(2)),2) || '-' || "
+        "substr('89ab',(abs(random()) % 4) + 1,1) || "
+        "substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),"
+        "?,?,?,?);";
+    for (int i = 0; rc == SQLITE_DONE && i < grant_count; i++) {
+        stmt = NULL;
+        rc = sqlite3_prepare_v2(db, insert_sql, -1, &stmt, NULL);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_int64(stmt, 1, user_id);
+            sqlite3_bind_text(stmt, 2, grants[i].role_uuid, -1,
+                              SQLITE_TRANSIENT);
+            sqlite3_bind_text(stmt, 3, grants[i].scope_type, -1,
+                              SQLITE_TRANSIENT);
+            if (grants[i].selector_json[0]) {
+                sqlite3_bind_text(stmt, 4, grants[i].selector_json, -1,
+                                  SQLITE_TRANSIENT);
+            } else {
+                sqlite3_bind_null(stmt, 4);
+            }
+            rc = sqlite3_step(stmt);
+        }
+        if (stmt) sqlite3_finalize(stmt);
+    }
+    if (rc == SQLITE_DONE) {
+        stmt = NULL;
+        rc = sqlite3_prepare_v2(
+            db, "UPDATE users SET authorization_mode=?,updated_at="
+                "strftime('%s','now') WHERE id=?;", -1, &stmt, NULL);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, mode, -1, SQLITE_TRANSIENT);
+            sqlite3_bind_int64(stmt, 2, user_id);
+            rc = sqlite3_step(stmt);
+        }
+        if (stmt) sqlite3_finalize(stmt);
+    }
+    bool committed = finish_policy_change(db, rc == SQLITE_DONE);
+    if (committed) *new_version = current_version + 1;
+    pthread_mutex_unlock(mutex);
+    return committed ? DB_AUTHORIZATION_OK : DB_AUTHORIZATION_ERROR;
 }

--- a/src/web/api_handlers_authorization.c
+++ b/src/web/api_handlers_authorization.c
@@ -1,13 +1,18 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <cjson/cJSON.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 
 #include "core/authorization.h"
 #include "database/db_auth.h"
+#include "database/db_authorization.h"
 #include "database/db_fleet_query.h"
+#include "utils/strings.h"
 #include "web/api_handlers_authorization.h"
 #include "web/httpd_utils.h"
 
@@ -30,6 +35,18 @@ static void set_json_response(http_response_t *res, cJSON *json) {
         return;
     }
     http_response_set_json(res, 200, body);
+    free(body);
+}
+
+static void set_json_response_status(http_response_t *res, int status,
+                                     cJSON *json) {
+    char *body = cJSON_PrintUnformatted(json);
+    cJSON_Delete(json);
+    if (!body) {
+        http_response_set_json_error(res, 500, "Failed to serialize response");
+        return;
+    }
+    http_response_set_json(res, status, body);
     free(body);
 }
 
@@ -218,4 +235,615 @@ void handle_post_authorization_simulate(const http_request_t *req,
     }
     free(cameras);
     set_json_response(res, response);
+}
+
+static bool authorize_policy_manager(const http_request_t *req,
+                                     http_response_t *res, user_t *requester) {
+    authorization_evaluation_t evaluation;
+    return httpd_authorize_action(req, res, AUTHZ_USERS_MANAGE, NULL,
+                                  requester, &evaluation) != 0;
+}
+
+static bool valid_uuid(const char *value) {
+    if (!value || strlen(value) != CAMERA_UUID_STRING_SIZE - 1) return false;
+    for (int i = 0; i < CAMERA_UUID_STRING_SIZE - 1; i++) {
+        unsigned char c = (unsigned char)value[i];
+        if (i == 8 || i == 13 || i == 18 || i == 23) {
+            if (c != '-') return false;
+        } else if (!isxdigit(c)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool extract_role_uuid(const http_request_t *req,
+                              char uuid[CAMERA_UUID_STRING_SIZE],
+                              http_response_t *res) {
+    char value[MAX_PATH_LENGTH];
+    if (http_request_extract_path_param(req, "/api/authorization/roles/",
+                                        value, sizeof(value)) != 0 ||
+        strchr(value, '/') || !valid_uuid(value)) {
+        http_response_set_json_error(res, 400, "Invalid role UUID");
+        return false;
+    }
+    safe_strcpy(uuid, value, CAMERA_UUID_STRING_SIZE, 0);
+    return true;
+}
+
+static bool extract_user_id(const http_request_t *req, int64_t *user_id,
+                            http_response_t *res) {
+    char value[MAX_PATH_LENGTH];
+    if (http_request_extract_path_param(req, "/api/authorization/users/",
+                                        value, sizeof(value)) != 0 ||
+        value[0] == '\0' || strchr(value, '/')) {
+        http_response_set_json_error(res, 400, "Invalid user ID");
+        return false;
+    }
+    char *end = NULL;
+    errno = 0;
+    long long parsed = strtoll(value, &end, 10);
+    if (errno == ERANGE || !end || *end != '\0' || parsed <= 0) {
+        http_response_set_json_error(res, 400, "Invalid user ID");
+        return false;
+    }
+    *user_id = (int64_t)parsed;
+    return true;
+}
+
+static bool parse_expected_version(const cJSON *body, int64_t *version,
+                                   http_response_t *res) {
+    const cJSON *item = cJSON_GetObjectItemCaseSensitive(
+        body, "expected_policy_version");
+    double numeric = cJSON_IsNumber(item) ? item->valuedouble : 0;
+    int64_t parsed = numeric >= 1 && numeric <= 9007199254740991.0
+        ? (int64_t)numeric : 0;
+    if (!cJSON_IsNumber(item) || parsed < 1 || (double)parsed != numeric) {
+        http_response_set_json_error(
+            res, 400, "expected_policy_version must be a positive integer");
+        return false;
+    }
+    *version = parsed;
+    return true;
+}
+
+static cJSON *role_to_json(const authorization_role_t *role) {
+    cJSON *object = cJSON_CreateObject();
+    cJSON *actions = cJSON_CreateArray();
+    if (!object || !actions) {
+        cJSON_Delete(object);
+        cJSON_Delete(actions);
+        return NULL;
+    }
+    cJSON_AddStringToObject(object, "uuid", role->uuid);
+    cJSON_AddStringToObject(object, "name", role->name);
+    cJSON_AddStringToObject(object, "description", role->description);
+    cJSON_AddBoolToObject(object, "builtin", role->is_builtin);
+    int count = 0;
+    const authorization_action_metadata_t *catalog =
+        authorization_action_catalog(&count);
+    for (int i = 0; i < count; i++) {
+        if ((role->action_mask & (UINT64_C(1) << catalog[i].action)) != 0) {
+            cJSON_AddItemToArray(actions, cJSON_CreateString(catalog[i].key));
+        }
+    }
+    cJSON_AddItemToObject(object, "actions", actions);
+    cJSON_AddNumberToObject(object, "created_at", (double)role->created_at);
+    cJSON_AddNumberToObject(object, "updated_at", (double)role->updated_at);
+    return object;
+}
+
+static bool parse_action_mask(const cJSON *body, uint64_t *action_mask,
+                              http_response_t *res) {
+    const cJSON *actions = cJSON_GetObjectItemCaseSensitive(body, "actions");
+    int count = cJSON_IsArray(actions) ? cJSON_GetArraySize(actions) : -1;
+    if (count < 1 || count > AUTHZ_ACTION_COUNT) {
+        http_response_set_json_error(
+            res, 400, "actions must be a non-empty action-key array");
+        return false;
+    }
+    uint64_t mask = 0;
+    for (int i = 0; i < count; i++) {
+        const cJSON *item = cJSON_GetArrayItem(actions, i);
+        authorization_action_t action = cJSON_IsString(item)
+            ? authorization_action_from_key(item->valuestring)
+            : AUTHZ_ACTION_INVALID;
+        if (action == AUTHZ_ACTION_INVALID ||
+            (mask & (UINT64_C(1) << action)) != 0) {
+            http_response_set_json_error(
+                res, 400, "actions contains an unknown or duplicate key");
+            return false;
+        }
+        mask |= UINT64_C(1) << action;
+    }
+    *action_mask = mask;
+    return true;
+}
+
+static bool contains_non_space(const char *value) {
+    if (!value) return false;
+    for (const unsigned char *cursor = (const unsigned char *)value;
+         *cursor; cursor++) {
+        if (!isspace(*cursor)) return true;
+    }
+    return false;
+}
+
+static bool parse_role_body(const cJSON *body, authorization_role_t *role,
+                            int64_t *expected_version,
+                            http_response_t *res) {
+    if (!cJSON_IsObject(body) ||
+        !parse_expected_version(body, expected_version, res)) {
+        if (!cJSON_IsObject(body)) {
+            http_response_set_json_error(res, 400,
+                                         "Request body must be an object");
+        }
+        return false;
+    }
+    const cJSON *name = cJSON_GetObjectItemCaseSensitive(body, "name");
+    const cJSON *description =
+        cJSON_GetObjectItemCaseSensitive(body, "description");
+    if (!cJSON_IsString(name) || !name->valuestring ||
+        !contains_non_space(name->valuestring) ||
+        strlen(name->valuestring) >= sizeof(role->name)) {
+        http_response_set_json_error(res, 400, "Invalid role name");
+        return false;
+    }
+    if (description &&
+        (!cJSON_IsString(description) || !description->valuestring ||
+         strlen(description->valuestring) >= sizeof(role->description))) {
+        http_response_set_json_error(res, 400, "Invalid role description");
+        return false;
+    }
+    safe_strcpy(role->name, name->valuestring, sizeof(role->name), 0);
+    safe_strcpy(role->description,
+                description ? description->valuestring : "",
+                sizeof(role->description), 0);
+    return parse_action_mask(body, &role->action_mask, res);
+}
+
+static void set_authorization_db_error(http_response_t *res,
+                                       db_authorization_result_t result) {
+    switch (result) {
+        case DB_AUTHORIZATION_NOT_FOUND:
+            http_response_set_json_error(res, 404, "Policy resource not found");
+            break;
+        case DB_AUTHORIZATION_CONFLICT:
+            http_response_set_json_error(res, 409,
+                                         "A role with that name already exists");
+            break;
+        case DB_AUTHORIZATION_IMMUTABLE:
+            http_response_set_json_error(res, 409,
+                                         "Built-in roles are immutable");
+            break;
+        case DB_AUTHORIZATION_IN_USE:
+            http_response_set_json_error(res, 409,
+                                         "Role is still referenced by a grant");
+            break;
+        case DB_AUTHORIZATION_STALE:
+            http_response_set_json_error(
+                res, 409, "Policy changed; reload before saving again");
+            break;
+        case DB_AUTHORIZATION_INVALID:
+            http_response_set_json_error(res, 400,
+                                         "Invalid authorization policy request");
+            break;
+        default:
+            http_response_set_json_error(res, 500,
+                                         "Authorization policy operation failed");
+            break;
+    }
+}
+
+void handle_get_authorization_roles(const http_request_t *req,
+                                    http_response_t *res) {
+    user_t requester;
+    if (!authorize_policy_manager(req, res, &requester)) return;
+    authorization_role_t *roles = NULL;
+    int count = 0;
+    int64_t policy_version = 0;
+    if (db_authorization_load_roles(&roles, &count, &policy_version) !=
+        DB_AUTHORIZATION_OK) {
+        http_response_set_json_error(res, 500, "Failed to load roles");
+        return;
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON *items = cJSON_CreateArray();
+    if (!root || !items) {
+        cJSON_Delete(root);
+        cJSON_Delete(items);
+        free(roles);
+        http_response_set_json_error(res, 500, "Failed to create response");
+        return;
+    }
+    cJSON_AddNumberToObject(root, "policy_version", (double)policy_version);
+    cJSON_AddNumberToObject(root, "count", count);
+    cJSON_AddItemToObject(root, "roles", items);
+    for (int i = 0; i < count; i++) {
+        cJSON *item = role_to_json(&roles[i]);
+        if (!item) {
+            cJSON_Delete(root);
+            free(roles);
+            http_response_set_json_error(res, 500,
+                                         "Failed to create response");
+            return;
+        }
+        cJSON_AddItemToArray(items, item);
+    }
+    free(roles);
+    set_json_response(res, root);
+}
+
+static void set_role_mutation_response(http_response_t *res, int status,
+                                       const char *uuid,
+                                       int64_t policy_version) {
+    authorization_role_t role;
+    if (db_authorization_role_get(uuid, &role) != DB_AUTHORIZATION_OK) {
+        http_response_set_json_error(res, 500, "Failed to reload role");
+        return;
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON *role_json = role_to_json(&role);
+    if (!root || !role_json) {
+        cJSON_Delete(root);
+        cJSON_Delete(role_json);
+        http_response_set_json_error(res, 500, "Failed to create response");
+        return;
+    }
+    cJSON_AddNumberToObject(root, "policy_version", (double)policy_version);
+    cJSON_AddItemToObject(root, "role", role_json);
+    set_json_response_status(res, status, root);
+}
+
+static int retains_management_after_role_update(
+    const user_t *requester, const authorization_role_t *proposed_role) {
+    if (strcmp(requester->authorization_mode, "policy") != 0) return 1;
+    char mode[USER_AUTHORIZATION_MODE_MAX];
+    authorization_grant_t *grants = NULL;
+    int grant_count = 0;
+    int64_t policy_version = 0;
+    if (db_authorization_get_user_policy(
+            requester->id, mode, &grants, &grant_count, &policy_version) !=
+        DB_AUTHORIZATION_OK) {
+        return -1;
+    }
+    bool retained = false;
+    for (int i = 0; i < grant_count && !retained; i++) {
+        if (!grants[i].enabled || strcmp(grants[i].scope_type, "all") != 0) {
+            continue;
+        }
+        uint64_t action_mask = 0;
+        if (strcmp(grants[i].role_uuid, proposed_role->uuid) == 0) {
+            action_mask = proposed_role->action_mask;
+        } else {
+            authorization_role_t role;
+            if (db_authorization_role_get(grants[i].role_uuid, &role) !=
+                DB_AUTHORIZATION_OK) {
+                free(grants);
+                return -1;
+            }
+            action_mask = role.action_mask;
+        }
+        retained =
+            (action_mask & (UINT64_C(1) << AUTHZ_USERS_MANAGE)) != 0;
+    }
+    free(grants);
+    return retained ? 1 : 0;
+}
+
+void handle_post_authorization_role(const http_request_t *req,
+                                    http_response_t *res) {
+    user_t requester;
+    if (!authorize_policy_manager(req, res, &requester)) return;
+    cJSON *body = httpd_parse_json_body(req);
+    authorization_role_t role;
+    memset(&role, 0, sizeof(role));
+    int64_t expected_version = 0;
+    if (!parse_role_body(body, &role, &expected_version, res)) {
+        cJSON_Delete(body);
+        return;
+    }
+    cJSON_Delete(body);
+    int64_t new_version = 0;
+    db_authorization_result_t result = db_authorization_role_create(
+        &role, expected_version, &new_version);
+    if (result != DB_AUTHORIZATION_OK) {
+        set_authorization_db_error(res, result);
+        return;
+    }
+    set_role_mutation_response(res, 201, role.uuid, new_version);
+}
+
+void handle_put_authorization_role(const http_request_t *req,
+                                   http_response_t *res) {
+    user_t requester;
+    if (!authorize_policy_manager(req, res, &requester)) return;
+    authorization_role_t role;
+    memset(&role, 0, sizeof(role));
+    if (!extract_role_uuid(req, role.uuid, res)) return;
+    cJSON *body = httpd_parse_json_body(req);
+    int64_t expected_version = 0;
+    if (!parse_role_body(body, &role, &expected_version, res)) {
+        cJSON_Delete(body);
+        return;
+    }
+    cJSON_Delete(body);
+    int retains_management =
+        retains_management_after_role_update(&requester, &role);
+    if (retains_management <= 0) {
+        http_response_set_json_error(
+            res, retains_management == 0 ? 409 : 500,
+            retains_management == 0
+                ? "This change would remove your own policy-management access"
+                : "Failed to verify policy-management access");
+        return;
+    }
+    int64_t new_version = 0;
+    db_authorization_result_t result = db_authorization_role_update(
+        &role, expected_version, &new_version);
+    if (result != DB_AUTHORIZATION_OK) {
+        set_authorization_db_error(res, result);
+        return;
+    }
+    set_role_mutation_response(res, 200, role.uuid, new_version);
+}
+
+void handle_delete_authorization_role(const http_request_t *req,
+                                      http_response_t *res) {
+    user_t requester;
+    if (!authorize_policy_manager(req, res, &requester)) return;
+    char uuid[CAMERA_UUID_STRING_SIZE];
+    if (!extract_role_uuid(req, uuid, res)) return;
+    cJSON *body = httpd_parse_json_body(req);
+    int64_t expected_version = 0;
+    if (!cJSON_IsObject(body) ||
+        !parse_expected_version(body, &expected_version, res)) {
+        if (!cJSON_IsObject(body)) {
+            http_response_set_json_error(res, 400,
+                                         "Request body must be an object");
+        }
+        cJSON_Delete(body);
+        return;
+    }
+    cJSON_Delete(body);
+    int64_t new_version = 0;
+    db_authorization_result_t result = db_authorization_role_delete(
+        uuid, expected_version, &new_version);
+    if (result != DB_AUTHORIZATION_OK) {
+        set_authorization_db_error(res, result);
+        return;
+    }
+    cJSON *response = cJSON_CreateObject();
+    cJSON_AddBoolToObject(response, "success", true);
+    cJSON_AddNumberToObject(response, "policy_version", (double)new_version);
+    set_json_response(res, response);
+}
+
+static cJSON *grant_to_json(const authorization_grant_t *grant) {
+    cJSON *object = cJSON_CreateObject();
+    cJSON *scope = cJSON_CreateObject();
+    if (!object || !scope) {
+        cJSON_Delete(object);
+        cJSON_Delete(scope);
+        return NULL;
+    }
+    cJSON_AddStringToObject(object, "uuid", grant->uuid);
+    cJSON_AddStringToObject(object, "role_uuid", grant->role_uuid);
+    cJSON_AddStringToObject(object, "role", grant->role_name);
+    cJSON_AddBoolToObject(object, "enabled", grant->enabled);
+    cJSON_AddNumberToObject(object, "created_at", (double)grant->created_at);
+    cJSON_AddNumberToObject(object, "updated_at", (double)grant->updated_at);
+    cJSON_AddStringToObject(scope, "type", grant->scope_type);
+    if (strcmp(grant->scope_type, "selector") == 0) {
+        cJSON *selector = cJSON_Parse(grant->selector_json);
+        if (!selector) {
+            cJSON_Delete(object);
+            cJSON_Delete(scope);
+            return NULL;
+        }
+        cJSON_AddItemToObject(scope, "selector", selector);
+    } else {
+        cJSON_AddNullToObject(scope, "selector");
+    }
+    cJSON_AddItemToObject(object, "scope", scope);
+    return object;
+}
+
+static void set_user_policy_response(http_response_t *res, int64_t user_id,
+                                     int status) {
+    char mode[USER_AUTHORIZATION_MODE_MAX];
+    authorization_grant_t *grants = NULL;
+    int grant_count = 0;
+    int64_t policy_version = 0;
+    db_authorization_result_t result = db_authorization_get_user_policy(
+        user_id, mode, &grants, &grant_count, &policy_version);
+    if (result != DB_AUTHORIZATION_OK) {
+        set_authorization_db_error(res, result);
+        return;
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON *items = cJSON_CreateArray();
+    if (!root || !items) {
+        cJSON_Delete(root);
+        cJSON_Delete(items);
+        free(grants);
+        http_response_set_json_error(res, 500, "Failed to create response");
+        return;
+    }
+    cJSON_AddNumberToObject(root, "user_id", (double)user_id);
+    cJSON_AddStringToObject(root, "mode", mode);
+    cJSON_AddNumberToObject(root, "policy_version", (double)policy_version);
+    cJSON_AddNumberToObject(root, "grant_count", grant_count);
+    cJSON_AddItemToObject(root, "grants", items);
+    for (int i = 0; i < grant_count; i++) {
+        cJSON *item = grant_to_json(&grants[i]);
+        if (!item) {
+            cJSON_Delete(root);
+            free(grants);
+            http_response_set_json_error(res, 500,
+                                         "Failed to create response");
+            return;
+        }
+        cJSON_AddItemToArray(items, item);
+    }
+    free(grants);
+    set_json_response_status(res, status, root);
+}
+
+void handle_get_user_authorization(const http_request_t *req,
+                                   http_response_t *res) {
+    user_t requester;
+    if (!authorize_policy_manager(req, res, &requester)) return;
+    int64_t user_id = 0;
+    if (!extract_user_id(req, &user_id, res)) return;
+    set_user_policy_response(res, user_id, 200);
+}
+
+static bool parse_grants(const cJSON *body,
+                         authorization_grant_input_t **grants_out,
+                         int *grant_count_out, http_response_t *res) {
+    const cJSON *grants = cJSON_GetObjectItemCaseSensitive(body, "grants");
+    if (!cJSON_IsArray(grants)) {
+        http_response_set_json_error(res, 400, "grants must be an array");
+        return false;
+    }
+    int count = cJSON_GetArraySize(grants);
+    if (count > AUTHORIZATION_MAX_USER_GRANTS) {
+        http_response_set_json_error(res, 400, "Grant limit exceeded");
+        return false;
+    }
+    authorization_grant_input_t *parsed = count > 0
+        ? calloc((size_t)count, sizeof(*parsed)) : NULL;
+    if (count > 0 && !parsed) {
+        http_response_set_json_error(res, 500, "Out of memory");
+        return false;
+    }
+    for (int i = 0; i < count; i++) {
+        const cJSON *grant = cJSON_GetArrayItem(grants, i);
+        const cJSON *role_uuid = cJSON_IsObject(grant)
+            ? cJSON_GetObjectItemCaseSensitive(grant, "role_uuid") : NULL;
+        const cJSON *scope = cJSON_IsObject(grant)
+            ? cJSON_GetObjectItemCaseSensitive(grant, "scope") : NULL;
+        const cJSON *type = cJSON_IsObject(scope)
+            ? cJSON_GetObjectItemCaseSensitive(scope, "type") : NULL;
+        const cJSON *selector = cJSON_IsObject(scope)
+            ? cJSON_GetObjectItemCaseSensitive(scope, "selector") : NULL;
+        if (!cJSON_IsString(role_uuid) ||
+            !valid_uuid(role_uuid->valuestring) || !cJSON_IsString(type) ||
+            (strcmp(type->valuestring, "all") != 0 &&
+             strcmp(type->valuestring, "selector") != 0)) {
+            free(parsed);
+            http_response_set_json_error(res, 400, "Invalid grant");
+            return false;
+        }
+        safe_strcpy(parsed[i].role_uuid, role_uuid->valuestring,
+                    sizeof(parsed[i].role_uuid), 0);
+        safe_strcpy(parsed[i].scope_type, type->valuestring,
+                    sizeof(parsed[i].scope_type), 0);
+        if (strcmp(type->valuestring, "all") == 0) {
+            if (selector && !cJSON_IsNull(selector)) {
+                free(parsed);
+                http_response_set_json_error(
+                    res, 400, "All-camera grants cannot include a selector");
+                return false;
+            }
+            continue;
+        }
+        if (!selector) {
+            free(parsed);
+            http_response_set_json_error(
+                res, 400, "Selector grants require a selector");
+            return false;
+        }
+        char *serialized = cJSON_PrintUnformatted(selector);
+        if (!serialized ||
+            strlen(serialized) >= sizeof(parsed[i].selector_json)) {
+            free(serialized);
+            free(parsed);
+            http_response_set_json_error(res, 400,
+                                         "Grant selector is too large");
+            return false;
+        }
+        safe_strcpy(parsed[i].selector_json, serialized,
+                    sizeof(parsed[i].selector_json), 0);
+        free(serialized);
+    }
+    *grants_out = parsed;
+    *grant_count_out = count;
+    return true;
+}
+
+static bool grants_allow_self_management(
+    const authorization_grant_input_t *grants, int grant_count) {
+    for (int i = 0; i < grant_count; i++) {
+        if (strcmp(grants[i].scope_type, "all") != 0) continue;
+        authorization_role_t role;
+        if (db_authorization_role_get(grants[i].role_uuid, &role) !=
+            DB_AUTHORIZATION_OK) {
+            continue;
+        }
+        if ((role.action_mask & (UINT64_C(1) << AUTHZ_USERS_MANAGE)) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void handle_put_user_authorization(const http_request_t *req,
+                                   http_response_t *res) {
+    user_t requester;
+    if (!authorize_policy_manager(req, res, &requester)) return;
+    int64_t user_id = 0;
+    if (!extract_user_id(req, &user_id, res)) return;
+    cJSON *body = httpd_parse_json_body(req);
+    if (!cJSON_IsObject(body)) {
+        cJSON_Delete(body);
+        http_response_set_json_error(res, 400,
+                                     "Request body must be an object");
+        return;
+    }
+    int64_t expected_version = 0;
+    const cJSON *mode = cJSON_GetObjectItemCaseSensitive(body, "mode");
+    if (!parse_expected_version(body, &expected_version, res)) {
+        cJSON_Delete(body);
+        return;
+    }
+    if (!cJSON_IsString(mode) || !mode->valuestring ||
+        (strcmp(mode->valuestring, "legacy") != 0 &&
+         strcmp(mode->valuestring, "policy") != 0)) {
+        http_response_set_json_error(res, 400,
+                                     "mode must be legacy or policy");
+        cJSON_Delete(body);
+        return;
+    }
+    authorization_grant_input_t *grants = NULL;
+    int grant_count = 0;
+    if (!parse_grants(body, &grants, &grant_count, res)) {
+        cJSON_Delete(body);
+        return;
+    }
+    if (user_id == requester.id &&
+        ((strcmp(mode->valuestring, "policy") == 0 &&
+          !grants_allow_self_management(grants, grant_count)) ||
+         (strcmp(mode->valuestring, "legacy") == 0 &&
+          requester.role != USER_ROLE_ADMIN))) {
+        free(grants);
+        cJSON_Delete(body);
+        http_response_set_json_error(
+            res, 409, "This change would remove your own policy-management access");
+        return;
+    }
+    char requested_mode[USER_AUTHORIZATION_MODE_MAX];
+    safe_strcpy(requested_mode, mode->valuestring, sizeof(requested_mode), 0);
+    cJSON_Delete(body);
+    int64_t new_version = 0;
+    db_authorization_result_t result = db_authorization_replace_user_policy(
+        user_id, requested_mode, grants, grant_count, expected_version,
+        &new_version);
+    free(grants);
+    if (result != DB_AUTHORIZATION_OK) {
+        set_authorization_db_error(res, result);
+        return;
+    }
+    set_user_policy_response(res, user_id, 200);
 }

--- a/src/web/libuv_api_handlers.c
+++ b/src/web/libuv_api_handlers.c
@@ -241,6 +241,18 @@ int register_all_libuv_handlers(http_server_handle_t server) {
                                  handle_get_authorization_actions);
     http_server_register_handler(server, "/api/authorization/simulate", "POST",
                                  handle_post_authorization_simulate);
+    http_server_register_handler(server, "/api/authorization/roles", "GET",
+                                 handle_get_authorization_roles);
+    http_server_register_handler(server, "/api/authorization/roles", "POST",
+                                 handle_post_authorization_role);
+    http_server_register_handler(server, "/api/authorization/roles/#", "PUT",
+                                 handle_put_authorization_role);
+    http_server_register_handler(server, "/api/authorization/roles/#", "DELETE",
+                                 handle_delete_authorization_role);
+    http_server_register_handler(server, "/api/authorization/users/#", "GET",
+                                 handle_get_user_authorization);
+    http_server_register_handler(server, "/api/authorization/users/#", "PUT",
+                                 handle_put_user_authorization);
 
     // TOTP MFA API (backend-agnostic handlers)
     http_server_register_handler(server, "/api/auth/users/#/totp/setup", "POST", handle_totp_setup);

--- a/tests/unit/test_authorization.c
+++ b/tests/unit/test_authorization.c
@@ -107,15 +107,16 @@ static void create_grant(int64_t user_id, const char *role_uuid,
     TEST_ASSERT_EQUAL_UINT(36, strlen(grant_uuid));
 }
 
-static cJSON *call_handler(
+static cJSON *call_handler_path(
     void (*handler)(const http_request_t *, http_response_t *),
-    http_method_t method, const char *body, const char *api_key,
-    int expected_status) {
+    http_method_t method, const char *path, const char *body,
+    const char *api_key, int expected_status) {
     http_request_t req;
     http_response_t res;
     http_request_init(&req);
     http_response_init(&res);
     req.method = method;
+    if (path) safe_strcpy(req.path, path, sizeof(req.path), 0);
     safe_strcpy(req.client_ip, "127.0.0.1", sizeof(req.client_ip), 0);
     if (body) {
         req.body = (void *)body;
@@ -136,11 +137,21 @@ static cJSON *call_handler(
     return json;
 }
 
+static cJSON *call_handler(
+    void (*handler)(const http_request_t *, http_response_t *),
+    http_method_t method, const char *body, const char *api_key,
+    int expected_status) {
+    return call_handler_path(handler, method, NULL, body, api_key,
+                             expected_status);
+}
+
 void setUp(void) {
     sqlite3 *db = get_db_handle();
     g_config.web_auth_enabled = false;
     g_config.demo_mode = false;
     sqlite3_exec(db, "DELETE FROM authz_grants;", NULL, NULL, NULL);
+    sqlite3_exec(db, "DELETE FROM authz_roles WHERE is_builtin=0;", NULL, NULL,
+                 NULL);
     sqlite3_exec(db, "DELETE FROM streams;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM camera_tags;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM users WHERE username != 'admin';",
@@ -376,6 +387,304 @@ void test_action_catalog_and_simulation_handlers(void) {
     cJSON_Delete(json);
 }
 
+void test_role_and_policy_database_mutations_are_atomic(void) {
+    int64_t version = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_get_policy_version(&version));
+    authorization_role_t role;
+    memset(&role, 0, sizeof(role));
+    safe_strcpy(role.name, "Evidence reviewer", sizeof(role.name), 0);
+    safe_strcpy(role.description, "Reviews without export",
+                sizeof(role.description), 0);
+    role.action_mask = (UINT64_C(1) << AUTHZ_LIVE_VIEW) |
+                       (UINT64_C(1) << AUTHZ_RECORDINGS_REPLAY);
+    int64_t next_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_role_create(&role, version, &next_version));
+    TEST_ASSERT_EQUAL_INT64(version + 1, next_version);
+    TEST_ASSERT_EQUAL_UINT(36, strlen(role.uuid));
+    TEST_ASSERT_EQUAL_INT(5, db_authorization_role_count());
+
+    authorization_role_t duplicate = role;
+    duplicate.uuid[0] = '\0';
+    int64_t ignored_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_CONFLICT,
+        db_authorization_role_create(&duplicate, next_version,
+                                     &ignored_version));
+    TEST_ASSERT_EQUAL_INT(0,
+                          db_authorization_get_policy_version(&ignored_version));
+    TEST_ASSERT_EQUAL_INT64(next_version, ignored_version);
+
+    authorization_role_t loaded;
+    TEST_ASSERT_EQUAL_INT(DB_AUTHORIZATION_OK,
+                          db_authorization_role_get(role.uuid, &loaded));
+    TEST_ASSERT_EQUAL_STRING(role.name, loaded.name);
+    TEST_ASSERT_EQUAL_UINT64(role.action_mask, loaded.action_mask);
+    safe_strcpy(role.name, "Evidence auditor", sizeof(role.name), 0);
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_STALE,
+        db_authorization_role_update(&role, version, &version));
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_role_update(&role, next_version, &version));
+    TEST_ASSERT_EQUAL_INT64(next_version + 1, version);
+
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("atomicpolicy", "password123", NULL,
+                               USER_ROLE_VIEWER, true, &user_id));
+    authorization_grant_input_t grant;
+    memset(&grant, 0, sizeof(grant));
+    safe_strcpy(grant.role_uuid, role.uuid, sizeof(grant.role_uuid), 0);
+    safe_strcpy(grant.scope_type, "all", sizeof(grant.scope_type), 0);
+    int64_t grants_version = 0;
+    int64_t read_version = 0;
+    authorization_grant_input_t invalid_grant = grant;
+    safe_strcpy(invalid_grant.scope_type, "selector",
+                sizeof(invalid_grant.scope_type), 0);
+    safe_strcpy(invalid_grant.selector_json, "{\"invalid\":true}",
+                sizeof(invalid_grant.selector_json), 0);
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_INVALID,
+        db_authorization_replace_user_policy(user_id, "policy",
+                                             &invalid_grant, 1, version,
+                                             &grants_version));
+    TEST_ASSERT_EQUAL_INT(0,
+                          db_authorization_get_policy_version(&read_version));
+    TEST_ASSERT_EQUAL_INT64(version, read_version);
+    authorization_grant_input_t duplicate_grants[2] = {grant, grant};
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_INVALID,
+        db_authorization_replace_user_policy(user_id, "policy",
+                                             duplicate_grants, 2, version,
+                                             &grants_version));
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_replace_user_policy(user_id, "policy", &grant, 1,
+                                             version, &grants_version));
+    TEST_ASSERT_EQUAL_INT64(version + 1, grants_version);
+
+    char mode[USER_AUTHORIZATION_MODE_MAX];
+    authorization_grant_t *grants = NULL;
+    int grant_count = 0;
+    read_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_get_user_policy(user_id, mode, &grants,
+                                         &grant_count, &read_version));
+    TEST_ASSERT_EQUAL_STRING("policy", mode);
+    TEST_ASSERT_EQUAL_INT(1, grant_count);
+    TEST_ASSERT_EQUAL_STRING(role.uuid, grants[0].role_uuid);
+    TEST_ASSERT_EQUAL_STRING("all", grants[0].scope_type);
+    TEST_ASSERT_EQUAL_INT64(grants_version, read_version);
+    free(grants);
+
+    ignored_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_STALE,
+        db_authorization_replace_user_policy(user_id, "legacy", NULL, 0,
+                                             version, &ignored_version));
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_IN_USE,
+        db_authorization_role_delete(role.uuid, grants_version,
+                                     &ignored_version));
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_get_policy_version(&read_version));
+    TEST_ASSERT_EQUAL_INT64(grants_version, read_version);
+
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_replace_user_policy(user_id, "legacy", NULL, 0,
+                                             grants_version, &version));
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_role_delete(role.uuid, version, &next_version));
+    TEST_ASSERT_EQUAL_INT64(version + 1, next_version);
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_IMMUTABLE,
+        db_authorization_role_delete(ADMIN_ROLE_UUID, next_version,
+                                     &ignored_version));
+    TEST_ASSERT_EQUAL_INT(4, db_authorization_role_count());
+}
+
+void test_policy_management_handlers_and_conflict_guards(void) {
+    int64_t version = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_get_policy_version(&version));
+    cJSON *json = call_handler_path(
+        handle_get_authorization_roles, HTTP_METHOD_GET,
+        "/api/authorization/roles", NULL, NULL, 200);
+    TEST_ASSERT_EQUAL_INT(
+        4, cJSON_GetObjectItemCaseSensitive(json, "count")->valueint);
+    TEST_ASSERT_EQUAL_INT64(
+        version,
+        (int64_t)cJSON_GetObjectItemCaseSensitive(
+            json, "policy_version")->valuedouble);
+    cJSON_Delete(json);
+
+    char body[1024];
+    snprintf(body, sizeof(body),
+             "{\"expected_policy_version\":%lld,"
+             "\"name\":\"Live desk\",\"description\":\"Live only\","
+             "\"actions\":[\"live.view\"]}",
+             (long long)version);
+    json = call_handler_path(
+        handle_post_authorization_role, HTTP_METHOD_POST,
+        "/api/authorization/roles", body, NULL, 201);
+    cJSON *created = cJSON_GetObjectItemCaseSensitive(json, "role");
+    char role_uuid[CAMERA_UUID_STRING_SIZE];
+    safe_strcpy(
+        role_uuid,
+        cJSON_GetObjectItemCaseSensitive(created, "uuid")->valuestring,
+        sizeof(role_uuid), 0);
+    int64_t role_version = (int64_t)cJSON_GetObjectItemCaseSensitive(
+        json, "policy_version")->valuedouble;
+    TEST_ASSERT_EQUAL_INT64(version + 1, role_version);
+    cJSON_Delete(json);
+
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("managedpolicy", "password123", NULL,
+                               USER_ROLE_VIEWER, true, &user_id));
+    char user_path[128];
+    snprintf(user_path, sizeof(user_path), "/api/authorization/users/%lld",
+             (long long)user_id);
+    snprintf(body, sizeof(body),
+             "{\"expected_policy_version\":%lld,\"mode\":\"policy\","
+             "\"grants\":[{\"role_uuid\":\"%s\","
+             "\"scope\":{\"type\":\"all\"}}]}",
+             (long long)role_version, role_uuid);
+    json = call_handler_path(handle_put_user_authorization, HTTP_METHOD_PUT,
+                             user_path, body, NULL, 200);
+    TEST_ASSERT_EQUAL_STRING(
+        "policy", cJSON_GetObjectItemCaseSensitive(json, "mode")->valuestring);
+    TEST_ASSERT_EQUAL_INT(
+        1, cJSON_GetObjectItemCaseSensitive(json, "grant_count")->valueint);
+    int64_t policy_version = (int64_t)cJSON_GetObjectItemCaseSensitive(
+        json, "policy_version")->valuedouble;
+    cJSON_Delete(json);
+
+    json = call_handler_path(handle_get_user_authorization, HTTP_METHOD_GET,
+                             user_path, NULL, NULL, 200);
+    cJSON *scope = cJSON_GetObjectItemCaseSensitive(
+        cJSON_GetArrayItem(
+            cJSON_GetObjectItemCaseSensitive(json, "grants"), 0), "scope");
+    TEST_ASSERT_EQUAL_STRING(
+        "all", cJSON_GetObjectItemCaseSensitive(scope, "type")->valuestring);
+    cJSON_Delete(json);
+
+    json = call_handler_path(handle_put_user_authorization, HTTP_METHOD_PUT,
+                             user_path, body, NULL, 409);
+    cJSON_Delete(json);
+
+    char role_path[160];
+    snprintf(role_path, sizeof(role_path), "/api/authorization/roles/%s",
+             role_uuid);
+    snprintf(body, sizeof(body),
+             "{\"expected_policy_version\":%lld}",
+             (long long)policy_version);
+    json = call_handler_path(handle_delete_authorization_role,
+                             HTTP_METHOD_DELETE, role_path, body, NULL, 409);
+    cJSON_Delete(json);
+
+    char builtin_path[160];
+    snprintf(builtin_path, sizeof(builtin_path),
+             "/api/authorization/roles/%s", ADMIN_ROLE_UUID);
+    snprintf(body, sizeof(body),
+             "{\"expected_policy_version\":%lld,\"name\":\"Changed\","
+             "\"actions\":[\"users.manage\"]}",
+             (long long)policy_version);
+    json = call_handler_path(handle_put_authorization_role, HTTP_METHOD_PUT,
+                             builtin_path, body, NULL, 409);
+    cJSON_Delete(json);
+
+    user_t admin;
+    TEST_ASSERT_EQUAL_INT(0, db_auth_get_user_by_username("admin", &admin));
+    char self_path[128];
+    snprintf(self_path, sizeof(self_path), "/api/authorization/users/%lld",
+             (long long)admin.id);
+    snprintf(body, sizeof(body),
+             "{\"expected_policy_version\":%lld,\"mode\":\"policy\","
+             "\"grants\":[{\"role_uuid\":\"%s\","
+             "\"scope\":{\"type\":\"all\"}}]}",
+             (long long)policy_version, OPERATOR_ROLE_UUID);
+    char admin_api_key[128] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_generate_api_key(admin.id, admin_api_key,
+                                    sizeof(admin_api_key)));
+    g_config.web_auth_enabled = true;
+    json = call_handler_path(handle_put_user_authorization, HTTP_METHOD_PUT,
+                             self_path, body, admin_api_key, 409);
+    cJSON_Delete(json);
+    g_config.web_auth_enabled = false;
+
+    int64_t viewer_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("policyreader", "password123", NULL,
+                               USER_ROLE_VIEWER, true, &viewer_id));
+    char api_key[128] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_generate_api_key(viewer_id, api_key, sizeof(api_key)));
+    g_config.web_auth_enabled = true;
+    json = call_handler_path(handle_get_authorization_roles, HTTP_METHOD_GET,
+                             "/api/authorization/roles", NULL, api_key, 403);
+    cJSON_Delete(json);
+    g_config.web_auth_enabled = false;
+}
+
+void test_policy_role_update_cannot_lock_out_requester(void) {
+    int64_t version = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_get_policy_version(&version));
+    authorization_role_t role;
+    memset(&role, 0, sizeof(role));
+    safe_strcpy(role.name, "Policy manager", sizeof(role.name), 0);
+    role.action_mask = UINT64_C(1) << AUTHZ_USERS_MANAGE;
+    int64_t role_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_role_create(&role, version, &role_version));
+
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("custommanager", "password123", NULL,
+                               USER_ROLE_USER, true, &user_id));
+    authorization_grant_input_t grant;
+    memset(&grant, 0, sizeof(grant));
+    safe_strcpy(grant.role_uuid, role.uuid, sizeof(grant.role_uuid), 0);
+    safe_strcpy(grant.scope_type, "all", sizeof(grant.scope_type), 0);
+    int64_t policy_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_replace_user_policy(user_id, "policy", &grant, 1,
+                                             role_version, &policy_version));
+    char api_key[128] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_generate_api_key(user_id, api_key, sizeof(api_key)));
+    char path[160];
+    snprintf(path, sizeof(path), "/api/authorization/roles/%s", role.uuid);
+    char body[512];
+    snprintf(body, sizeof(body),
+             "{\"expected_policy_version\":%lld,"
+             "\"name\":\"Policy manager\","
+             "\"actions\":[\"live.view\"]}",
+             (long long)policy_version);
+    g_config.web_auth_enabled = true;
+    cJSON *json = call_handler_path(
+        handle_put_authorization_role, HTTP_METHOD_PUT, path, body, api_key,
+        409);
+    cJSON_Delete(json);
+    g_config.web_auth_enabled = false;
+
+    authorization_role_t unchanged;
+    TEST_ASSERT_EQUAL_INT(DB_AUTHORIZATION_OK,
+                          db_authorization_role_get(role.uuid, &unchanged));
+    TEST_ASSERT_EQUAL_UINT64(UINT64_C(1) << AUTHZ_USERS_MANAGE,
+                             unchanged.action_mask);
+    int64_t unchanged_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_authorization_get_policy_version(&unchanged_version));
+    TEST_ASSERT_EQUAL_INT64(policy_version, unchanged_version);
+}
+
 int main(void) {
     unlink(TEST_DB_PATH);
     if (init_database(TEST_DB_PATH) != 0) {
@@ -395,6 +704,9 @@ int main(void) {
     RUN_TEST(test_all_scope_admin_grant_allows_global_action_and_bumps_version);
     RUN_TEST(test_invalid_stored_selector_fails_closed);
     RUN_TEST(test_action_catalog_and_simulation_handlers);
+    RUN_TEST(test_role_and_policy_database_mutations_are_atomic);
+    RUN_TEST(test_policy_management_handlers_and_conflict_guards);
+    RUN_TEST(test_policy_role_update_cannot_lock_out_requester);
     int result = UNITY_END();
     shutdown_database();
     unlink(TEST_DB_PATH);


### PR DESCRIPTION
## Summary

- add administrator APIs for coherent role snapshots and custom-role create/update/delete while keeping built-ins immutable
- add complete per-user policy reads and atomic replacement of mode plus selector-backed grants
- require optimistic expected_policy_version checks for every mutation so concurrent edits return 409 instead of overwriting
- validate all roles/selectors/duplicates before changing policy and preserve configured grants while a user remains in legacy mode
- prevent authenticated administrators from removing their own effective users.manage access, including indirectly through a custom-role edit

## Stack

This PR is stacked on #509, which introduces migration 0052, the action vocabulary, central evaluator, and policy simulation API.

## API surface

- GET/POST /api/authorization/roles
- PUT/DELETE /api/authorization/roles/{role_uuid}
- GET/PUT /api/authorization/users/{user_id}

## Verification

- production lightnvr target builds
- test_authorization: 9/9
- test_db_auth: 17/17
- test_api_handlers_fleet: 8/8
- collection DB/API tests: 12/12
- duplicate grants, malformed selectors, stale writes, immutable roles, in-use roles, non-admin calls, direct self-lockout, and role-edit self-lockout all have regression coverage
