### PR TITLE
feat(auth): enforce scoped recording exports

### DIFF
--- a/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
+++ b/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
@@ -31,7 +31,7 @@ must be reachable before a policy can be evaluated.
 | `GET /api/fleet/*`, collection reads/previews, camera tag/location reads | `live.view` per returned camera | Existing viewer access plus allowed tags |
 | `GET /hls/#/#`, go2rtc HLS/stream proxy reads | `live.view` | Existing authentication/proxy checks |
 | Camera audio playback | `audio.listen` | Transport-specific existing checks |
-| Camera backchannel/talk activation | `audio.talk` | Existing non-viewer checks |
+| Camera backchannel/talk activation | `audio.talk` | Transport gap: browser WebRTC connects directly to unauthenticated go2rtc; enforce with a tokenized or lightNVR-proxied signaling path before enabling policy-mode talk |
 | PTZ capability/preset reads | `live.view` | Centralized action policy with server-resolved camera scope |
 | PTZ move, stop, home, absolute, relative, and preset writes | `ptz.control` | Centralized action policy with server-resolved camera scope |
 | Imaging/day-night reads | `live.view` | Existing stream access checks |
@@ -65,7 +65,7 @@ facets, or collection membership. A request for one unauthorized camera returns
 | --- | --- | --- |
 | Recording lists/details, timeline segments/manifest/play, thumbnails | `recordings.replay` | Existing viewer access plus stream tags |
 | Recording playback and HLS media | `recordings.replay` | Existing viewer access plus stream tags |
-| Recording download and batch-download lifecycle | `recordings.export` | Existing viewer access plus stream tags |
+| Recording download and batch-download lifecycle | `recordings.export` | Centralized action policy; fixed batches are authorized in full and job status/results are bound to the creating user |
 | Snapshot creation/download | `snapshot.create` | Existing viewer access plus stream tags |
 | go2rtc frame capture proxy | `snapshot.create` | Existing proxy checks |
 | Protect/unprotect and retention overrides | `evidence.protect` | Centralized action policy; batch members are resolved and evaluated individually |

--- a/include/web/httpd_utils.h
+++ b/include/web/httpd_utils.h
@@ -152,6 +152,10 @@ int httpd_evaluate_stream_action(const user_t *user,
                                  const char *stream_name,
                                  authorization_evaluation_t *evaluation);
 
+/** Copy a basename into an HTTP attachment-safe ASCII filename. */
+void httpd_sanitize_attachment_filename(const char *input, char *output,
+                                        size_t output_size);
+
 /**
  * @brief Check if demo mode is enabled
  * @return 1 if demo mode is enabled, 0 otherwise

--- a/src/web/api_handlers_recordings_batch_download.c
+++ b/src/web/api_handlers_recordings_batch_download.c
@@ -25,10 +25,8 @@
 #include "web/httpd_utils.h"
 #define LOG_COMPONENT "RecordingsAPI"
 #include "core/logger.h"
-#include "core/config.h"
 #include "utils/strings.h"
 #include "database/db_recordings.h"
-#include "database/db_auth.h"
 
 /* ─── ZIP primitives ─────────────────────────────────────────────────── */
 
