### PR TITLE
feat(auth): enforce scoped PTZ and evidence actions

### DIFF
--- a/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
+++ b/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
@@ -32,8 +32,8 @@ must be reachable before a policy can be evaluated.
 | `GET /hls/#/#`, go2rtc HLS/stream proxy reads | `live.view` | Existing authentication/proxy checks |
 | Camera audio playback | `audio.listen` | Transport-specific existing checks |
 | Camera backchannel/talk activation | `audio.talk` | Existing non-viewer checks |
-| PTZ capability/preset reads | `live.view` | Existing stream access checks |
-| PTZ move, stop, home, absolute, relative, and preset writes | `ptz.control` | Existing stream access checks |
+| PTZ capability/preset reads | `live.view` | Centralized action policy with server-resolved camera scope |
+| PTZ move, stop, home, absolute, relative, and preset writes | `ptz.control` | Centralized action policy with server-resolved camera scope |
 | Imaging/day-night reads | `live.view` | Existing stream access checks |
 | Imaging/day-night writes | `camera.configure` | Existing stream write checks |
 | `POST /api/motion/trigger` | `camera.configure` | Existing non-viewer check |
@@ -68,8 +68,8 @@ facets, or collection membership. A request for one unauthorized camera returns
 | Recording download and batch-download lifecycle | `recordings.export` | Existing viewer access plus stream tags |
 | Snapshot creation/download | `snapshot.create` | Existing viewer access plus stream tags |
 | go2rtc frame capture proxy | `snapshot.create` | Existing proxy checks |
-| Protect/unprotect and retention overrides | `evidence.protect` | Inconsistent legacy checks; high-priority enforcement gap |
-| Single/file/batch recording deletion | `recording.delete` | Existing admin/user check; batch scope must be revalidated server-side |
+| Protect/unprotect and retention overrides | `evidence.protect` | Centralized action policy; batch members are resolved and evaluated individually |
+| Single/file/batch recording deletion | `recording.delete` | Centralized action policy; fixed batches are filtered member-by-member and open-ended filters require sufficient server-resolved scope |
 | Recording tag reads | `recordings.replay` | Existing viewer access |
 | Recording tag writes | `evidence.protect` | Existing endpoint checks |
 | Recording database/file sync | `storage.configure` | Existing administrative behavior |

--- a/include/database/db_fleet_query.h
+++ b/include/database/db_fleet_query.h
@@ -7,6 +7,11 @@
  * returned array and must free it. Zero cameras returns success with NULL. */
 int db_fleet_camera_load(fleet_camera_t **cameras, int *count);
 
+/* Load one credential-free fleet camera by its current stream name. Returns
+ * 0 when found, 1 when no such stream exists, and -1 on a query error. */
+int db_fleet_camera_find_by_name(const char *stream_name,
+                                 fleet_camera_t *camera);
+
 /* Add the current in-process health snapshot to a loaded inventory. Cameras
  * without an active metrics slot remain unknown; disabled cameras stay disabled. */
 void fleet_camera_enrich_runtime_health(fleet_camera_t *cameras, int count);

--- a/include/web/httpd_utils.h
+++ b/include/web/httpd_utils.h
@@ -133,6 +133,26 @@ int httpd_authorize_action(const http_request_t *req, http_response_t *res,
                            authorization_evaluation_t *evaluation);
 
 /**
+ * Resolve a stream to its immutable fleet camera and authorize a camera-scoped
+ * action. Missing streams return 404, query failures return 500, and policy
+ * denials return 403. This avoids trusting a client-supplied selector or UUID.
+ */
+int httpd_authorize_stream_action(const http_request_t *req,
+                                  http_response_t *res,
+                                  authorization_action_t action,
+                                  const char *stream_name);
+
+/**
+ * Evaluate an already-authenticated user against a server-resolved stream.
+ * Returns 0 with an allow/deny evaluation, 1 if the stream does not exist, and
+ * -1 on a database or policy evaluation error. Useful for batch operations.
+ */
+int httpd_evaluate_stream_action(const user_t *user,
+                                 authorization_action_t action,
+                                 const char *stream_name,
+                                 authorization_evaluation_t *evaluation);
+
+/**
  * @brief Check if demo mode is enabled
  * @return 1 if demo mode is enabled, 0 otherwise
  */

--- a/src/database/db_fleet_query.c
+++ b/src/database/db_fleet_query.c
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 #include <sqlite3.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -56,7 +57,8 @@ static int load_location_ancestors(fleet_camera_t *camera,
     return 0;
 }
 
