### PR TITLE
feat(auth): add scoped API tokens

### DIFF
--- a/db/migrations/0054_add_scoped_api_tokens.sql
+++ b/db/migrations/0054_add_scoped_api_tokens.sql
@@ -1,0 +1,42 @@
+-- Hashed, expiring API tokens that narrow their issuing user's authorization.
+
+-- migrate:up
+
+CREATE TABLE authz_api_tokens (
+    uuid TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    description TEXT NOT NULL,
+    token_prefix TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    action_mask INTEGER NOT NULL CHECK (action_mask > 0),
+    scope_type TEXT NOT NULL
+        CHECK (scope_type IN ('all', 'selector', 'collection')),
+    selector_json TEXT,
+    collection_uuid TEXT
+        REFERENCES camera_collections(uuid) ON DELETE RESTRICT,
+    expires_at INTEGER NOT NULL,
+    revoked_at INTEGER,
+    last_used_at INTEGER,
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    CHECK (
+        (scope_type = 'all' AND selector_json IS NULL AND collection_uuid IS NULL) OR
+        (scope_type = 'selector' AND selector_json IS NOT NULL AND collection_uuid IS NULL) OR
+        (scope_type = 'collection' AND selector_json IS NULL AND collection_uuid IS NOT NULL)
+    ),
+    CHECK (expires_at > created_at)
+);
+
+CREATE INDEX idx_authz_api_tokens_user
+ON authz_api_tokens(user_id, created_at DESC);
+
+CREATE INDEX idx_authz_api_tokens_active
+ON authz_api_tokens(token_hash, expires_at)
+WHERE revoked_at IS NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_authz_api_tokens_active;
+DROP INDEX IF EXISTS idx_authz_api_tokens_user;
+DROP TABLE IF EXISTS authz_api_tokens;
+SELECT 1;

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ curl -c cookies.txt -X POST -H "Content-Type: application/json" \
 curl -b cookies.txt http://your-lightnvr-ip:8080/api/streams
 ```
 
-### 2. API key (automation, long-lived integrations)
+### 2. Legacy API key (compatibility automation)
 
 Every user has an `api_key` field. Pass it via either header:
 
@@ -41,7 +41,9 @@ curl -H "Authorization: Bearer <your-api-key>" http://your-lightnvr-ip:8080/api/
 
 For automation (Home Assistant, NodeRED, cron jobs, etc.), create a dedicated
 user with the `USER_ROLE_API` role and use that user's `api_key`. Keep admin
-keys out of automation configs.
+keys out of automation configs. New integrations should use the expiring,
+action- and camera-scoped tokens described below. The single legacy key remains
+available during the endpoint-enforcement migration.
 
 ### 3. HTTP Basic Auth
 
@@ -192,6 +194,45 @@ anything. It also
 rejects an authenticated administrator's attempt to remove their own effective
 `users.manage` grant. Saving grants in `legacy` mode is supported so an
 administrator can prepare policy before activating default-deny evaluation.
+
+#### Manage scoped API tokens
+
+```
+GET    /api/authorization/users/{user_id}/tokens
+POST   /api/authorization/users/{user_id}/tokens
+DELETE /api/authorization/users/{user_id}/tokens/{token_uuid}
+```
+
+A user may manage their own tokens; a principal with `users.manage` may manage
+another user's. Token management itself requires a session, Basic auth, or a
+legacy API key—a scoped token cannot mint another token. `POST` requires a
+description, an explicit expiry no more than 366 days away, one or more action
+keys, and an all-fleet, selector, or shared-collection scope:
+
+```json
+{
+  "description": "North garage PTZ bridge",
+  "expires_at": 1819075200,
+  "actions": ["live.view", "ptz.control"],
+  "scope": {
+    "type": "collection",
+    "collection_uuid": "d813e24e-0c7a-48e7-960c-4f5b843466db"
+  }
+}
+```
+
+The `201` response contains the secret once as `secret` plus non-secret token
+metadata. lightNVR stores only its SHA-256 hash and a short display prefix.
+`GET` returns metadata, expiry, revocation, last-use time, actions, and scope but
+never the secret or hash. `DELETE` revokes rather than erases the token.
+
+Token authorization is the intersection of the token and its owning user's
+current effective access, so changing the user policy can only reduce what an
+existing token can do. During the incremental enforcement rollout, scoped
+tokens are accepted only by handlers that immediately invoke the central action
+evaluator (currently scoped PTZ, recording export, evidence protection, and
+deletion paths). Other legacy handlers reject them rather than risk ignoring a
+camera scope. The endpoint inventory tracks expansion of that safe surface.
 
 ## API Endpoints
 

--- a/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
+++ b/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
@@ -84,6 +84,7 @@ they may not trust a client-supplied collection expansion.
 | --- | --- | --- |
 | User list/create/get/update/delete, API-key generation, password lock and lockout clear | `users.manage` | Existing administrator/self-service rules |
 | Authorization action catalog, roles, user grants, and policy simulation | `users.manage` | Central evaluator with optimistic policy-version checks |
+| Scoped API token list/create/revoke | Self-service or `users.manage` | Hashed, expiring tokens; token-authenticated token chaining is rejected |
 | Settings reads containing secrets | `system.admin` | Existing administrator/redaction behavior |
 | Settings writes and go2rtc configuration validation | `system.admin` | Existing administrator checks |
 | System information/status/log reads | `system.admin` | Existing endpoint checks |
@@ -98,6 +99,13 @@ Shared static and smart collections may be referenced directly by grants. The
 evaluator resolves their current membership server-side; private collections
 are rejected, and referenced collections cannot be made private or deleted.
 Collection membership or selector changes increment the policy version.
+
+Scoped API tokens are accepted only through `httpd_check_action_access()` and
+must be followed by central action evaluation for every affected resource.
+Handlers still marked “Existing” use `httpd_check_viewer_access()` or legacy
+role checks and intentionally reject scoped tokens until migrated. Multi-step
+batch-download jobs additionally bind their status/result to the exact scoped
+token that created them, not only to the owning user.
 
 ## Enforcement rollout order
 

--- a/docs/prd/FLEET_02_Scoped_Authorization_Audit.md
+++ b/docs/prd/FLEET_02_Scoped_Authorization_Audit.md
@@ -1,6 +1,6 @@
 # PRD — Scoped Authorization & Audit
 
-**Status**: In progress — P0 foundation and initial P1 grants/UI implemented
+**Status**: In progress — P0 foundation and initial P1 grants/tokens implemented
 **Created**: 2026-08-22
 **Owner**: TBD
 **Priority**: 2 — access-control foundation

--- a/include/core/authorization.h
+++ b/include/core/authorization.h
@@ -57,6 +57,7 @@ typedef struct {
     authorization_decision_source_t source;
     int64_t policy_version;
     char grant_uuid[CAMERA_UUID_STRING_SIZE];
+    char token_uuid[CAMERA_UUID_STRING_SIZE];
     char role_uuid[CAMERA_UUID_STRING_SIZE];
     char role_name[128];
     char explanation[AUTHORIZATION_EXPLANATION_MAX];
@@ -73,6 +74,7 @@ const char *authorization_decision_source_name(
 /*
  * Evaluate one user/action/resource tuple. A NULL camera is valid for global
  * actions and for an all-fleet grant, but never matches a selector-backed grant.
+ * Scoped API tokens are intersected with the user's effective decision.
  * Returns 0 for an allow/deny decision and -1 for an evaluation failure. Callers
  * must fail closed when this function returns -1.
  */

--- a/include/database/db_api_tokens.h
+++ b/include/database/db_api_tokens.h
@@ -1,0 +1,69 @@
+#ifndef LIGHTNVR_DB_API_TOKENS_H
+#define LIGHTNVR_DB_API_TOKENS_H
+
+#include <stdint.h>
+
+#include "core/config.h"
+
+#define API_TOKEN_DESCRIPTION_MAX 128
+#define API_TOKEN_PREFIX_MAX 16
+#define API_TOKEN_SECRET_MAX 80
+#define API_TOKEN_SCOPE_TYPE_MAX 16
+#define API_TOKEN_SELECTOR_MAX 8192
+#define API_TOKEN_MAX_PER_USER 256
+#define API_TOKEN_MAX_LIFETIME_SECONDS (INT64_C(366) * 24 * 60 * 60)
+
+typedef enum {
+    DB_API_TOKEN_OK = 0,
+    DB_API_TOKEN_ERROR = -1,
+    DB_API_TOKEN_NOT_FOUND = -2,
+    DB_API_TOKEN_INVALID = -3,
+    DB_API_TOKEN_LIMIT = -4
+} db_api_token_result_t;
+
+typedef struct {
+    char uuid[CAMERA_UUID_STRING_SIZE];
+    int64_t user_id;
+    int64_t created_by_user_id;
+    char description[API_TOKEN_DESCRIPTION_MAX];
+    char token_prefix[API_TOKEN_PREFIX_MAX];
+    uint64_t action_mask;
+    char scope_type[API_TOKEN_SCOPE_TYPE_MAX];
+    char selector_json[API_TOKEN_SELECTOR_MAX];
+    char collection_uuid[CAMERA_UUID_STRING_SIZE];
+    int64_t expires_at;
+    int64_t revoked_at;
+    int64_t last_used_at;
+    int64_t created_at;
+} api_token_t;
+
+typedef struct {
+    int64_t user_id;
+    int64_t created_by_user_id;
+    const char *description;
+    uint64_t action_mask;
+    const char *scope_type;
+    const char *selector_json;
+    const char *collection_uuid;
+    int64_t expires_at;
+} api_token_create_t;
+
+db_api_token_result_t db_api_token_create(
+    const api_token_create_t *input, api_token_t *token,
+    char secret[API_TOKEN_SECRET_MAX]);
+db_api_token_result_t db_api_token_list(int64_t user_id,
+                                        api_token_t **tokens,
+                                        int *token_count);
+db_api_token_result_t db_api_token_revoke(int64_t user_id,
+                                          const char *token_uuid);
+
+/* Resolve a secret to an active token owner. The secret is never persisted. */
+db_api_token_result_t db_api_token_authenticate(
+    const char *secret, int64_t *user_id,
+    char token_uuid[CAMERA_UUID_STRING_SIZE]);
+
+/* Reload one active token so authorization observes revocation and expiry. */
+db_api_token_result_t db_api_token_get_active(const char *token_uuid,
+                                              api_token_t *token);
+
+#endif /* LIGHTNVR_DB_API_TOKENS_H */

--- a/include/database/db_auth.h
+++ b/include/database/db_auth.h
@@ -13,6 +13,7 @@
 #define USER_ALLOWED_TAGS_MAX 256
 #define USER_ALLOWED_LOGIN_CIDRS_MAX 1024
 #define USER_AUTHORIZATION_MODE_MAX 16
+#define USER_API_TOKEN_UUID_MAX 37
 
 /**
  * @brief User roles
@@ -44,6 +45,8 @@ typedef struct {
     char allowed_login_cidrs[USER_ALLOWED_LOGIN_CIDRS_MAX]; /**< Newline-separated CIDR whitelist for login/auth IPs */
     bool has_login_cidr_restriction; /**< Whether allowed_login_cidrs is set (true) or NULL/unrestricted (false) */
     char authorization_mode[USER_AUTHORIZATION_MODE_MAX]; /**< legacy compatibility or default-deny policy evaluation */
+    bool authenticated_via_scoped_token; /**< Request used a scoped, hashed API token */
+    char api_token_uuid[USER_API_TOKEN_UUID_MAX]; /**< Scoped token constraint for this request */
 } user_t;
 
 /**

--- a/include/database/db_embedded_migrations.h
+++ b/include/database/db_embedded_migrations.h
@@ -985,6 +985,34 @@ static const char migration_0053_down[] =
     "CREATE INDEX idx_authz_grants_role ON authz_grants(role_uuid);\n"
     "SELECT 1;";
 
+static const char migration_0054_up[] =
+    "CREATE TABLE authz_api_tokens ("
+    "uuid TEXT PRIMARY KEY, "
+    "user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE, "
+    "created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL, "
+    "description TEXT NOT NULL, token_prefix TEXT NOT NULL, "
+    "token_hash TEXT NOT NULL UNIQUE, "
+    "action_mask INTEGER NOT NULL CHECK (action_mask>0), "
+    "scope_type TEXT NOT NULL CHECK (scope_type IN ('all','selector','collection')), "
+    "selector_json TEXT, "
+    "collection_uuid TEXT REFERENCES camera_collections(uuid) ON DELETE RESTRICT, "
+    "expires_at INTEGER NOT NULL, revoked_at INTEGER, last_used_at INTEGER, "
+    "created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')), "
+    "CHECK ((scope_type='all' AND selector_json IS NULL AND collection_uuid IS NULL) OR "
+    "(scope_type='selector' AND selector_json IS NOT NULL AND collection_uuid IS NULL) OR "
+    "(scope_type='collection' AND selector_json IS NULL AND collection_uuid IS NOT NULL)), "
+    "CHECK (expires_at>created_at));\n"
+    "CREATE INDEX idx_authz_api_tokens_user "
+    "ON authz_api_tokens(user_id,created_at DESC);\n"
+    "CREATE INDEX idx_authz_api_tokens_active "
+    "ON authz_api_tokens(token_hash,expires_at) WHERE revoked_at IS NULL;";
+
+static const char migration_0054_down[] =
+    "DROP INDEX IF EXISTS idx_authz_api_tokens_active;\n"
+    "DROP INDEX IF EXISTS idx_authz_api_tokens_user;\n"
+    "DROP TABLE IF EXISTS authz_api_tokens;\n"
+    "SELECT 1;";
+
 static const migration_t embedded_migrations_data[] = {
     {
         .version = "0001",
@@ -1357,8 +1385,15 @@ static const migration_t embedded_migrations_data[] = {
         .sql_down = migration_0053_down,
         .is_embedded = true
     },
+    {
+        .version = "0054",
+        .description = "add_scoped_api_tokens",
+        .sql_up = migration_0054_up,
+        .sql_down = migration_0054_down,
+        .is_embedded = true
+    },
 };
 
-#define EMBEDDED_MIGRATIONS_COUNT 53
+#define EMBEDDED_MIGRATIONS_COUNT 54
 
 #endif /* DB_EMBEDDED_MIGRATIONS_H */

--- a/include/web/api_handlers_authorization.h
+++ b/include/web/api_handlers_authorization.h
@@ -19,5 +19,11 @@ void handle_get_user_authorization(const http_request_t *req,
                                    http_response_t *res);
 void handle_put_user_authorization(const http_request_t *req,
                                    http_response_t *res);
+void handle_get_user_api_tokens(const http_request_t *req,
+                                http_response_t *res);
+void handle_post_user_api_token(const http_request_t *req,
+                                http_response_t *res);
+void handle_delete_user_api_token(const http_request_t *req,
+                                  http_response_t *res);
 
 #endif /* LIGHTNVR_API_HANDLERS_AUTHORIZATION_H */

--- a/include/web/httpd_utils.h
+++ b/include/web/httpd_utils.h
@@ -123,6 +123,13 @@ void httpd_clear_trusted_device_cookie(http_response_t *res);
 int httpd_check_viewer_access(const http_request_t *req, user_t *user);
 
 /**
+ * Authenticate for a handler that immediately applies centralized action
+ * authorization. This additionally accepts scoped API tokens. Do not use it
+ * in handlers that rely only on legacy role or allowed-tag checks.
+ */
+int httpd_check_action_access(const http_request_t *req, user_t *user);
+
+/**
  * Authenticate and authorize a request through the centralized action policy.
  * A NULL camera is valid for global actions and all-fleet grants. Evaluation
  * errors fail closed with a 500 response; denials return 403.

--- a/src/core/authorization.c
+++ b/src/core/authorization.c
@@ -7,6 +7,7 @@
 
 #include "core/authorization.h"
 #include "core/camera_collection_filter.h"
+#include "database/db_api_tokens.h"
 #include "database/db_authorization.h"
 #include "utils/strings.h"
 
@@ -170,9 +171,10 @@ static int grant_matches(const authorization_grant_t *grant,
     return 0;
 }
 
-int authorization_evaluate(const user_t *user, authorization_action_t action,
-                           const fleet_camera_t *camera,
-                           authorization_evaluation_t *evaluation) {
+static int evaluate_principal(const user_t *user,
+                              authorization_action_t action,
+                              const fleet_camera_t *camera,
+                              authorization_evaluation_t *evaluation) {
     if (!user || !evaluation) return -1;
     const authorization_action_metadata_t *metadata =
         authorization_action_metadata(action);
@@ -224,5 +226,92 @@ int authorization_evaluate(const user_t *user, authorization_action_t action,
                     ? "No all-fleet grant allows this action"
                     : "No matching grant allows this action",
                 sizeof(evaluation->explanation), 0);
+    return 0;
+}
+
+static int token_scope_matches(const api_token_t *token,
+                               const fleet_camera_t *camera, bool *matches) {
+    *matches = false;
+    if (strcmp(token->scope_type, "all") == 0) {
+        *matches = true;
+        return 0;
+    }
+    if (!camera) return 0;
+    if (strcmp(token->scope_type, "collection") == 0) {
+        camera_collection_filter_t filter;
+        camera_collection_filter_result_t result =
+            camera_collection_filter_load_for_authorization(
+                token->collection_uuid, &filter);
+        if (result != CAMERA_COLLECTION_FILTER_OK) return -1;
+        *matches = camera_collection_filter_matches(&filter, camera);
+        camera_collection_filter_free(&filter);
+        return 0;
+    }
+    if (strcmp(token->scope_type, "selector") != 0 ||
+        token->selector_json[0] == '\0') {
+        return -1;
+    }
+    cJSON *json = cJSON_Parse(token->selector_json);
+    if (!json) return -1;
+    char error[FLEET_SELECTOR_ERROR_MAX] = {0};
+    fleet_selector_t *selector =
+        fleet_selector_parse(json, error, sizeof(error));
+    cJSON_Delete(json);
+    if (!selector) return -1;
+    *matches = fleet_selector_matches(selector, camera, NULL);
+    fleet_selector_free(selector);
+    return 0;
+}
+
+int authorization_evaluate(const user_t *user, authorization_action_t action,
+                           const fleet_camera_t *camera,
+                           authorization_evaluation_t *evaluation) {
+    int result = evaluate_principal(user, action, camera, evaluation);
+    if (result != 0 || !user || !evaluation ||
+        evaluation->decision != AUTHZ_DECISION_ALLOW ||
+        !user->authenticated_via_scoped_token) {
+        return result;
+    }
+
+    api_token_t token;
+    db_api_token_result_t token_result =
+        db_api_token_get_active(user->api_token_uuid, &token);
+    if (token_result == DB_API_TOKEN_ERROR) return -1;
+    if (token_result != DB_API_TOKEN_OK || token.user_id != user->id) {
+        evaluation->decision = AUTHZ_DECISION_DENY;
+        evaluation->source = AUTHZ_SOURCE_NONE;
+        safe_strcpy(evaluation->explanation,
+                    "Scoped API token is expired, revoked, or unavailable",
+                    sizeof(evaluation->explanation), 0);
+        return 0;
+    }
+    safe_strcpy(evaluation->token_uuid, token.uuid,
+                sizeof(evaluation->token_uuid), 0);
+    if ((token.action_mask & (UINT64_C(1) << action)) == 0) {
+        evaluation->decision = AUTHZ_DECISION_DENY;
+        evaluation->source = AUTHZ_SOURCE_NONE;
+        safe_strcpy(evaluation->explanation,
+                    "Scoped API token does not include this action",
+                    sizeof(evaluation->explanation), 0);
+        return 0;
+    }
+    bool matches = false;
+    if (token_scope_matches(&token, camera, &matches) != 0) return -1;
+    if (!matches) {
+        evaluation->decision = AUTHZ_DECISION_DENY;
+        evaluation->source = AUTHZ_SOURCE_NONE;
+        safe_strcpy(evaluation->explanation,
+                    camera ? "Camera is outside the scoped API token"
+                           : "Scoped API token is not valid for global actions",
+                    sizeof(evaluation->explanation), 0);
+        return 0;
+    }
+    char principal_explanation[AUTHORIZATION_EXPLANATION_MAX];
+    safe_strcpy(principal_explanation, evaluation->explanation,
+                sizeof(principal_explanation), 0);
+    safe_strcpy(evaluation->explanation, principal_explanation,
+                sizeof(evaluation->explanation), 0);
+    safe_strcat(evaluation->explanation, "; narrowed by scoped API token",
+                sizeof(evaluation->explanation));
     return 0;
 }

--- a/src/database/db_api_tokens.c
+++ b/src/database/db_api_tokens.c
@@ -1,0 +1,441 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <cjson/cJSON.h>
+#include <ctype.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/sha256.h>
+#include <pthread.h>
+#include <sqlite3.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "core/authorization.h"
+#include "core/camera_selector.h"
+#include "database/db_api_tokens.h"
+#include "database/db_core.h"
+#include "utils/memory.h"
+#include "utils/strings.h"
+
+#define TOKEN_RANDOM_BYTES 32
+#define TOKEN_HASH_HEX_SIZE 65
+
+static void copy_column(char *destination, size_t destination_size,
+                        sqlite3_stmt *stmt, int column) {
+    const char *value = (const char *)sqlite3_column_text(stmt, column);
+    safe_strcpy(destination, value ? value : "", destination_size, 0);
+}
+
+static void populate_token(sqlite3_stmt *stmt, api_token_t *token) {
+    memset(token, 0, sizeof(*token));
+    copy_column(token->uuid, sizeof(token->uuid), stmt, 0);
+    token->user_id = sqlite3_column_int64(stmt, 1);
+    token->created_by_user_id = sqlite3_column_int64(stmt, 2);
+    copy_column(token->description, sizeof(token->description), stmt, 3);
+    copy_column(token->token_prefix, sizeof(token->token_prefix), stmt, 4);
+    token->action_mask = (uint64_t)sqlite3_column_int64(stmt, 5);
+    copy_column(token->scope_type, sizeof(token->scope_type), stmt, 6);
+    copy_column(token->selector_json, sizeof(token->selector_json), stmt, 7);
+    copy_column(token->collection_uuid, sizeof(token->collection_uuid), stmt, 8);
+    token->expires_at = sqlite3_column_int64(stmt, 9);
+    token->revoked_at = sqlite3_column_int64(stmt, 10);
+    token->last_used_at = sqlite3_column_int64(stmt, 11);
+    token->created_at = sqlite3_column_int64(stmt, 12);
+}
+
+static const char *token_select_fields(void) {
+    return "uuid,user_id,COALESCE(created_by_user_id,0),description,"
+           "token_prefix,action_mask,scope_type,COALESCE(selector_json,''),"
+           "COALESCE(collection_uuid,''),expires_at,COALESCE(revoked_at,0),"
+           "COALESCE(last_used_at,0),created_at";
+}
+
+static bool valid_selector(const char *serialized) {
+    if (!serialized || serialized[0] == '\0' ||
+        strlen(serialized) >= API_TOKEN_SELECTOR_MAX) {
+        return false;
+    }
+    cJSON *json = cJSON_Parse(serialized);
+    if (!json) return false;
+    char error[FLEET_SELECTOR_ERROR_MAX] = {0};
+    fleet_selector_t *selector =
+        fleet_selector_parse(json, error, sizeof(error));
+    cJSON_Delete(json);
+    if (!selector) return false;
+    fleet_selector_free(selector);
+    return true;
+}
+
+static bool valid_scope(const api_token_create_t *input) {
+    if (strcmp(input->scope_type, "all") == 0) {
+        return !input->selector_json && !input->collection_uuid;
+    }
+    if (strcmp(input->scope_type, "selector") == 0) {
+        return !input->collection_uuid && valid_selector(input->selector_json);
+    }
+    return strcmp(input->scope_type, "collection") == 0 &&
+           !input->selector_json && input->collection_uuid &&
+           input->collection_uuid[0] != '\0';
+}
+
+static bool shared_collection_exists_locked(sqlite3 *db, const char *uuid) {
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db,
+        "SELECT 1 FROM camera_collections WHERE uuid=? AND is_shared=1;",
+        -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    return rc == SQLITE_ROW;
+}
+
+static int bytes_to_hex(const unsigned char *bytes, size_t byte_count,
+                        char *output, size_t output_size) {
+    static const char alphabet[] = "0123456789abcdef";
+    if (!bytes || !output || output_size < byte_count * 2 + 1) return -1;
+    for (size_t i = 0; i < byte_count; i++) {
+        output[i * 2] = alphabet[bytes[i] >> 4];
+        output[i * 2 + 1] = alphabet[bytes[i] & 0x0f];
+    }
+    output[byte_count * 2] = '\0';
+    return 0;
+}
+
+static int generate_secret(char secret[API_TOKEN_SECRET_MAX]) {
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context random;
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&random);
+    static const unsigned char personalization[] = "lightnvr-api-token";
+    int rc = mbedtls_ctr_drbg_seed(
+        &random, mbedtls_entropy_func, &entropy, personalization,
+        sizeof(personalization) - 1);
+    unsigned char bytes[TOKEN_RANDOM_BYTES];
+    if (rc == 0) {
+        rc = mbedtls_ctr_drbg_random(&random, bytes, sizeof(bytes));
+    }
+    char hex[TOKEN_RANDOM_BYTES * 2 + 1];
+    if (rc == 0) rc = bytes_to_hex(bytes, sizeof(bytes), hex, sizeof(hex));
+    if (rc == 0) {
+        int written = snprintf(secret, API_TOKEN_SECRET_MAX, "lnvr_%s", hex);
+        if (written < 0 || written >= API_TOKEN_SECRET_MAX) rc = -1;
+    }
+    memset(bytes, 0, sizeof(bytes));
+    mbedtls_ctr_drbg_free(&random);
+    mbedtls_entropy_free(&entropy);
+    return rc == 0 ? 0 : -1;
+}
+
+static int hash_secret(const char *secret,
+                       char hash[TOKEN_HASH_HEX_SIZE]) {
+    if (!secret || secret[0] == '\0') return -1;
+    unsigned char digest[32];
+    if (mbedtls_sha256((const unsigned char *)secret, strlen(secret), digest,
+                       0) != 0) {
+        secure_zero_memory(digest, sizeof(digest));
+        return -1;
+    }
+    int rc = bytes_to_hex(digest, sizeof(digest), hash, TOKEN_HASH_HEX_SIZE);
+    secure_zero_memory(digest, sizeof(digest));
+    return rc;
+}
+
+db_api_token_result_t db_api_token_create(
+    const api_token_create_t *input, api_token_t *token,
+    char secret[API_TOKEN_SECRET_MAX]) {
+    int64_t now = (int64_t)time(NULL);
+    uint64_t valid_actions = (UINT64_C(1) << AUTHZ_ACTION_COUNT) - 1;
+    char description[API_TOKEN_DESCRIPTION_MAX];
+    if (!input || !token || !secret || input->user_id <= 0 ||
+        input->created_by_user_id <= 0 || !input->description ||
+        strlen(input->description) >= sizeof(description) ||
+        copy_trimmed_value(description, sizeof(description),
+                           input->description, 0) == 0 ||
+        input->action_mask == 0 ||
+        (input->action_mask & ~valid_actions) != 0 || !input->scope_type ||
+        !valid_scope(input) || input->expires_at <= now ||
+        input->expires_at - now > API_TOKEN_MAX_LIFETIME_SECONDS) {
+        return DB_API_TOKEN_INVALID;
+    }
+    for (const unsigned char *cursor = (const unsigned char *)description;
+         *cursor; cursor++) {
+        if (iscntrl(*cursor)) return DB_API_TOKEN_INVALID;
+    }
+    memset(token, 0, sizeof(*token));
+    secret[0] = '\0';
+    if (generate_secret(secret) != 0) return DB_API_TOKEN_ERROR;
+    char hash[TOKEN_HASH_HEX_SIZE];
+    if (hash_secret(secret, hash) != 0) {
+        secure_zero_memory(secret, API_TOKEN_SECRET_MAX);
+        return DB_API_TOKEN_ERROR;
+    }
+
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) {
+        secure_zero_memory(secret, API_TOKEN_SECRET_MAX);
+        return DB_API_TOKEN_ERROR;
+    }
+    pthread_mutex_lock(mutex);
+    if (sqlite3_exec(db, "BEGIN IMMEDIATE;", NULL, NULL, NULL) != SQLITE_OK) {
+        pthread_mutex_unlock(mutex);
+        secure_zero_memory(secret, API_TOKEN_SECRET_MAX);
+        return DB_API_TOKEN_ERROR;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db,
+        "SELECT count(*) FROM authz_api_tokens WHERE user_id=? AND "
+        "revoked_at IS NULL AND expires_at>strftime('%s','now');",
+        -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, input->user_id);
+        rc = sqlite3_step(stmt);
+    }
+    int active_count = rc == SQLITE_ROW ? sqlite3_column_int(stmt, 0) : -1;
+    if (stmt) sqlite3_finalize(stmt);
+    if (active_count >= API_TOKEN_MAX_PER_USER) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        secure_zero_memory(secret, API_TOKEN_SECRET_MAX);
+        return DB_API_TOKEN_LIMIT;
+    }
+    if (active_count < 0 ||
+        (strcmp(input->scope_type, "collection") == 0 &&
+         !shared_collection_exists_locked(db, input->collection_uuid))) {
+        sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+        pthread_mutex_unlock(mutex);
+        secure_zero_memory(secret, API_TOKEN_SECRET_MAX);
+        return active_count < 0 ? DB_API_TOKEN_ERROR : DB_API_TOKEN_INVALID;
+    }
+
+    const char *sql =
+        "INSERT INTO authz_api_tokens "
+        "(uuid,user_id,created_by_user_id,description,token_prefix,token_hash,"
+        "action_mask,scope_type,selector_json,collection_uuid,expires_at) "
+        "VALUES (lower(hex(randomblob(4))||'-'||hex(randomblob(2))||'-4'||"
+        "substr(hex(randomblob(2)),2)||'-'||"
+        "substr('89ab',(abs(random())%4)+1,1)||substr(hex(randomblob(2)),2)||"
+        "'-'||hex(randomblob(6))),?,?,?,?,?,?,?,?,?,?);";
+    stmt = NULL;
+    rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, input->user_id);
+        sqlite3_bind_int64(stmt, 2, input->created_by_user_id);
+        sqlite3_bind_text(stmt, 3, description, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 4, secret, 13, SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 5, hash, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(stmt, 6, (sqlite3_int64)input->action_mask);
+        sqlite3_bind_text(stmt, 7, input->scope_type, -1, SQLITE_TRANSIENT);
+        if (input->selector_json) {
+            sqlite3_bind_text(stmt, 8, input->selector_json, -1,
+                              SQLITE_TRANSIENT);
+        } else {
+            sqlite3_bind_null(stmt, 8);
+        }
+        if (input->collection_uuid) {
+            sqlite3_bind_text(stmt, 9, input->collection_uuid, -1,
+                              SQLITE_TRANSIENT);
+        } else {
+            sqlite3_bind_null(stmt, 9);
+        }
+        sqlite3_bind_int64(stmt, 10, input->expires_at);
+        rc = sqlite3_step(stmt);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    if (rc == SQLITE_DONE) {
+        char query[512];
+        snprintf(query, sizeof(query),
+                 "SELECT %s FROM authz_api_tokens "
+                 "WHERE rowid=last_insert_rowid();",
+                 token_select_fields());
+        stmt = NULL;
+        rc = sqlite3_prepare_v2(db, query, -1, &stmt, NULL);
+        if (rc == SQLITE_OK && sqlite3_step(stmt) == SQLITE_ROW) {
+            populate_token(stmt, token);
+            rc = SQLITE_DONE;
+        }
+        if (stmt) sqlite3_finalize(stmt);
+    }
+    bool committed = rc == SQLITE_DONE && token->uuid[0] != '\0' &&
+        sqlite3_exec(db, "COMMIT;", NULL, NULL, NULL) == SQLITE_OK;
+    if (!committed) sqlite3_exec(db, "ROLLBACK;", NULL, NULL, NULL);
+    pthread_mutex_unlock(mutex);
+    secure_zero_memory(hash, sizeof(hash));
+    if (!committed) {
+        secure_zero_memory(secret, API_TOKEN_SECRET_MAX);
+        return DB_API_TOKEN_ERROR;
+    }
+    return DB_API_TOKEN_OK;
+}
+
+db_api_token_result_t db_api_token_list(int64_t user_id,
+                                        api_token_t **tokens,
+                                        int *token_count) {
+    if (user_id <= 0 || !tokens || !token_count) return DB_API_TOKEN_INVALID;
+    *tokens = NULL;
+    *token_count = 0;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_API_TOKEN_ERROR;
+    pthread_mutex_lock(mutex);
+    char sql[512];
+    snprintf(sql, sizeof(sql),
+             "SELECT %s FROM authz_api_tokens WHERE user_id=? "
+             "ORDER BY created_at DESC,uuid LIMIT ?;",
+             token_select_fields());
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_int64(stmt, 1, user_id);
+        sqlite3_bind_int(stmt, 2, API_TOKEN_MAX_PER_USER);
+    }
+    int capacity = 8;
+    api_token_t *loaded = rc == SQLITE_OK
+        ? calloc((size_t)capacity, sizeof(*loaded)) : NULL;
+    if (rc == SQLITE_OK && !loaded) rc = SQLITE_NOMEM;
+    int count = 0;
+    if (rc == SQLITE_OK) {
+        while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+            if (count == capacity) {
+                capacity *= 2;
+                api_token_t *resized =
+                    realloc(loaded, (size_t)capacity * sizeof(*loaded));
+                if (!resized) {
+                    rc = SQLITE_NOMEM;
+                    break;
+                }
+                loaded = resized;
+            }
+            populate_token(stmt, &loaded[count++]);
+        }
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    pthread_mutex_unlock(mutex);
+    if (rc != SQLITE_DONE) {
+        free(loaded);
+        return DB_API_TOKEN_ERROR;
+    }
+    if (count == 0) {
+        free(loaded);
+        loaded = NULL;
+    }
+    *tokens = loaded;
+    *token_count = count;
+    return DB_API_TOKEN_OK;
+}
+
+db_api_token_result_t db_api_token_revoke(int64_t user_id,
+                                          const char *token_uuid) {
+    if (user_id <= 0 || !token_uuid || token_uuid[0] == '\0') {
+        return DB_API_TOKEN_INVALID;
+    }
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_API_TOKEN_ERROR;
+    pthread_mutex_lock(mutex);
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db,
+        "UPDATE authz_api_tokens SET revoked_at=strftime('%s','now') "
+        "WHERE uuid=? AND user_id=? AND revoked_at IS NULL;",
+        -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, token_uuid, -1, SQLITE_TRANSIENT);
+        sqlite3_bind_int64(stmt, 2, user_id);
+        rc = sqlite3_step(stmt);
+    }
+    int changes = rc == SQLITE_DONE ? sqlite3_changes(db) : 0;
+    if (stmt) sqlite3_finalize(stmt);
+    pthread_mutex_unlock(mutex);
+    if (rc != SQLITE_DONE) return DB_API_TOKEN_ERROR;
+    return changes == 1 ? DB_API_TOKEN_OK : DB_API_TOKEN_NOT_FOUND;
+}
+
+db_api_token_result_t db_api_token_authenticate(
+    const char *secret, int64_t *user_id,
+    char token_uuid[CAMERA_UUID_STRING_SIZE]) {
+    if (!secret || strlen(secret) != 5 + TOKEN_RANDOM_BYTES * 2 ||
+        strncmp(secret, "lnvr_", 5) != 0 || !user_id || !token_uuid) {
+        return DB_API_TOKEN_NOT_FOUND;
+    }
+    *user_id = 0;
+    token_uuid[0] = '\0';
+    char hash[TOKEN_HASH_HEX_SIZE];
+    if (hash_secret(secret, hash) != 0) return DB_API_TOKEN_ERROR;
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_API_TOKEN_ERROR;
+    pthread_mutex_lock(mutex);
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db,
+        "SELECT t.uuid,t.user_id FROM authz_api_tokens t "
+        "JOIN users u ON u.id=t.user_id "
+        "WHERE t.token_hash=? AND t.revoked_at IS NULL "
+        "AND t.expires_at>strftime('%s','now') AND u.is_active=1 LIMIT 1;",
+        -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, hash, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    if (rc == SQLITE_ROW) {
+        copy_column(token_uuid, CAMERA_UUID_STRING_SIZE, stmt, 0);
+        *user_id = sqlite3_column_int64(stmt, 1);
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    if (*user_id > 0) {
+        rc = sqlite3_prepare_v2(
+            db,
+            "UPDATE authz_api_tokens SET last_used_at=strftime('%s','now') "
+            "WHERE uuid=? AND (last_used_at IS NULL OR "
+            "last_used_at<strftime('%s','now')-60);",
+            -1, &stmt, NULL);
+        if (rc == SQLITE_OK) {
+            sqlite3_bind_text(stmt, 1, token_uuid, -1, SQLITE_TRANSIENT);
+            rc = sqlite3_step(stmt);
+        }
+        if (stmt) sqlite3_finalize(stmt);
+    }
+    pthread_mutex_unlock(mutex);
+    secure_zero_memory(hash, sizeof(hash));
+    if (*user_id <= 0) return DB_API_TOKEN_NOT_FOUND;
+    return rc == SQLITE_DONE ? DB_API_TOKEN_OK : DB_API_TOKEN_ERROR;
+}
+
+db_api_token_result_t db_api_token_get_active(const char *token_uuid,
+                                              api_token_t *token) {
+    if (!token_uuid || token_uuid[0] == '\0' || !token) {
+        return DB_API_TOKEN_INVALID;
+    }
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return DB_API_TOKEN_ERROR;
+    pthread_mutex_lock(mutex);
+    char sql[640];
+    snprintf(sql, sizeof(sql),
+             "SELECT %s FROM authz_api_tokens WHERE uuid=? AND "
+             "revoked_at IS NULL AND expires_at>strftime('%%s','now') LIMIT 1;",
+             token_select_fields());
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc == SQLITE_OK) {
+        sqlite3_bind_text(stmt, 1, token_uuid, -1, SQLITE_TRANSIENT);
+        rc = sqlite3_step(stmt);
+    }
+    db_api_token_result_t result = DB_API_TOKEN_NOT_FOUND;
+    if (rc == SQLITE_ROW) {
+        populate_token(stmt, token);
+        result = DB_API_TOKEN_OK;
+    } else if (rc != SQLITE_DONE) {
+        result = DB_API_TOKEN_ERROR;
+    }
+    if (stmt) sqlite3_finalize(stmt);
+    pthread_mutex_unlock(mutex);
+    return result;
+}

--- a/src/database/db_camera_collections.c
+++ b/src/database/db_camera_collections.c
@@ -139,7 +139,9 @@ static bool authorization_scope_in_use_locked(sqlite3 *db,
                                               const char *collection_uuid) {
     return row_exists_locked(
         db,
-        "SELECT 1 FROM authz_grants WHERE collection_uuid = ? LIMIT 1;",
+        "SELECT collection_uuid FROM authz_grants WHERE collection_uuid = ?1 "
+        "UNION ALL SELECT collection_uuid FROM authz_api_tokens "
+        "WHERE collection_uuid = ?1 LIMIT 1;",
         collection_uuid);
 }
 

--- a/src/web/api_handlers_authorization.c
+++ b/src/web/api_handlers_authorization.c
@@ -10,8 +10,10 @@
 
 #include "core/authorization.h"
 #include "database/db_auth.h"
+#include "database/db_api_tokens.h"
 #include "database/db_authorization.h"
 #include "database/db_fleet_query.h"
+#include "utils/memory.h"
 #include "utils/strings.h"
 #include "web/api_handlers_authorization.h"
 #include "web/httpd_utils.h"
@@ -879,4 +881,379 @@ void handle_put_user_authorization(const http_request_t *req,
         return;
     }
     set_user_policy_response(res, user_id, 200);
+}
+
+static bool extract_token_path(const http_request_t *req, int64_t *user_id,
+                               char token_uuid[CAMERA_UUID_STRING_SIZE],
+                               bool require_token, http_response_t *res) {
+    char value[MAX_PATH_LENGTH];
+    if (http_request_extract_path_param(req, "/api/authorization/users/",
+                                        value, sizeof(value)) != 0) {
+        http_response_set_json_error(res, 400, "Invalid token path");
+        return false;
+    }
+    char *separator = strchr(value, '/');
+    if (!separator) {
+        http_response_set_json_error(res, 400, "Invalid token path");
+        return false;
+    }
+    *separator = '\0';
+    char *end = NULL;
+    errno = 0;
+    long long parsed = strtoll(value, &end, 10);
+    if (errno == ERANGE || !end || *end != '\0' || parsed <= 0) {
+        http_response_set_json_error(res, 400, "Invalid user ID");
+        return false;
+    }
+    *user_id = (int64_t)parsed;
+    const char *suffix = separator + 1;
+    if (!require_token) {
+        if (strcmp(suffix, "tokens") != 0) {
+            http_response_set_json_error(res, 400, "Invalid token path");
+            return false;
+        }
+        token_uuid[0] = '\0';
+        return true;
+    }
+    if (strncmp(suffix, "tokens/", 7) != 0 ||
+        !valid_uuid(suffix + 7) || strchr(suffix + 7, '/')) {
+        http_response_set_json_error(res, 400, "Invalid token UUID");
+        return false;
+    }
+    safe_strcpy(token_uuid, suffix + 7, CAMERA_UUID_STRING_SIZE, 0);
+    return true;
+}
+
+static bool authorize_token_manager(const http_request_t *req,
+                                    http_response_t *res,
+                                    int64_t target_user_id,
+                                    user_t *requester) {
+    if (!httpd_get_authenticated_user(req, requester)) {
+        http_response_set_json_error(res, 401, "Unauthorized");
+        return false;
+    }
+    if (requester->id == target_user_id) return true;
+    authorization_evaluation_t evaluation;
+    if (authorization_evaluate(requester, AUTHZ_USERS_MANAGE, NULL,
+                               &evaluation) != 0) {
+        http_response_set_json_error(
+            res, 500, "Authorization policy evaluation failed");
+        return false;
+    }
+    if (evaluation.decision != AUTHZ_DECISION_ALLOW) {
+        http_response_set_json_error(res, 403, "Forbidden");
+        return false;
+    }
+    return true;
+}
+
+static cJSON *api_token_to_json(const api_token_t *token) {
+    cJSON *object = cJSON_CreateObject();
+    cJSON *actions = cJSON_CreateArray();
+    cJSON *scope = cJSON_CreateObject();
+    if (!object || !actions || !scope) {
+        cJSON_Delete(object);
+        cJSON_Delete(actions);
+        cJSON_Delete(scope);
+        return NULL;
+    }
+    cJSON_AddStringToObject(object, "uuid", token->uuid);
+    cJSON_AddStringToObject(object, "description", token->description);
+    cJSON_AddStringToObject(object, "prefix", token->token_prefix);
+    cJSON_AddNumberToObject(object, "expires_at", (double)token->expires_at);
+    if (token->revoked_at > 0) {
+        cJSON_AddNumberToObject(object, "revoked_at",
+                                (double)token->revoked_at);
+    } else {
+        cJSON_AddNullToObject(object, "revoked_at");
+    }
+    if (token->last_used_at > 0) {
+        cJSON_AddNumberToObject(object, "last_used_at",
+                                (double)token->last_used_at);
+    } else {
+        cJSON_AddNullToObject(object, "last_used_at");
+    }
+    cJSON_AddNumberToObject(object, "created_at", (double)token->created_at);
+    int action_count = 0;
+    const authorization_action_metadata_t *catalog =
+        authorization_action_catalog(&action_count);
+    for (int i = 0; i < action_count; i++) {
+        if ((token->action_mask & (UINT64_C(1) << catalog[i].action)) != 0) {
+            cJSON_AddItemToArray(actions, cJSON_CreateString(catalog[i].key));
+        }
+    }
+    cJSON_AddItemToObject(object, "actions", actions);
+    cJSON_AddStringToObject(scope, "type", token->scope_type);
+    if (strcmp(token->scope_type, "selector") == 0) {
+        cJSON *selector = cJSON_Parse(token->selector_json);
+        if (!selector) {
+            cJSON_Delete(object);
+            cJSON_Delete(scope);
+            return NULL;
+        }
+        cJSON_AddItemToObject(scope, "selector", selector);
+    } else {
+        cJSON_AddNullToObject(scope, "selector");
+    }
+    if (strcmp(token->scope_type, "collection") == 0) {
+        cJSON_AddStringToObject(scope, "collection_uuid",
+                                token->collection_uuid);
+    } else {
+        cJSON_AddNullToObject(scope, "collection_uuid");
+    }
+    cJSON_AddItemToObject(object, "scope", scope);
+    return object;
+}
+
+static void set_api_token_error(http_response_t *res,
+                                db_api_token_result_t result) {
+    switch (result) {
+        case DB_API_TOKEN_NOT_FOUND:
+            http_response_set_json_error(res, 404, "API token not found");
+            break;
+        case DB_API_TOKEN_INVALID:
+            http_response_set_json_error(res, 400,
+                                         "Invalid API token request");
+            break;
+        case DB_API_TOKEN_LIMIT:
+            http_response_set_json_error(res, 409,
+                                         "Active API token limit reached");
+            break;
+        default:
+            http_response_set_json_error(res, 500,
+                                         "API token operation failed");
+            break;
+    }
+}
+
+void handle_get_user_api_tokens(const http_request_t *req,
+                                http_response_t *res) {
+    int64_t user_id = 0;
+    char unused_uuid[CAMERA_UUID_STRING_SIZE];
+    if (!extract_token_path(req, &user_id, unused_uuid, false, res)) return;
+    user_t requester;
+    if (!authorize_token_manager(req, res, user_id, &requester)) return;
+    user_t target;
+    if (db_auth_get_user_by_id(user_id, &target) != 0) {
+        http_response_set_json_error(res, 404, "User not found");
+        return;
+    }
+    api_token_t *tokens = NULL;
+    int count = 0;
+    db_api_token_result_t result =
+        db_api_token_list(user_id, &tokens, &count);
+    if (result != DB_API_TOKEN_OK) {
+        set_api_token_error(res, result);
+        return;
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON *items = cJSON_CreateArray();
+    if (!root || !items) {
+        cJSON_Delete(root);
+        cJSON_Delete(items);
+        free(tokens);
+        http_response_set_json_error(res, 500, "Failed to create response");
+        return;
+    }
+    cJSON_AddNumberToObject(root, "user_id", (double)user_id);
+    cJSON_AddNumberToObject(root, "count", count);
+    cJSON_AddItemToObject(root, "tokens", items);
+    for (int i = 0; i < count; i++) {
+        cJSON *item = api_token_to_json(&tokens[i]);
+        if (!item) {
+            cJSON_Delete(root);
+            free(tokens);
+            http_response_set_json_error(res, 500,
+                                         "Failed to create response");
+            return;
+        }
+        cJSON_AddItemToArray(items, item);
+    }
+    free(tokens);
+    set_json_response(res, root);
+}
+
+static bool parse_token_actions(const cJSON *body, uint64_t *action_mask,
+                                http_response_t *res) {
+    const cJSON *actions = cJSON_GetObjectItemCaseSensitive(body, "actions");
+    if (!cJSON_IsArray(actions) || cJSON_GetArraySize(actions) == 0) {
+        http_response_set_json_error(res, 400,
+                                     "actions must be a non-empty array");
+        return false;
+    }
+    *action_mask = 0;
+    const cJSON *item = NULL;
+    cJSON_ArrayForEach(item, actions) {
+        authorization_action_t action = cJSON_IsString(item)
+            ? authorization_action_from_key(item->valuestring)
+            : AUTHZ_ACTION_INVALID;
+        if (action == AUTHZ_ACTION_INVALID) {
+            http_response_set_json_error(res, 400,
+                                         "Unknown API token action");
+            return false;
+        }
+        *action_mask |= UINT64_C(1) << action;
+    }
+    return true;
+}
+
+static bool parse_token_scope(const cJSON *body, char *scope_type,
+                              size_t scope_type_size, char **selector_json,
+                              char collection_uuid[CAMERA_UUID_STRING_SIZE],
+                              http_response_t *res) {
+    const cJSON *scope = cJSON_GetObjectItemCaseSensitive(body, "scope");
+    const cJSON *type = cJSON_IsObject(scope)
+        ? cJSON_GetObjectItemCaseSensitive(scope, "type") : NULL;
+    const cJSON *selector = cJSON_IsObject(scope)
+        ? cJSON_GetObjectItemCaseSensitive(scope, "selector") : NULL;
+    const cJSON *collection = cJSON_IsObject(scope)
+        ? cJSON_GetObjectItemCaseSensitive(scope, "collection_uuid") : NULL;
+    if (!cJSON_IsString(type) ||
+        (strcmp(type->valuestring, "all") != 0 &&
+         strcmp(type->valuestring, "selector") != 0 &&
+         strcmp(type->valuestring, "collection") != 0)) {
+        http_response_set_json_error(res, 400, "Invalid API token scope");
+        return false;
+    }
+    safe_strcpy(scope_type, type->valuestring, scope_type_size, 0);
+    *selector_json = NULL;
+    collection_uuid[0] = '\0';
+    if (strcmp(type->valuestring, "all") == 0) {
+        if ((selector && !cJSON_IsNull(selector)) ||
+            (collection && !cJSON_IsNull(collection))) {
+            http_response_set_json_error(
+                res, 400, "All-camera token scope cannot include a resource");
+            return false;
+        }
+        return true;
+    }
+    if (strcmp(type->valuestring, "collection") == 0) {
+        if ((selector && !cJSON_IsNull(selector)) ||
+            !cJSON_IsString(collection) ||
+            !valid_uuid(collection->valuestring)) {
+            http_response_set_json_error(
+                res, 400, "Collection token scope requires a valid UUID");
+            return false;
+        }
+        safe_strcpy(collection_uuid, collection->valuestring,
+                    CAMERA_UUID_STRING_SIZE, 0);
+        return true;
+    }
+    if (!selector || (collection && !cJSON_IsNull(collection))) {
+        http_response_set_json_error(
+            res, 400, "Selector token scope requires only a selector");
+        return false;
+    }
+    *selector_json = cJSON_PrintUnformatted(selector);
+    if (!*selector_json || strlen(*selector_json) >= API_TOKEN_SELECTOR_MAX) {
+        free(*selector_json);
+        *selector_json = NULL;
+        http_response_set_json_error(res, 400, "API token selector is too large");
+        return false;
+    }
+    return true;
+}
+
+void handle_post_user_api_token(const http_request_t *req,
+                                http_response_t *res) {
+    int64_t user_id = 0;
+    char unused_uuid[CAMERA_UUID_STRING_SIZE];
+    if (!extract_token_path(req, &user_id, unused_uuid, false, res)) return;
+    user_t requester;
+    if (!authorize_token_manager(req, res, user_id, &requester)) return;
+    user_t target;
+    if (db_auth_get_user_by_id(user_id, &target) != 0) {
+        http_response_set_json_error(res, 404, "User not found");
+        return;
+    }
+    cJSON *body = httpd_parse_json_body(req);
+    const cJSON *description = cJSON_IsObject(body)
+        ? cJSON_GetObjectItemCaseSensitive(body, "description") : NULL;
+    const cJSON *expires_at = cJSON_IsObject(body)
+        ? cJSON_GetObjectItemCaseSensitive(body, "expires_at") : NULL;
+    double expiry_number = cJSON_IsNumber(expires_at)
+        ? expires_at->valuedouble : 0;
+    int64_t expiry = expiry_number > 0 &&
+        expiry_number <= 9007199254740991.0 ? (int64_t)expiry_number : 0;
+    uint64_t action_mask = 0;
+    char scope_type[API_TOKEN_SCOPE_TYPE_MAX];
+    char collection_uuid[CAMERA_UUID_STRING_SIZE];
+    char *selector_json = NULL;
+    if (!cJSON_IsObject(body) || !cJSON_IsString(description) ||
+        !description->valuestring || description->valuestring[0] == '\0' ||
+        strlen(description->valuestring) >= API_TOKEN_DESCRIPTION_MAX ||
+        expiry <= 0 || (double)expiry != expiry_number) {
+        http_response_set_json_error(res, 400,
+                                     "Invalid API token request");
+        cJSON_Delete(body);
+        return;
+    }
+    if (!parse_token_actions(body, &action_mask, res) ||
+        !parse_token_scope(body, scope_type, sizeof(scope_type),
+                           &selector_json, collection_uuid, res)) {
+        free(selector_json);
+        cJSON_Delete(body);
+        return;
+    }
+    api_token_create_t input = {
+        .user_id = user_id,
+        .created_by_user_id = requester.id > 0 ? requester.id : user_id,
+        .description = description->valuestring,
+        .action_mask = action_mask,
+        .scope_type = scope_type,
+        .selector_json = selector_json,
+        .collection_uuid = collection_uuid[0] ? collection_uuid : NULL,
+        .expires_at = expiry,
+    };
+    api_token_t token;
+    char secret[API_TOKEN_SECRET_MAX];
+    db_api_token_result_t result =
+        db_api_token_create(&input, &token, secret);
+    free(selector_json);
+    cJSON_Delete(body);
+    if (result != DB_API_TOKEN_OK) {
+        set_api_token_error(res, result);
+        return;
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON *token_json = api_token_to_json(&token);
+    cJSON *secret_json = cJSON_CreateString(secret);
+    if (!root || !token_json || !secret_json) {
+        cJSON_Delete(root);
+        cJSON_Delete(token_json);
+        cJSON_Delete(secret_json);
+        db_api_token_revoke(user_id, token.uuid);
+        secure_zero_memory(secret, sizeof(secret));
+        http_response_set_json_error(res, 500, "Failed to create response");
+        return;
+    }
+    cJSON_AddItemToObject(root, "secret", secret_json);
+    cJSON_AddItemToObject(root, "token", token_json);
+    char *response_body = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!response_body) {
+        db_api_token_revoke(user_id, token.uuid);
+        secure_zero_memory(secret, sizeof(secret));
+        http_response_set_json_error(res, 500, "Failed to serialize response");
+        return;
+    }
+    http_response_set_json(res, 201, response_body);
+    secure_zero_memory(secret, sizeof(secret));
+    free(response_body);
+}
+
+void handle_delete_user_api_token(const http_request_t *req,
+                                  http_response_t *res) {
+    int64_t user_id = 0;
+    char token_uuid[CAMERA_UUID_STRING_SIZE];
+    if (!extract_token_path(req, &user_id, token_uuid, true, res)) return;
+    user_t requester;
+    if (!authorize_token_manager(req, res, user_id, &requester)) return;
+    db_api_token_result_t result =
+        db_api_token_revoke(user_id, token_uuid);
+    if (result != DB_API_TOKEN_OK) {
+        set_api_token_error(res, result);
+        return;
+    }
+    http_response_set_json(res, 200, "{\"success\":true}");
 }

--- a/src/web/api_handlers_recordings_backend_agnostic.c
+++ b/src/web/api_handlers_recordings_backend_agnostic.c
@@ -719,7 +719,7 @@ void handle_batch_delete_recordings(const http_request_t *req, http_response_t *
     log_info("Handling POST /api/recordings/batch-delete request");
 
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return;
     }

--- a/src/web/api_handlers_recordings_batch_download.c
+++ b/src/web/api_handlers_recordings_batch_download.c
@@ -145,6 +145,7 @@ typedef struct {
     char        job_id[64];
     int64_t     owner_user_id;
     char        owner_username[64];
+    char        owner_api_token_uuid[CAMERA_UUID_STRING_SIZE];
     char        zip_filename[DOWNLOAD_FILENAME_MAX];
     char        tmp_path[MAX_PATH_LENGTH];
     uint64_t    ids[MAX_DL_IDS];
@@ -209,8 +210,15 @@ static int find_dl_job(const char *jid) {
 }
 
 static bool dl_job_owned_by(const batch_dl_job_t *job, const user_t *user) {
-    return job && user && job->owner_user_id == user->id &&
-           strcmp(job->owner_username, user->username) == 0;
+    if (!job || !user || job->owner_user_id != user->id ||
+        strcmp(job->owner_username, user->username) != 0) {
+        return false;
+    }
+    if (job->owner_api_token_uuid[0] == '\0') {
+        return !user->authenticated_via_scoped_token;
+    }
+    return user->authenticated_via_scoped_token &&
+           strcmp(job->owner_api_token_uuid, user->api_token_uuid) == 0;
 }
 
 static void discard_dl_job(const char *job_id) {
@@ -357,7 +365,7 @@ static void *zip_worker(void *arg) {
  */
 void handle_batch_download_recordings(const http_request_t *req, http_response_t *res) {
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return;
     }
@@ -438,6 +446,10 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
     job->owner_user_id = user.id;
     safe_strcpy(job->owner_username, user.username,
                 sizeof(job->owner_username), 0);
+    if (user.authenticated_via_scoped_token) {
+        safe_strcpy(job->owner_api_token_uuid, user.api_token_uuid,
+                    sizeof(job->owner_api_token_uuid), 0);
+    }
     httpd_sanitize_attachment_filename(filename_raw, job->zip_filename,
                                        sizeof(job->zip_filename));
     if (job->zip_filename[0] == '\0') {
@@ -494,7 +506,7 @@ void handle_batch_download_recordings(const http_request_t *req, http_response_t
  */
 void handle_batch_download_status(const http_request_t *req, http_response_t *res) {
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return;
     }
@@ -533,7 +545,7 @@ void handle_batch_download_status(const http_request_t *req, http_response_t *re
  */
 void handle_batch_download_result(const http_request_t *req, http_response_t *res) {
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return;
     }

--- a/src/web/api_handlers_recordings_download.c
+++ b/src/web/api_handlers_recordings_download.c
@@ -29,7 +29,7 @@ void handle_recordings_download(const http_request_t *req, http_response_t *res)
     }
 
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         log_error("Authentication failed for GET /api/recordings/download request");
         http_response_set_json_error(res, 401, "Unauthorized");
         return;

--- a/src/web/api_handlers_recordings_files_backend_agnostic.c
+++ b/src/web/api_handlers_recordings_files_backend_agnostic.c
@@ -93,7 +93,7 @@ void handle_delete_recording_file(const http_request_t *req, http_response_t *re
     log_info("Handling DELETE /api/recordings/files request");
 
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return;
     }

--- a/src/web/api_handlers_retention.c
+++ b/src/web/api_handlers_retention.c
@@ -376,7 +376,7 @@ void handle_batch_protect_recordings(const http_request_t *req, http_response_t 
 
     bool protected = cJSON_IsTrue(protected_json);
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         cJSON_Delete(json);
         http_response_set_json_error(res, 401, "Unauthorized");
         return;

--- a/src/web/httpd_utils.c
+++ b/src/web/httpd_utils.c
@@ -16,6 +16,7 @@
 #include "core/config.h"
 #include "utils/strings.h"
 #include "database/db_auth.h"
+#include "database/db_api_tokens.h"
 #include "database/db_fleet_query.h"
 
 cJSON* httpd_parse_json_body(const http_request_t *req) {
@@ -343,7 +344,8 @@ void httpd_clear_trusted_device_cookie(http_response_t *res) {
                              "trusted_device=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax");
 }
 
-int httpd_get_authenticated_user(const http_request_t *req, user_t *user) {
+static int get_authenticated_user(const http_request_t *req, user_t *user,
+                                  bool allow_scoped_token) {
     if (!req || !user) return 0;
 
     char effective_client_ip[64] = {0};
@@ -412,9 +414,28 @@ int httpd_get_authenticated_user(const http_request_t *req, user_t *user) {
             log_warn("API key auth blocked by allowed_login_cidrs for user '%s' from IP %s",
                      user->username, effective_client_ip[0] != '\0' ? effective_client_ip : "(unknown)");
         }
+        if (rc != 0 && allow_scoped_token) {
+            int64_t user_id = 0;
+            char token_uuid[CAMERA_UUID_STRING_SIZE] = {0};
+            db_api_token_result_t token_result = db_api_token_authenticate(
+                api_key, &user_id, token_uuid);
+            if (token_result == DB_API_TOKEN_OK &&
+                db_auth_get_user_by_id(user_id, user) == 0 &&
+                user->is_active &&
+                db_auth_ip_allowed_for_user(user, effective_client_ip)) {
+                user->authenticated_via_scoped_token = true;
+                safe_strcpy(user->api_token_uuid, token_uuid,
+                            sizeof(user->api_token_uuid), 0);
+                return 1;
+            }
+        }
     }
 
     return 0;
+}
+
+int httpd_get_authenticated_user(const http_request_t *req, user_t *user) {
+    return get_authenticated_user(req, user, false);
 }
 
 int httpd_check_admin_privileges(const http_request_t *req, http_response_t *res) {
@@ -442,11 +463,12 @@ int httpd_is_demo_mode(void) {
     return g_config.demo_mode ? 1 : 0;
 }
 
-int httpd_check_viewer_access(const http_request_t *req, user_t *user) {
+static int check_viewer_access(const http_request_t *req, user_t *user,
+                               bool allow_scoped_token) {
     if (!user) return 0;
 
     // First, try to get an authenticated user
-    if (httpd_get_authenticated_user(req, user)) {
+    if (get_authenticated_user(req, user, allow_scoped_token)) {
         // User is authenticated - they have at least viewer access
         return 1;
     }
@@ -476,6 +498,15 @@ int httpd_check_viewer_access(const http_request_t *req, user_t *user) {
     return 0;
 }
 
+
+int httpd_check_viewer_access(const http_request_t *req, user_t *user) {
+    return check_viewer_access(req, user, false);
+}
+
+int httpd_check_action_access(const http_request_t *req, user_t *user) {
+    return check_viewer_access(req, user, true);
+}
+
 int httpd_authorize_action(const http_request_t *req, http_response_t *res,
                            authorization_action_t action,
                            const fleet_camera_t *camera, user_t *user,
@@ -483,7 +514,7 @@ int httpd_authorize_action(const http_request_t *req, http_response_t *res,
     if (!req || !res || !user || !evaluation) return 0;
     memset(user, 0, sizeof(*user));
     memset(evaluation, 0, sizeof(*evaluation));
-    if (!httpd_check_viewer_access(req, user)) {
+    if (!httpd_check_action_access(req, user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return 0;
     }
@@ -520,7 +551,7 @@ int httpd_authorize_stream_action(const http_request_t *req,
                                   authorization_action_t action,
                                   const char *stream_name) {
     user_t user;
-    if (!httpd_check_viewer_access(req, &user)) {
+    if (!httpd_check_action_access(req, &user)) {
         http_response_set_json_error(res, 401, "Unauthorized");
         return 0;
     }

--- a/src/web/libuv_api_handlers.c
+++ b/src/web/libuv_api_handlers.c
@@ -249,6 +249,15 @@ int register_all_libuv_handlers(http_server_handle_t server) {
                                  handle_put_authorization_role);
     http_server_register_handler(server, "/api/authorization/roles/#", "DELETE",
                                  handle_delete_authorization_role);
+    http_server_register_handler(server,
+                                 "/api/authorization/users/#/tokens", "GET",
+                                 handle_get_user_api_tokens);
+    http_server_register_handler(server,
+                                 "/api/authorization/users/#/tokens", "POST",
+                                 handle_post_user_api_token);
+    http_server_register_handler(server,
+                                 "/api/authorization/users/#/tokens/#", "DELETE",
+                                 handle_delete_user_api_token);
     http_server_register_handler(server, "/api/authorization/users/#", "GET",
                                  handle_get_user_authorization);
     http_server_register_handler(server, "/api/authorization/users/#", "PUT",

--- a/tests/unit/test_authorization.c
+++ b/tests/unit/test_authorization.c
@@ -18,6 +18,7 @@
 #include "core/authorization.h"
 #include "core/config.h"
 #include "database/db_auth.h"
+#include "database/db_api_tokens.h"
 #include "database/db_authorization.h"
 #include "database/db_camera_collections.h"
 #include "database/db_camera_tags.h"
@@ -33,6 +34,7 @@
 #include "web/api_handlers_recordings_batch_download.h"
 #include "web/api_handlers_recordings_download.h"
 #include "web/api_handlers_users.h"
+#include "web/httpd_utils.h"
 #include "web/request_response.h"
 
 #define TEST_DB_PATH "/tmp/lightnvr_unit_authorization_test.db"
@@ -153,6 +155,27 @@ static cJSON *call_handler(
     int expected_status) {
     return call_handler_path(handler, method, NULL, body, api_key,
                              expected_status);
+}
+
+static int authorize_stream_with_key(const char *api_key,
+                                     authorization_action_t action,
+                                     const char *stream_name,
+                                     int expected_status) {
+    http_request_t req;
+    http_response_t res;
+    http_request_init(&req);
+    http_response_init(&res);
+    safe_strcpy(req.client_ip, "127.0.0.1", sizeof(req.client_ip), 0);
+    safe_strcpy(req.headers[0].name, "X-API-Key",
+                sizeof(req.headers[0].name), 0);
+    safe_strcpy(req.headers[0].value, api_key,
+                sizeof(req.headers[0].value), 0);
+    req.num_headers = 1;
+    int allowed =
+        httpd_authorize_stream_action(&req, &res, action, stream_name);
+    TEST_ASSERT_EQUAL_INT(expected_status, res.status_code);
+    http_response_free(&res);
+    return allowed;
 }
 
 void setUp(void) {
@@ -486,6 +509,114 @@ void test_shared_collection_grants_track_membership_and_guard_scope(void) {
              (long long)cleared_version, OPERATOR_ROLE_UUID,
              private_collection.uuid);
     json = call_handler_path(handle_put_user_authorization, HTTP_METHOD_PUT,
+                             path, body, NULL, 400);
+    cJSON_Delete(json);
+}
+
+void test_scoped_api_token_intersects_user_policy_and_revokes(void) {
+    stream_config_t allowed = create_camera("Token Allowed", "Token");
+    stream_config_t denied = create_camera("Token Denied", "Token");
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("tokenoperator", "password123", NULL,
+                               USER_ROLE_USER, true, &user_id));
+    TEST_ASSERT_EQUAL_INT(0,
+                          db_authorization_set_user_mode(user_id, "policy"));
+    char grant_uuid[CAMERA_UUID_STRING_SIZE];
+    create_grant(user_id, OPERATOR_ROLE_UUID, "all", NULL, grant_uuid);
+
+    int64_t expiry = (int64_t)time(NULL) + 3600;
+    char path[128];
+    snprintf(path, sizeof(path), "/api/authorization/users/%lld/tokens",
+             (long long)user_id);
+    char body[1536];
+    snprintf(body, sizeof(body),
+             "{\"description\":\"North PTZ integration\","
+             "\"expires_at\":%lld,\"actions\":[\"ptz.control\"],"
+             "\"scope\":{\"type\":\"selector\",\"selector\":{"
+             "\"version\":1,\"expression\":{\"op\":\"camera_uuid\","
+             "\"values\":[\"%s\"]}}}}",
+             (long long)expiry, allowed.camera_uuid);
+    cJSON *json = call_handler_path(
+        handle_post_user_api_token, HTTP_METHOD_POST, path, body, NULL, 201);
+    cJSON *secret_item = cJSON_GetObjectItemCaseSensitive(json, "secret");
+    cJSON *created = cJSON_GetObjectItemCaseSensitive(json, "token");
+    TEST_ASSERT_TRUE(cJSON_IsString(secret_item));
+    TEST_ASSERT_TRUE(strncmp(secret_item->valuestring, "lnvr_", 5) == 0);
+    char secret[API_TOKEN_SECRET_MAX];
+    char token_uuid[CAMERA_UUID_STRING_SIZE];
+    safe_strcpy(secret, secret_item->valuestring, sizeof(secret), 0);
+    safe_strcpy(token_uuid,
+                cJSON_GetObjectItemCaseSensitive(created, "uuid")->valuestring,
+                sizeof(token_uuid), 0);
+    cJSON_Delete(json);
+
+    sqlite3 *db = get_db_handle();
+    sqlite3_stmt *stmt = NULL;
+    TEST_ASSERT_EQUAL_INT(
+        SQLITE_OK,
+        sqlite3_prepare_v2(
+            db, "SELECT token_hash FROM authz_api_tokens WHERE uuid=?;", -1,
+            &stmt, NULL));
+    sqlite3_bind_text(stmt, 1, token_uuid, -1, SQLITE_TRANSIENT);
+    TEST_ASSERT_EQUAL_INT(SQLITE_ROW, sqlite3_step(stmt));
+    const char *stored_hash = (const char *)sqlite3_column_text(stmt, 0);
+    TEST_ASSERT_NOT_NULL(stored_hash);
+    TEST_ASSERT_EQUAL_UINT(64, strlen(stored_hash));
+    TEST_ASSERT_NOT_EQUAL(0, strcmp(secret, stored_hash));
+    sqlite3_finalize(stmt);
+
+    json = call_handler_path(handle_get_user_api_tokens, HTTP_METHOD_GET,
+                             path, NULL, NULL, 200);
+    TEST_ASSERT_EQUAL_INT(
+        1, cJSON_GetObjectItemCaseSensitive(json, "count")->valueint);
+    TEST_ASSERT_NULL(cJSON_GetObjectItemCaseSensitive(
+        cJSON_GetArrayItem(cJSON_GetObjectItemCaseSensitive(json, "tokens"), 0),
+        "secret"));
+    cJSON_Delete(json);
+
+    g_config.web_auth_enabled = true;
+    TEST_ASSERT_EQUAL_INT(
+        1, authorize_stream_with_key(secret, AUTHZ_PTZ_CONTROL,
+                                     allowed.name, 200));
+    TEST_ASSERT_EQUAL_INT(
+        0, authorize_stream_with_key(secret, AUTHZ_PTZ_CONTROL,
+                                     denied.name, 403));
+    TEST_ASSERT_EQUAL_INT(
+        0, authorize_stream_with_key(secret, AUTHZ_EVIDENCE_PROTECT,
+                                     allowed.name, 403));
+
+    http_request_t request;
+    http_request_init(&request);
+    safe_strcpy(request.client_ip, "127.0.0.1", sizeof(request.client_ip), 0);
+    safe_strcpy(request.headers[0].name, "X-API-Key",
+                sizeof(request.headers[0].name), 0);
+    safe_strcpy(request.headers[0].value, secret,
+                sizeof(request.headers[0].value), 0);
+    request.num_headers = 1;
+    user_t authenticated;
+    TEST_ASSERT_EQUAL_INT(
+        0, httpd_get_authenticated_user(&request, &authenticated));
+
+    g_config.web_auth_enabled = false;
+    char revoke_path[192];
+    snprintf(revoke_path, sizeof(revoke_path),
+             "/api/authorization/users/%lld/tokens/%s",
+             (long long)user_id, token_uuid);
+    json = call_handler_path(handle_delete_user_api_token,
+                             HTTP_METHOD_DELETE, revoke_path, NULL, NULL, 200);
+    cJSON_Delete(json);
+    g_config.web_auth_enabled = true;
+    TEST_ASSERT_EQUAL_INT(
+        0, authorize_stream_with_key(secret, AUTHZ_PTZ_CONTROL,
+                                     allowed.name, 401));
+    g_config.web_auth_enabled = false;
+
+    snprintf(body, sizeof(body),
+             "{\"description\":\"No expiry\","
+             "\"actions\":[\"ptz.control\"],"
+             "\"scope\":{\"type\":\"all\"}}");
+    json = call_handler_path(handle_post_user_api_token, HTTP_METHOD_POST,
                              path, body, NULL, 400);
     cJSON_Delete(json);
 }
@@ -1055,6 +1186,7 @@ int main(void) {
     RUN_TEST(test_all_scope_admin_grant_allows_global_action_and_bumps_version);
     RUN_TEST(test_invalid_stored_selector_fails_closed);
     RUN_TEST(test_shared_collection_grants_track_membership_and_guard_scope);
+    RUN_TEST(test_scoped_api_token_intersects_user_policy_and_revokes);
     RUN_TEST(test_action_catalog_and_simulation_handlers);
     RUN_TEST(test_role_and_policy_database_mutations_are_atomic);
     RUN_TEST(test_policy_management_handlers_and_conflict_guards);


### PR DESCRIPTION
## Summary

- add independently revocable API tokens with mandatory expiry, action scopes, and all/selector/shared-collection camera scopes
- store only a SHA-256 token hash and display prefix; return the secret once at creation
- intersect every token decision with the owning user's current effective policy so a token can never widen access
- accept scoped tokens only in handlers that immediately use centralized authorization, while legacy handlers fail closed
- bind asynchronous batch-download status/results to the exact token that created the job
- guard referenced shared collections from privacy/deletion changes and invalidate policy caches when membership changes
- expose self-service and `users.manage` list/create/revoke APIs and document the incremental enforcement contract

## Stack

- Depends on #514 (`feat/authz-collection-grants`)
- A follow-up PR will add the token-management UI and retain the legacy key only as an explicitly marked compatibility path.

## Validation

- `cmake --build build --target test_authorization test_httpd_utils test_db_camera_collections lightnvr -j2`
- `build/bin/test_authorization` — 13 tests, 0 failures
- `build/bin/test_httpd_utils` — 35 tests, 0 failures
- `build/bin/test_db_camera_collections` — 6 tests, 0 failures
- fresh-database migration run — 54 migrations applied, including embedded migration 0054
- `git diff --check`