@@ -139,12 +137,15 @@ static uint64_t zip_copy_file(FILE *zip, const char *path) {
 #define MAX_BATCH_DL_JOBS   8
 #define MAX_DL_IDS         200
 #define JOB_DL_RETENTION   600
+#define DOWNLOAD_FILENAME_MAX 192
 
 typedef enum { DL_PENDING=0, DL_RUNNING, DL_COMPLETE, DL_ERROR } dl_status_t;
 
 typedef struct {
     char        job_id[64];
-    char        zip_filename[MAX_PATH_LENGTH];
+    int64_t     owner_user_id;
+    char        owner_username[64];
+    char        zip_filename[DOWNLOAD_FILENAME_MAX];
     char        tmp_path[MAX_PATH_LENGTH];
     uint64_t    ids[MAX_DL_IDS];
     int         id_count;
@@ -167,17 +168,21 @@ static void dl_jobs_init(void) {
     s_dl_inited = true;
 }
 
-static void gen_uuid(char *out) {
+static bool gen_uuid(char *out) {
     uint8_t b[16];
-    if (getrandom(b, 16, 0) < 0) {
+    if (getrandom(b, sizeof(b), 0) != (ssize_t)sizeof(b)) {
         FILE *f = fopen("/dev/urandom", "rb");
-        if (f) { (void)fread(b, 1, 16, f); fclose(f); }
+        if (!f) return false;
+        size_t bytes_read = fread(b, 1, sizeof(b), f);
+        fclose(f);
+        if (bytes_read != sizeof(b)) return false;
     }
     b[6]=(b[6]&0x0F)|0x40; b[8]=(b[8]&0x3F)|0x80;
     snprintf(out,37,
         "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
         b[0],b[1],b[2],b[3],b[4],b[5],b[6],b[7],
         b[8],b[9],b[10],b[11],b[12],b[13],b[14],b[15]);
+    return true;
 }
 
 static int find_dl_slot(void) {
@@ -201,6 +206,23 @@ static int find_dl_job(const char *jid) {
     for (int i=0;i<MAX_BATCH_DL_JOBS;i++)
         if (s_dl_jobs[i].is_active && strcmp(s_dl_jobs[i].job_id,jid)==0) return i;
     return -1;
+}
+
+static bool dl_job_owned_by(const batch_dl_job_t *job, const user_t *user) {
+    return job && user && job->owner_user_id == user->id &&
+           strcmp(job->owner_username, user->username) == 0;
+}
+
+static void discard_dl_job(const char *job_id) {
+    pthread_mutex_lock(&s_dl_mutex);
+    int slot = find_dl_job(job_id);
+    if (slot >= 0) {
+        if (s_dl_jobs[slot].tmp_path[0] != '\0') {
+            unlink(s_dl_jobs[slot].tmp_path);
+        }
+        memset(&s_dl_jobs[slot], 0, sizeof(s_dl_jobs[slot]));
+    }
+    pthread_mutex_unlock(&s_dl_mutex);
 }
 
 
@@ -334,13 +356,10 @@ static void *zip_worker(void *arg) {
  * Returns: { "token": "uuid", "total": N }
  */
 void handle_batch_download_recordings(const http_request_t *req, http_response_t *res) {
-    /* Auth check (viewer and above can download) */
-    if (g_config.web_auth_enabled) {
-        user_t user;
-        if (!httpd_check_viewer_access(req, &user)) {
-            http_response_set_json_error(res, 401, "Unauthorized");
-            return;
-        }
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return;
     }
 
     cJSON *json = httpd_parse_json_body(req);
@@ -364,6 +383,39 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
     cJSON *fn = cJSON_GetObjectItem(json, "filename");
     if (fn && cJSON_IsString(fn) && fn->valuestring[0]) filename_raw = fn->valuestring;
 
+    // Export batches are all-or-nothing: resolve and authorize every server
+    // recording before any background job can read files.
+    for (int i = 0; i < count; i++) {
+        cJSON *item = cJSON_GetArrayItem(ids_arr, i);
+        if (!cJSON_IsNumber(item) || item->valuedouble <= 0) {
+            cJSON_Delete(json);
+            http_response_set_json_error(res, 400, "Invalid recording ID");
+            return;
+        }
+        recording_metadata_t recording;
+        if (get_recording_metadata_by_id((uint64_t)item->valuedouble,
+                                         &recording) != 0) {
+            cJSON_Delete(json);
+            http_response_set_json_error(res, 404, "Recording not found");
+            return;
+        }
+        authorization_evaluation_t evaluation;
+        int result = httpd_evaluate_stream_action(
+            &user, AUTHZ_RECORDINGS_EXPORT, recording.stream_name,
+            &evaluation);
+        if (result < 0) {
+            cJSON_Delete(json);
+            http_response_set_json_error(
+                res, 500, "Authorization policy evaluation failed");
+            return;
+        }
+        if (result > 0 || evaluation.decision != AUTHZ_DECISION_ALLOW) {
+            cJSON_Delete(json);
+            http_response_set_json_error(res, 403, "Forbidden");
+            return;
+        }
+    }
+
     pthread_mutex_lock(&s_dl_mutex);
     dl_jobs_init();
     int slot = find_dl_slot();
@@ -376,8 +428,22 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
 
     batch_dl_job_t *job = &s_dl_jobs[slot];
     memset(job, 0, sizeof(*job));
-    gen_uuid(job->job_id);
-    safe_strcpy(job->zip_filename, filename_raw, sizeof(job->zip_filename), 0);
+    if (!gen_uuid(job->job_id)) {
+        pthread_mutex_unlock(&s_dl_mutex);
+        cJSON_Delete(json);
+        http_response_set_json_error(res, 500,
+                                     "Failed to create download token");
+        return;
+    }
+    job->owner_user_id = user.id;
+    safe_strcpy(job->owner_username, user.username,
+                sizeof(job->owner_username), 0);
+    httpd_sanitize_attachment_filename(filename_raw, job->zip_filename,
+                                       sizeof(job->zip_filename));
+    if (job->zip_filename[0] == '\0') {
+        safe_strcpy(job->zip_filename, "recordings.zip",
+                    sizeof(job->zip_filename), 0);
+    }
     job->id_count = count;
     job->total    = count;
     job->status   = DL_PENDING;
@@ -396,7 +462,11 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
 
     /* Spawn worker thread */
     dl_thread_arg_t *targ = malloc(sizeof(dl_thread_arg_t));
-    if (!targ) { http_response_set_json_error(res, 500, "Out of memory"); return; }
+    if (!targ) {
+        discard_dl_job(job_id);
+        http_response_set_json_error(res, 500, "Out of memory");
+        return;
+    }
     safe_strcpy(targ->job_id, job_id, sizeof(targ->job_id), 0);
 
     pthread_t tid;
@@ -406,6 +476,7 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
     if (pthread_create(&tid, &attr, zip_worker, targ) != 0) {
         pthread_attr_destroy(&attr);
         free(targ);
+        discard_dl_job(job_id);
         http_response_set_json_error(res, 500, "Failed to start ZIP worker");
         return;
     }
@@ -422,12 +493,10 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
  * Returns: { "status": "pending|running|complete|error", "current": N, "total": N, "error": "..." }
  */
 void handle_batch_download_status(const http_request_t *req, http_response_t *res) {
-    if (g_config.web_auth_enabled) {
-        user_t user;
-        if (!httpd_check_viewer_access(req, &user)) {
-            http_response_set_json_error(res, 401, "Unauthorized");
-            return;
-        }
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return;
     }
 
     char token[64] = {0};
@@ -437,7 +506,7 @@ void handle_batch_download_status(const http_request_t *req, http_response_t *re
 
     pthread_mutex_lock(&s_dl_mutex);
     int slot = find_dl_job(token);
-    if (slot < 0) {
+    if (slot < 0 || !dl_job_owned_by(&s_dl_jobs[slot], &user)) {
         pthread_mutex_unlock(&s_dl_mutex);
         http_response_set_json_error(res, 404, "Job not found");
         return;
@@ -459,15 +528,14 @@ void handle_batch_download_status(const http_request_t *req, http_response_t *re
 
 /**
  * GET /api/recordings/batch-download/result/{token}
- * Streams the ZIP file and deletes the temp file afterwards.
+ * Streams the ZIP file. The retained job owns the temp file until the bounded
+ * recycling window expires, which lets libuv open it asynchronously.
  */
 void handle_batch_download_result(const http_request_t *req, http_response_t *res) {
-    if (g_config.web_auth_enabled) {
-        user_t user;
-        if (!httpd_check_viewer_access(req, &user)) {
-            http_response_set_json_error(res, 401, "Unauthorized");
-            return;
-        }
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return;
     }
 
     char token[64] = {0};
@@ -477,7 +545,7 @@ void handle_batch_download_result(const http_request_t *req, http_response_t *re
 
     pthread_mutex_lock(&s_dl_mutex);
     int slot = find_dl_job(token);
-    if (slot < 0) {
+    if (slot < 0 || !dl_job_owned_by(&s_dl_jobs[slot], &user)) {
         pthread_mutex_unlock(&s_dl_mutex);
         http_response_set_json_error(res, 404, "Job not found");
         return;
@@ -490,19 +558,13 @@ void handle_batch_download_result(const http_request_t *req, http_response_t *re
         return;
     }
     char tmp_path[MAX_PATH_LENGTH];
-    char zip_filename[MAX_PATH_LENGTH];
+    char zip_filename[DOWNLOAD_FILENAME_MAX];
     safe_strcpy(tmp_path,     s_dl_jobs[slot].tmp_path,     sizeof(tmp_path), 0);
     safe_strcpy(zip_filename, s_dl_jobs[slot].zip_filename, sizeof(zip_filename), 0);
-    /*
-     * Mark the slot as inactive so it can be reused, but do NOT unlink the
-     * temp file here.  http_serve_file() uses libuv async I/O: it queues a
-     * uv_fs_open() and returns immediately.  If we unlink before that open
-     * completes the path no longer exists and the client gets a 404.
-     * The temp file is cleaned up lazily when find_dl_slot() recycles this
-     * slot after JOB_DL_RETENTION seconds.
-     */
-    s_dl_jobs[slot].is_active  = false;
-    s_dl_jobs[slot].updated_at = time(NULL);   /* reset retention timer */
+    /* Keep the completed slot active while libuv opens the file
+     * asynchronously. find_dl_slot() recycles it after the retention window
+     * and removes the temp file before reusing the slot. */
+    s_dl_jobs[slot].updated_at = time(NULL);
     pthread_mutex_unlock(&s_dl_mutex);
 
     /* Build Content-Disposition header */
@@ -514,6 +576,13 @@ void handle_batch_download_result(const http_request_t *req, http_response_t *re
         http_response_set_json_error(res, 500, "Failed to serve ZIP file");
         /* Safe to unlink here because http_serve_file failed before opening */
         unlink(tmp_path);
+        pthread_mutex_lock(&s_dl_mutex);
+        slot = find_dl_job(token);
+        if (slot >= 0) {
+            s_dl_jobs[slot].tmp_path[0] = '\0';
+            s_dl_jobs[slot].is_active = false;
+        }
+        pthread_mutex_unlock(&s_dl_mutex);
         return;
     }
     log_info("Serving batch download ZIP: %s -> %s", token, zip_filename);

--- a/src/web/api_handlers_recordings_download.c
+++ b/src/web/api_handlers_recordings_download.c
@@ -13,9 +13,9 @@
 #include "web/httpd_utils.h"
 #define LOG_COMPONENT "RecordingsAPI"
 #include "core/logger.h"
-#include "core/config.h"
 #include "database/database_manager.h"
 #include "database/db_recordings.h"
+#include "utils/strings.h"
 
 /**
  * @brief Backend-agnostic handler for GET /api/recordings/download/:id
@@ -28,23 +28,11 @@ void handle_recordings_download(const http_request_t *req, http_response_t *res)
         return;
     }
 
-    // Check authentication if enabled
-    // In demo mode, allow unauthenticated viewer access to download recordings
-    if (g_config.web_auth_enabled) {
-        user_t user;
-        if (g_config.demo_mode) {
-            if (!httpd_check_viewer_access(req, &user)) {
-                log_error("Authentication failed for GET /api/recordings/download request");
-                http_response_set_json_error(res, 401, "Unauthorized");
-                return;
-            }
-        } else {
-            if (!httpd_get_authenticated_user(req, &user)) {
-                log_error("Authentication failed for GET /api/recordings/download request");
-                http_response_set_json_error(res, 401, "Unauthorized");
-                return;
-            }
-        }
+    user_t user;
+    if (!httpd_check_viewer_access(req, &user)) {
+        log_error("Authentication failed for GET /api/recordings/download request");
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return;
     }
 
     // Extract recording ID from URL
@@ -72,6 +60,19 @@ void handle_recordings_download(const http_request_t *req, http_response_t *res)
         http_response_set_json_error(res, 404, "Recording not found");
         return;
     }
+    authorization_evaluation_t evaluation;
+    int authorization_result = httpd_evaluate_stream_action(
+        &user, AUTHZ_RECORDINGS_EXPORT, recording.stream_name, &evaluation);
+    if (authorization_result < 0) {
+        http_response_set_json_error(
+            res, 500, "Authorization policy evaluation failed");
+        return;
+    }
+    if (authorization_result > 0 ||
+        evaluation.decision != AUTHZ_DECISION_ALLOW) {
+        http_response_set_json_error(res, 403, "Forbidden");
+        return;
+    }
 
     // Check if file exists
     struct stat st;
@@ -82,12 +83,11 @@ void handle_recordings_download(const http_request_t *req, http_response_t *res)
     }
 
     // Extract filename from path
-    const char *filename = strrchr(recording.file_path, '/');
-    if (filename) {
-        filename++; // Skip the '/'
-    } else {
-        filename = recording.file_path;
-    }
+    char filename[192];
+    httpd_sanitize_attachment_filename(recording.file_path, filename,
+                                       sizeof(filename));
+    if (filename[0] == '\0') safe_strcpy(filename, "recording.mp4",
+                                          sizeof(filename), 0);
 
     // Determine content type based on file extension
     const char *content_type = "video/mp4"; // Default
@@ -121,4 +121,3 @@ void handle_recordings_download(const http_request_t *req, http_response_t *res)
 
     log_info("Successfully handled GET /api/recordings/download/%llu request", (unsigned long long)id);
 }
-

--- a/src/web/httpd_utils.c
+++ b/src/web/httpd_utils.c
@@ -547,3 +547,23 @@ int httpd_authorize_stream_action(const http_request_t *req,
     }
     return 1;
 }
+
+void httpd_sanitize_attachment_filename(const char *input, char *output,
+                                        size_t output_size) {
+    if (!output || output_size == 0) return;
+    output[0] = '\0';
+    if (!input) return;
+    const char *basename = input;
+    for (const char *cursor = input; *cursor; cursor++) {
+        if (*cursor == '/' || *cursor == '\\') basename = cursor + 1;
+    }
+    size_t written = 0;
+    for (const unsigned char *cursor = (const unsigned char *)basename;
+         *cursor && written + 1 < output_size; cursor++) {
+        unsigned char character = *cursor;
+        output[written++] = (isalnum(character) || character == '.' ||
+                             character == '-' || character == '_')
+            ? (char)character : '_';
+    }
+    output[written] = '\0';
+}

--- a/tests/unit/test_authorization.c
+++ b/tests/unit/test_authorization.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "unity.h"
@@ -28,6 +29,8 @@
 #include "web/api_handlers_authorization.h"
 #include "web/api_handlers_ptz.h"
 #include "web/api_handlers_recordings.h"
+#include "web/api_handlers_recordings_batch_download.h"
+#include "web/api_handlers_recordings_download.h"
 #include "web/api_handlers_users.h"
 #include "web/request_response.h"
 
@@ -815,6 +818,74 @@ void test_sensitive_handlers_enforce_camera_scoped_policy(void) {
              denied.name);
     json = call_handler_path(handle_ptz_move, HTTP_METHOD_POST, ptz_path,
                              "{\"pan\":1}", api_key, 403);
+    cJSON_Delete(json);
+
+    snprintf(path, sizeof(path), "/api/recordings/download/%llu",
+             (unsigned long long)denied_id);
+    json = call_handler_path(handle_recordings_download, HTTP_METHOD_GET,
+                             path, NULL, api_key, 403);
+    cJSON_Delete(json);
+
+    snprintf(batch_body, sizeof(batch_body),
+             "{\"ids\":[%llu,%llu],\"filename\":\"evidence.zip\"}",
+             (unsigned long long)allowed_id,
+             (unsigned long long)denied_id);
+    json = call_handler_path(handle_batch_download_recordings,
+                             HTTP_METHOD_POST,
+                             "/api/recordings/batch-download", batch_body,
+                             api_key, 403);
+    cJSON_Delete(json);
+
+    snprintf(batch_body, sizeof(batch_body),
+             "{\"ids\":[%llu],\"filename\":\"allowed.zip\"}",
+             (unsigned long long)allowed_id);
+    json = call_handler_path(handle_batch_download_recordings,
+                             HTTP_METHOD_POST,
+                             "/api/recordings/batch-download", batch_body,
+                             api_key, 202);
+    char download_token[64];
+    safe_strcpy(
+        download_token,
+        cJSON_GetObjectItemCaseSensitive(json, "token")->valuestring,
+        sizeof(download_token), 0);
+    cJSON_Delete(json);
+
+    int64_t other_user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("otherexporter", "password123", NULL,
+                               USER_ROLE_VIEWER, true, &other_user_id));
+    char other_api_key[128] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_generate_api_key(other_user_id, other_api_key,
+                                    sizeof(other_api_key)));
+    char status_path[160];
+    snprintf(status_path, sizeof(status_path),
+             "/api/recordings/batch-download/status/%s", download_token);
+    json = call_handler_path(handle_batch_download_status, HTTP_METHOD_GET,
+                             status_path, NULL, other_api_key, 404);
+    cJSON_Delete(json);
+
+    bool download_finished = false;
+    for (int attempt = 0; attempt < 100 && !download_finished; attempt++) {
+        json = call_handler_path(handle_batch_download_status,
+                                 HTTP_METHOD_GET, status_path, NULL, api_key,
+                                 200);
+        const char *status = cJSON_GetObjectItemCaseSensitive(
+            json, "status")->valuestring;
+        download_finished = strcmp(status, "complete") == 0 ||
+                            strcmp(status, "error") == 0;
+        cJSON_Delete(json);
+        if (!download_finished) {
+            const struct timespec delay = {.tv_sec = 0,
+                                           .tv_nsec = 1000000};
+            nanosleep(&delay, NULL);
+        }
+    }
+    TEST_ASSERT_TRUE(download_finished);
+    snprintf(status_path, sizeof(status_path),
+             "/api/recordings/batch-download/result/%s", download_token);
+    json = call_handler_path(handle_batch_download_result, HTTP_METHOD_GET,
+                             status_path, NULL, api_key, 500);
     cJSON_Delete(json);
 
     snprintf(path, sizeof(path), "/api/recordings/%llu",

--- a/tests/unit/test_httpd_utils.c
+++ b/tests/unit/test_httpd_utils.c
@@ -549,6 +549,17 @@ void test_check_admin_privileges_no_auth_returns_zero(void) {
     http_response_free(&res);
 }
 
+void test_sanitize_attachment_filename_removes_path_and_header_bytes(void) {
+    char filename[64];
+    httpd_sanitize_attachment_filename(
+        "/recordings/front door\"\r\nInjected: yes.mp4", filename,
+        sizeof(filename));
+    TEST_ASSERT_EQUAL_STRING("front_door___Injected__yes.mp4", filename);
+
+    httpd_sanitize_attachment_filename(NULL, filename, sizeof(filename));
+    TEST_ASSERT_EQUAL_STRING("", filename);
+}
+
 /* ================================================================
  * main
  * ================================================================ */
@@ -593,9 +604,9 @@ int main(void) {
     RUN_TEST(test_get_authenticated_user_rejects_api_key_with_spoofed_forwarded_ip_from_untrusted_proxy);
     RUN_TEST(test_check_admin_privileges_auth_disabled_returns_one);
     RUN_TEST(test_check_admin_privileges_no_auth_returns_zero);
+    RUN_TEST(test_sanitize_attachment_filename_removes_path_and_header_bytes);
     int result = UNITY_END();
     shutdown_database();
     unlink(TEST_DB_PATH);
     return result;
 }
-


### PR DESCRIPTION
## Summary

- enforce recordings.export on single recording downloads using the recording owner camera resolved by the server
- preflight every member of a ZIP export and reject the whole request when any member is missing, malformed, or outside the requester scope
- bind batch export status and result tokens to the user who created the job
- generate job tokens with checked OS randomness and reclaim failed job setup
- retain completed ZIP jobs through the libuv asynchronous-open window and clean failed temp files correctly
- sanitize attachment filenames before constructing Content-Disposition headers
- document the separate WebRTC/go2rtc transport dependency required for enforceable audio.talk policy

## Verification

- production lightnvr build
- test_authorization (11/11), including scoped single/batch export denial and cross-user job token isolation
- test_httpd_utils (35/35), including attachment filename sanitization

## Stack

Depends on #512.