-int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
+static int load_fleet_cameras(const char *stream_name,
+                              fleet_camera_t **cameras, int *count) {
     if (!cameras || !count) return -1;
     *cameras = NULL;
     *count = 0;
@@ -67,8 +69,13 @@ int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
 
     pthread_mutex_lock(mutex);
     sqlite3_stmt *stmt = NULL;
-    int rc = sqlite3_prepare_v2(db, "SELECT count(*) FROM streams;", -1,
-                                &stmt, NULL);
+    const char *count_sql = stream_name
+        ? "SELECT count(*) FROM streams WHERE name = ?;"
+        : "SELECT count(*) FROM streams;";
+    int rc = sqlite3_prepare_v2(db, count_sql, -1, &stmt, NULL);
+    if (rc == SQLITE_OK && stream_name) {
+        sqlite3_bind_text(stmt, 1, stream_name, -1, SQLITE_TRANSIENT);
+    }
     int camera_count = -1;
     if (rc == SQLITE_OK && sqlite3_step(stmt) == SQLITE_ROW) {
         camera_count = sqlite3_column_int(stmt, 0);
@@ -93,7 +100,7 @@ int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
         return -1;
     }
 
-    const char *sql =
+    const char *select_prefix =
         "WITH RECURSIVE location_tree(uuid, parent_uuid, name, path, ancestors) AS ("
         " SELECT uuid, parent_uuid, name, name, uuid FROM camera_locations "
         " WHERE parent_uuid IS NULL "
@@ -114,8 +121,18 @@ int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
         "LEFT JOIN location_tree loc ON loc.uuid = s.location_uuid "
         "LEFT JOIN camera_tag_assignments assignment "
         "       ON assignment.camera_uuid = s.camera_uuid "
-        "LEFT JOIN camera_tags tag ON tag.uuid = assignment.tag_uuid "
+        "LEFT JOIN camera_tags tag ON tag.uuid = assignment.tag_uuid ";
+    const char *select_suffix =
         "ORDER BY s.camera_uuid, tag.label COLLATE NOCASE;";
+    char sql[4096];
+    int written = snprintf(sql, sizeof(sql), "%s%s%s", select_prefix,
+                           stream_name ? "WHERE s.name = ? " : "",
+                           select_suffix);
+    if (written < 0 || (size_t)written >= sizeof(sql)) {
+        free(loaded);
+        pthread_mutex_unlock(mutex);
+        return -1;
+    }
 
     rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
     if (rc != SQLITE_OK) {
@@ -124,6 +141,9 @@ int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
         free(loaded);
         pthread_mutex_unlock(mutex);
         return -1;
+    }
+    if (stream_name) {
+        sqlite3_bind_text(stmt, 1, stream_name, -1, SQLITE_TRANSIENT);
     }
 
     int loaded_count = 0;
@@ -194,6 +214,26 @@ int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
 
     *cameras = loaded;
     *count = loaded_count;
+    return 0;
+}
+
+int db_fleet_camera_load(fleet_camera_t **cameras, int *count) {
+    return load_fleet_cameras(NULL, cameras, count);
+}
+
+int db_fleet_camera_find_by_name(const char *stream_name,
+                                 fleet_camera_t *camera) {
+    if (!stream_name || stream_name[0] == '\0' || !camera) return -1;
+    fleet_camera_t *loaded = NULL;
+    int count = 0;
+    if (load_fleet_cameras(stream_name, &loaded, &count) != 0) return -1;
+    if (count == 0) return 1;
+    if (count != 1) {
+        free(loaded);
+        return -1;
+    }
+    *camera = loaded[0];
+    free(loaded);
     return 0;
 }
 

--- a/src/web/api_handlers_ptz.c
+++ b/src/web/api_handlers_ptz.c
@@ -94,6 +94,13 @@ static int extract_ptz_stream_name(const http_request_t *req, char *stream_name,
     return 0;
 }
 
+static int authorize_ptz_stream(const http_request_t *req,
+                                http_response_t *res,
+                                const char *stream_name,
+                                authorization_action_t action) {
+    return httpd_authorize_stream_action(req, res, action, stream_name);
+}
+
 void handle_ptz_move(const http_request_t *req, http_response_t *res) {
     char stream_name[MAX_STREAM_NAME];
     if (extract_ptz_stream_name(req, stream_name, sizeof(stream_name)) != 0) {
@@ -110,6 +117,9 @@ void handle_ptz_move(const http_request_t *req, http_response_t *res) {
         return;
     } else if (rc == -2) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
+        return;
+    }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
         return;
     }
     
@@ -177,6 +187,9 @@ void handle_ptz_stop(const http_request_t *req, http_response_t *res) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
         return;
     }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
+        return;
+    }
 
     char ptz_url[512];
     if (build_ptz_url(&config, ptz_url, sizeof(ptz_url)) != 0) {
@@ -219,6 +232,9 @@ void handle_ptz_absolute(const http_request_t *req, http_response_t *res) {
         return;
     } else if (rc == -2) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
+        return;
+    }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
         return;
     }
 
@@ -299,6 +315,9 @@ void handle_ptz_relative(const http_request_t *req, http_response_t *res) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
         return;
     }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
+        return;
+    }
 
     cJSON *body = httpd_parse_json_body(req);
     if (!body) {
@@ -377,6 +396,9 @@ void handle_ptz_home(const http_request_t *req, http_response_t *res) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
         return;
     }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
+        return;
+    }
 
     char ptz_url[512];
     if (build_ptz_url(&config, ptz_url, sizeof(ptz_url)) != 0) {
@@ -421,6 +443,9 @@ void handle_ptz_set_home(const http_request_t *req, http_response_t *res) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
         return;
     }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
+        return;
+    }
 
     char ptz_url[512];
     if (build_ptz_url(&config, ptz_url, sizeof(ptz_url)) != 0) {
@@ -463,6 +488,9 @@ void handle_ptz_get_presets(const http_request_t *req, http_response_t *res) {
         return;
     } else if (rc == -2) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
+        return;
+    }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_LIVE_VIEW)) {
         return;
     }
 
@@ -536,6 +564,9 @@ void handle_ptz_goto_preset(const http_request_t *req, http_response_t *res) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
         return;
     }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
+        return;
+    }
 
     char ptz_url[512];
     if (build_ptz_url(&config, ptz_url, sizeof(ptz_url)) != 0) {
@@ -578,6 +609,9 @@ void handle_ptz_set_preset(const http_request_t *req, http_response_t *res) {
         return;
     } else if (rc == -2) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
+        return;
+    }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_PTZ_CONTROL)) {
         return;
     }
 
@@ -640,6 +674,9 @@ void handle_ptz_capabilities(const http_request_t *req, http_response_t *res) {
         return;
     } else if (rc == -2) {
         http_response_set_json_error(res, 400, "PTZ not enabled for this stream");
+        return;
+    }
+    if (!authorize_ptz_stream(req, res, stream_name, AUTHZ_LIVE_VIEW)) {
         return;
     }
 

--- a/src/web/api_handlers_recordings_backend_agnostic.c
+++ b/src/web/api_handlers_recordings_backend_agnostic.c
@@ -189,33 +189,11 @@ void handle_get_recording(const http_request_t *req, http_response_t *res) {
 }
 
 /**
- * @brief Check if the user has permission to delete recordings
- */
-static int check_delete_permission(const http_request_t *req) {
-    user_t user;
-
-    // Get the authenticated user
-    if (!httpd_get_authenticated_user(req, &user)) {
-        return 0; // Not authenticated
-    }
-
-    // Only admin and regular users can delete recordings, viewers cannot
-    return (user.role == USER_ROLE_ADMIN || user.role == USER_ROLE_USER);
-}
-
-/**
  * @brief Backend-agnostic handler for DELETE /api/recordings/:id
  *
  * Deletes a single recording from the database and filesystem.
  */
 void handle_delete_recording(const http_request_t *req, http_response_t *res) {
-    // Check authentication and permissions
-    if (!check_delete_permission(req)) {
-        log_error("Permission denied for DELETE /api/recordings/:id");
-        http_response_set_json_error(res, 403, "Permission denied: Only admin and regular users can delete recordings");
-        return;
-    }
-
     // Extract recording ID from URL
     char id_str[32];
     if (http_request_extract_path_param(req, "/api/recordings/", id_str, sizeof(id_str)) != 0) {
@@ -241,6 +219,10 @@ void handle_delete_recording(const http_request_t *req, http_response_t *res) {
     if (get_recording_metadata_by_id(id, &recording) != 0) {
         log_error("Recording not found: %llu", (unsigned long long)id);
         http_response_set_json_error(res, 404, "Recording not found");
+        return;
+    }
+    if (!httpd_authorize_stream_action(req, res, AUTHZ_RECORDING_DELETE,
+                                       recording.stream_name)) {
         return;
     }
 
@@ -291,6 +273,7 @@ void handle_delete_recording(const http_request_t *req, http_response_t *res) {
 typedef struct {
     char job_id[64];
     cJSON *json;  // Parsed JSON request (will be freed by thread)
+    int preflight_error_count;
 } batch_delete_thread_data_t;
 
 /**
@@ -322,7 +305,7 @@ static void *batch_delete_worker_thread(void *arg) {
 
         // Process each ID
         int success_count = 0;
-        int error_count = 0;
+        int error_count = data->preflight_error_count;
 
         for (int i = 0; i < array_size; i++) {
             cJSON *id_item = cJSON_GetArrayItem(ids_array, i);
@@ -635,6 +618,98 @@ static void *batch_delete_worker_thread(void *arg) {
     return NULL;
 }
 
+static int authorize_batch_delete_ids(const user_t *user, cJSON *json,
+                                      int *failure_count,
+                                      http_response_t *res) {
+    cJSON *ids = cJSON_GetObjectItemCaseSensitive(json, "ids");
+    cJSON *authorized = cJSON_CreateArray();
+    if (!authorized) {
+        http_response_set_json_error(res, 500, "Failed to authorize batch");
+        return 0;
+    }
+
+    *failure_count = 0;
+    cJSON *item = NULL;
+    cJSON_ArrayForEach(item, ids) {
+        if (!cJSON_IsNumber(item) || item->valuedouble <= 0) {
+            (*failure_count)++;
+            continue;
+        }
+        uint64_t id = (uint64_t)item->valuedouble;
+        recording_metadata_t recording;
+        if (get_recording_metadata_by_id(id, &recording) != 0) {
+            (*failure_count)++;
+            continue;
+        }
+        authorization_evaluation_t evaluation;
+        int result = httpd_evaluate_stream_action(
+            user, AUTHZ_RECORDING_DELETE, recording.stream_name, &evaluation);
+        if (result < 0) {
+            cJSON_Delete(authorized);
+            http_response_set_json_error(
+                res, 500, "Authorization policy evaluation failed");
+            return 0;
+        }
+        if (result > 0 || evaluation.decision != AUTHZ_DECISION_ALLOW) {
+            (*failure_count)++;
+            continue;
+        }
+        cJSON_AddItemToArray(authorized, cJSON_CreateNumber((double)id));
+    }
+
+    cJSON_DeleteItemFromObjectCaseSensitive(json, "ids");
+    cJSON_AddItemToObject(json, "ids", authorized);
+    return 1;
+}
+
+static int authorize_batch_delete_filter(const user_t *user,
+                                         const cJSON *filter,
+                                         http_response_t *res) {
+    cJSON *stream = cJSON_GetObjectItemCaseSensitive(filter, "stream_name");
+    if (!stream) stream = cJSON_GetObjectItemCaseSensitive(filter, "stream");
+    if (cJSON_IsString(stream) && stream->valuestring[0] != '\0') {
+        char names[256];
+        if (strlen(stream->valuestring) >= sizeof(names)) {
+            http_response_set_json_error(res, 400, "Stream filter is too long");
+            return 0;
+        }
+        safe_strcpy(names, stream->valuestring, sizeof(names), 0);
+        char *saveptr = NULL;
+        for (char *name = strtok_r(names, ",", &saveptr); name;
+             name = strtok_r(NULL, ",", &saveptr)) {
+            name = trim_ascii_whitespace(name);
+            authorization_evaluation_t evaluation;
+            int result = httpd_evaluate_stream_action(
+                user, AUTHZ_RECORDING_DELETE, name, &evaluation);
+            if (result < 0) {
+                http_response_set_json_error(
+                    res, 500, "Authorization policy evaluation failed");
+                return 0;
+            }
+            if (result > 0 || evaluation.decision != AUTHZ_DECISION_ALLOW) {
+                http_response_set_json_error(res, 403, "Forbidden");
+                return 0;
+            }
+        }
+        return 1;
+    }
+
+    // Open-ended filters can expand after this request. Only an all-fleet
+    // grant (or an unrestricted compatible legacy role) may launch them.
+    authorization_evaluation_t evaluation;
+    if (authorization_evaluate(user, AUTHZ_RECORDING_DELETE, NULL,
+                               &evaluation) != 0) {
+        http_response_set_json_error(
+            res, 500, "Authorization policy evaluation failed");
+        return 0;
+    }
+    if (evaluation.decision != AUTHZ_DECISION_ALLOW) {
+        http_response_set_json_error(res, 403, "Forbidden");
+        return 0;
+    }
+    return 1;
+}
+
 /**
  * @brief Backend-agnostic handler for POST /api/recordings/batch-delete
  *
@@ -643,10 +718,9 @@ static void *batch_delete_worker_thread(void *arg) {
 void handle_batch_delete_recordings(const http_request_t *req, http_response_t *res) {
     log_info("Handling POST /api/recordings/batch-delete request");
 
-    // Check authentication and permissions
-    if (!check_delete_permission(req)) {
-        log_error("Permission denied for batch delete");
-        http_response_set_json_error(res, 403, "Permission denied: Only admin and regular users can delete recordings");
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
         return;
     }
 
@@ -665,6 +739,7 @@ void handle_batch_delete_recordings(const http_request_t *req, http_response_t *
     // Determine total count for job creation
     int total_count = 0;
 
+    int preflight_error_count = 0;
     if (ids_array && cJSON_IsArray(ids_array)) {
         // Delete by IDs
         total_count = cJSON_GetArraySize(ids_array);
@@ -674,9 +749,18 @@ void handle_batch_delete_recordings(const http_request_t *req, http_response_t *
             http_response_set_json_error(res, 400, "Empty 'ids' array");
             return;
         }
+        if (!authorize_batch_delete_ids(&user, json,
+                                        &preflight_error_count, res)) {
+            cJSON_Delete(json);
+            return;
+        }
     } else if (filter && cJSON_IsObject(filter)) {
         // Delete by filter - total count will be determined by worker thread
         total_count = 0;
+        if (!authorize_batch_delete_filter(&user, filter, res)) {
+            cJSON_Delete(json);
+            return;
+        }
     } else {
         log_error("Request must contain either 'ids' array or 'filter' object");
         cJSON_Delete(json);
@@ -707,6 +791,7 @@ void handle_batch_delete_recordings(const http_request_t *req, http_response_t *
 
     safe_strcpy(thread_data->job_id, job_id, sizeof(thread_data->job_id), 0);
     thread_data->json = json;  // Transfer ownership to thread
+    thread_data->preflight_error_count = preflight_error_count;
 
     // Spawn worker thread
     pthread_t thread;

--- a/src/web/api_handlers_recordings_files_backend_agnostic.c
+++ b/src/web/api_handlers_recordings_files_backend_agnostic.c
@@ -11,8 +11,10 @@
 
 #include "web/api_handlers_recordings.h"
 #include "web/request_response.h"
+#include "web/httpd_utils.h"
 #define LOG_COMPONENT "RecordingsAPI"
 #include "core/logger.h"
+#include "database/db_recordings.h"
 
 /**
  * @brief Handle GET /api/recordings/files/check
@@ -90,11 +92,36 @@ void handle_check_recording_file(const http_request_t *req, http_response_t *res
 void handle_delete_recording_file(const http_request_t *req, http_response_t *res) {
     log_info("Handling DELETE /api/recordings/files request");
 
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return;
+    }
+
     // Extract path from query parameter
     char path[MAX_PATH_LENGTH];
     if (http_request_get_query_param(req, "path", path, sizeof(path)) < 0) {
         log_error("Missing path parameter");
         http_response_set_json_error(res, 400, "Missing path parameter");
+        return;
+    }
+
+    recording_metadata_t recording;
+    if (get_recording_metadata_by_path(path, &recording) != 0) {
+        http_response_set_json_error(res, 404, "Recording not found");
+        return;
+    }
+    authorization_evaluation_t evaluation;
+    int authorization_result = httpd_evaluate_stream_action(
+        &user, AUTHZ_RECORDING_DELETE, recording.stream_name, &evaluation);
+    if (authorization_result < 0) {
+        http_response_set_json_error(
+            res, 500, "Authorization policy evaluation failed");
+        return;
+    }
+    if (authorization_result > 0 ||
+        evaluation.decision != AUTHZ_DECISION_ALLOW) {
+        http_response_set_json_error(res, 403, "Forbidden");
         return;
     }
 
@@ -140,4 +167,3 @@ void handle_delete_recording_file(const http_request_t *req, http_response_t *re
     http_response_set_json(res, 200, json_str);
     free(json_str);
 }
-

--- a/src/web/api_handlers_retention.c
+++ b/src/web/api_handlers_retention.c
@@ -19,6 +19,19 @@
 #include "database/db_streams.h"
 #include "database/db_recordings.h"
 
+static int authorize_recording_action(const http_request_t *req,
+                                      http_response_t *res, uint64_t id,
+                                      authorization_action_t action,
+                                      recording_metadata_t *recording) {
+    memset(recording, 0, sizeof(*recording));
+    if (get_recording_metadata_by_id(id, recording) != 0) {
+        http_response_set_json_error(res, 404, "Recording not found");
+        return 0;
+    }
+    return httpd_authorize_stream_action(req, res, action,
+                                         recording->stream_name);
+}
+
 /**
  * @brief Handler for GET /api/streams/:name/retention
  * Get retention configuration for a stream
@@ -196,6 +209,12 @@ void handle_put_recording_protect(const http_request_t *req, http_response_t *re
     bool protected = cJSON_IsTrue(protected_json);
     cJSON_Delete(json);
 
+    recording_metadata_t recording;
+    if (!authorize_recording_action(req, res, id, AUTHZ_EVIDENCE_PROTECT,
+                                    &recording)) {
+        return;
+    }
+
     // Update protection status
     if (set_recording_protected(id, protected) != 0) {
         http_response_set_json_error(res, 500, "Failed to update recording protection status");
@@ -261,6 +280,12 @@ void handle_put_recording_retention(const http_request_t *req, http_response_t *
 
     int days = days_json->valueint;
     cJSON_Delete(json);
+
+    recording_metadata_t recording;
+    if (!authorize_recording_action(req, res, id, AUTHZ_EVIDENCE_PROTECT,
+                                    &recording)) {
+        return;
+    }
 
     // Update retention override
     if (set_recording_retention_override(id, days) != 0) {
@@ -350,24 +375,65 @@ void handle_batch_protect_recordings(const http_request_t *req, http_response_t 
     }
 
     bool protected = cJSON_IsTrue(protected_json);
-    int success_count = 0;
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        cJSON_Delete(json);
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return;
+    }
+
+    int item_count = cJSON_GetArraySize(ids_json);
+    uint64_t *authorized_ids = item_count > 0
+        ? calloc((size_t)item_count, sizeof(*authorized_ids)) : NULL;
+    if (item_count > 0 && !authorized_ids) {
+        cJSON_Delete(json);
+        http_response_set_json_error(res, 500, "Failed to authorize batch");
+        return;
+    }
+    int authorized_count = 0;
     int fail_count = 0;
 
-    // Process each ID
+    // Resolve and authorize every fixed member before mutating any recording.
     cJSON *id_item;
     cJSON_ArrayForEach(id_item, ids_json) {
-        if (cJSON_IsNumber(id_item)) {
-            uint64_t id = (uint64_t)id_item->valuedouble;
-            if (set_recording_protected(id, protected) == 0) {
-                success_count++;
-            } else {
-                fail_count++;
-            }
+        if (!cJSON_IsNumber(id_item) || id_item->valuedouble <= 0) {
+            fail_count++;
+            continue;
+        }
+        uint64_t id = (uint64_t)id_item->valuedouble;
+        recording_metadata_t recording;
+        if (get_recording_metadata_by_id(id, &recording) != 0) {
+            fail_count++;
+            continue;
+        }
+        authorization_evaluation_t evaluation;
+        int result = httpd_evaluate_stream_action(
+            &user, AUTHZ_EVIDENCE_PROTECT, recording.stream_name,
+            &evaluation);
+        if (result < 0) {
+            free(authorized_ids);
+            cJSON_Delete(json);
+            http_response_set_json_error(
+                res, 500, "Authorization policy evaluation failed");
+            return;
+        }
+        if (result > 0 || evaluation.decision != AUTHZ_DECISION_ALLOW) {
+            fail_count++;
+            continue;
+        }
+        authorized_ids[authorized_count++] = id;
+    }
+
+    int success_count = 0;
+    for (int i = 0; i < authorized_count; i++) {
+        if (set_recording_protected(authorized_ids[i], protected) == 0) {
+            success_count++;
         } else {
             fail_count++;
         }
     }
 
+    free(authorized_ids);
     cJSON_Delete(json);
 
     // Return response

--- a/src/web/httpd_utils.c
+++ b/src/web/httpd_utils.c
@@ -16,6 +16,7 @@
 #include "core/config.h"
 #include "utils/strings.h"
 #include "database/db_auth.h"
+#include "database/db_fleet_query.h"
 
 cJSON* httpd_parse_json_body(const http_request_t *req) {
     if (!req || !req->body || req->body_len == 0) {
@@ -496,6 +497,51 @@ int httpd_authorize_action(const http_request_t *req, http_response_t *res,
     if (evaluation->decision != AUTHZ_DECISION_ALLOW) {
         log_warn("Access denied: User '%s' action %d: %s", user->username,
                  (int)action, evaluation->explanation);
+        http_response_set_json_error(res, 403, "Forbidden");
+        return 0;
+    }
+    return 1;
+}
+
+int httpd_evaluate_stream_action(const user_t *user,
+                                 authorization_action_t action,
+                                 const char *stream_name,
+                                 authorization_evaluation_t *evaluation) {
+    if (!user || !stream_name || !evaluation) return -1;
+    fleet_camera_t camera;
+    memset(&camera, 0, sizeof(camera));
+    int result = db_fleet_camera_find_by_name(stream_name, &camera);
+    if (result != 0) return result;
+    return authorization_evaluate(user, action, &camera, evaluation);
+}
+
+int httpd_authorize_stream_action(const http_request_t *req,
+                                  http_response_t *res,
+                                  authorization_action_t action,
+                                  const char *stream_name) {
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return 0;
+    }
+    authorization_evaluation_t evaluation;
+    int result = httpd_evaluate_stream_action(&user, action, stream_name,
+                                               &evaluation);
+    if (result > 0) {
+        http_response_set_json_error(res, 404, "Camera not found");
+        return 0;
+    }
+    if (result < 0) {
+        log_error("Failed to evaluate authorization for stream '%s'",
+                  stream_name);
+        http_response_set_json_error(
+            res, 500, "Authorization policy evaluation failed");
+        return 0;
+    }
+    if (evaluation.decision != AUTHZ_DECISION_ALLOW) {
+        log_warn("Access denied: User '%s' action %d on stream '%s': %s",
+                 user.username, (int)action, stream_name,
+                 evaluation.explanation);
         http_response_set_json_error(res, 403, "Forbidden");
         return 0;
     }

--- a/tests/unit/test_authorization.c
+++ b/tests/unit/test_authorization.c
@@ -21,9 +21,13 @@
 #include "database/db_camera_tags.h"
 #include "database/db_core.h"
 #include "database/db_fleet_query.h"
+#include "database/db_recordings.h"
 #include "database/db_streams.h"
 #include "utils/strings.h"
+#include "web/api_handlers.h"
 #include "web/api_handlers_authorization.h"
+#include "web/api_handlers_ptz.h"
+#include "web/api_handlers_recordings.h"
 #include "web/api_handlers_users.h"
 #include "web/request_response.h"
 
@@ -153,6 +157,7 @@ void setUp(void) {
     sqlite3_exec(db, "DELETE FROM authz_grants;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM authz_roles WHERE is_builtin=0;", NULL, NULL,
                  NULL);
+    sqlite3_exec(db, "DELETE FROM recordings;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM streams;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM camera_tags;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM users WHERE username != 'admin';",
@@ -714,6 +719,122 @@ void test_users_api_reports_authorization_mode(void) {
     cJSON_Delete(json);
 }
 
+void test_sensitive_handlers_enforce_camera_scoped_policy(void) {
+    stream_config_t allowed = create_camera("Scoped Camera", "Outdoor");
+    stream_config_t denied = create_camera("Other Camera", "Indoor");
+    allowed.ptz_enabled = true;
+    denied.ptz_enabled = true;
+    TEST_ASSERT_EQUAL_INT(0, update_stream_config(allowed.name, &allowed));
+    TEST_ASSERT_EQUAL_INT(0, update_stream_config(denied.name, &denied));
+
+    fleet_camera_t resolved;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_fleet_camera_find_by_name(allowed.name, &resolved));
+    TEST_ASSERT_EQUAL_STRING(allowed.camera_uuid, resolved.camera_uuid);
+    TEST_ASSERT_EQUAL_INT(
+        1, db_fleet_camera_find_by_name("Missing Camera", &resolved));
+
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("scopedoperator", "password123", NULL,
+                               USER_ROLE_VIEWER, true, &user_id));
+    TEST_ASSERT_EQUAL_INT(
+        0, db_authorization_set_user_mode(user_id, "policy"));
+    char selector[512];
+    snprintf(selector, sizeof(selector),
+             "{\"version\":1,\"expression\":{\"op\":\"camera_uuid\","
+             "\"values\":[\"%s\"]}}",
+             allowed.camera_uuid);
+    char grant_uuid[CAMERA_UUID_STRING_SIZE];
+    create_grant(user_id, OPERATOR_ROLE_UUID, "selector", selector,
+                 grant_uuid);
+    char api_key[128] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_generate_api_key(user_id, api_key, sizeof(api_key)));
+
+    recording_metadata_t allowed_recording;
+    memset(&allowed_recording, 0, sizeof(allowed_recording));
+    safe_strcpy(allowed_recording.stream_name, allowed.name,
+                sizeof(allowed_recording.stream_name), 0);
+    safe_strcpy(allowed_recording.file_path, "/tmp/lightnvr-scoped-recording.mp4",
+                sizeof(allowed_recording.file_path), 0);
+    allowed_recording.start_time = 100;
+    allowed_recording.end_time = 200;
+    allowed_recording.is_complete = true;
+    allowed_recording.retention_override_days = -1;
+    uint64_t allowed_id = add_recording_metadata(&allowed_recording);
+    TEST_ASSERT_NOT_EQUAL(0, allowed_id);
+
+    recording_metadata_t denied_recording = allowed_recording;
+    safe_strcpy(denied_recording.stream_name, denied.name,
+                sizeof(denied_recording.stream_name), 0);
+    safe_strcpy(denied_recording.file_path, "/tmp/lightnvr-denied-recording.mp4",
+                sizeof(denied_recording.file_path), 0);
+    uint64_t denied_id = add_recording_metadata(&denied_recording);
+    TEST_ASSERT_NOT_EQUAL(0, denied_id);
+
+    char path[128];
+    snprintf(path, sizeof(path), "/api/recordings/%llu/protect",
+             (unsigned long long)allowed_id);
+    g_config.web_auth_enabled = true;
+    cJSON *json = call_handler_path(
+        handle_put_recording_protect, HTTP_METHOD_PUT, path,
+        "{\"protected\":true}", api_key, 200);
+    cJSON_Delete(json);
+    recording_metadata_t reloaded;
+    TEST_ASSERT_EQUAL_INT(
+        0, get_recording_metadata_by_id(allowed_id, &reloaded));
+    TEST_ASSERT_TRUE(reloaded.protected);
+
+    snprintf(path, sizeof(path), "/api/recordings/%llu/protect",
+             (unsigned long long)denied_id);
+    json = call_handler_path(handle_put_recording_protect, HTTP_METHOD_PUT,
+                             path, "{\"protected\":true}", api_key, 403);
+    cJSON_Delete(json);
+    TEST_ASSERT_EQUAL_INT(
+        0, get_recording_metadata_by_id(denied_id, &reloaded));
+    TEST_ASSERT_FALSE(reloaded.protected);
+
+    char batch_body[256];
+    snprintf(batch_body, sizeof(batch_body),
+             "{\"ids\":[%llu,%llu],\"protected\":false}",
+             (unsigned long long)allowed_id,
+             (unsigned long long)denied_id);
+    json = call_handler_path(handle_batch_protect_recordings,
+                             HTTP_METHOD_POST,
+                             "/api/recordings/batch-protect", batch_body,
+                             api_key, 200);
+    TEST_ASSERT_EQUAL_INT(
+        1, cJSON_GetObjectItemCaseSensitive(json, "success_count")->valueint);
+    TEST_ASSERT_EQUAL_INT(
+        1, cJSON_GetObjectItemCaseSensitive(json, "fail_count")->valueint);
+    cJSON_Delete(json);
+
+    char ptz_path[MAX_STREAM_NAME + 64];
+    snprintf(ptz_path, sizeof(ptz_path), "/api/streams/%s/ptz/move",
+             denied.name);
+    json = call_handler_path(handle_ptz_move, HTTP_METHOD_POST, ptz_path,
+                             "{\"pan\":1}", api_key, 403);
+    cJSON_Delete(json);
+
+    snprintf(path, sizeof(path), "/api/recordings/%llu",
+             (unsigned long long)denied_id);
+    json = call_handler_path(handle_delete_recording, HTTP_METHOD_DELETE,
+                             path, NULL, api_key, 403);
+    cJSON_Delete(json);
+    TEST_ASSERT_EQUAL_INT(
+        0, get_recording_metadata_by_id(denied_id, &reloaded));
+
+    snprintf(path, sizeof(path), "/api/recordings/%llu",
+             (unsigned long long)allowed_id);
+    json = call_handler_path(handle_delete_recording, HTTP_METHOD_DELETE,
+                             path, NULL, api_key, 200);
+    cJSON_Delete(json);
+    TEST_ASSERT_NOT_EQUAL(
+        0, get_recording_metadata_by_id(allowed_id, &reloaded));
+    g_config.web_auth_enabled = false;
+}
+
 int main(void) {
     unlink(TEST_DB_PATH);
     if (init_database(TEST_DB_PATH) != 0) {
@@ -737,6 +858,7 @@ int main(void) {
     RUN_TEST(test_policy_management_handlers_and_conflict_guards);
     RUN_TEST(test_policy_role_update_cannot_lock_out_requester);
     RUN_TEST(test_users_api_reports_authorization_mode);
+    RUN_TEST(test_sensitive_handlers_enforce_camera_scoped_policy);
     int result = UNITY_END();
     shutdown_database();
     unlink(TEST_DB_PATH);


### PR DESCRIPTION
## Summary

- resolve stream names and recording IDs to immutable server-owned camera resources before policy evaluation
- enforce live.view on PTZ capability/preset reads and ptz.control on all PTZ mutations
- enforce evidence.protect on recording protection, retention overrides, and mixed-member batch protection
- enforce recording.delete on single, file, and batch deletion; fixed batches reject unauthorized members individually and open-ended filters require sufficient server-resolved scope
- retain legacy-role compatibility while making policy mode default-deny operational on high-risk endpoints

## Verification

- production lightnvr build
- test_authorization (11/11), including direct handler allow/deny coverage across two cameras
- test_api_handlers_fleet
- test_db_recordings_extended
- test_httpd_utils

## Stack

Depends on #511.