### PR TITLE
fix(auth): close scoping, escalation, and durability gaps in the authz stack

### DIFF
--- a/db/migrations/0056_harden_authorization_metadata.sql
+++ b/db/migrations/0056_harden_authorization_metadata.sql
@@ -1,0 +1,63 @@
+-- Make the persisted action-mask layout explicit, stop empty camera UUIDs at
+-- the source, and let the legacy tag backfill run once instead of every boot.
+
+-- migrate:up
+
+-- authz_api_tokens.action_mask stores one bit per action, positioned by the
+-- authorization_action_t ordinal. Recording that position makes the coupling
+-- visible to operators and lets the daemon detect catalog drift at startup
+-- instead of silently re-mapping every issued token.
+ALTER TABLE authz_actions ADD COLUMN bit_index INTEGER NOT NULL DEFAULT -1;
+
+UPDATE authz_actions SET bit_index = CASE action_key
+    WHEN 'live.view'          THEN 0
+    WHEN 'audio.listen'       THEN 1
+    WHEN 'audio.talk'         THEN 2
+    WHEN 'recordings.replay'  THEN 3
+    WHEN 'recordings.export'  THEN 4
+    WHEN 'snapshot.create'    THEN 5
+    WHEN 'ptz.control'        THEN 6
+    WHEN 'evidence.protect'   THEN 7
+    WHEN 'recording.delete'   THEN 8
+    WHEN 'camera.configure'   THEN 9
+    WHEN 'fleet.execute_job'  THEN 10
+    WHEN 'storage.configure'  THEN 11
+    WHEN 'events.configure'   THEN 12
+    WHEN 'users.manage'       THEN 13
+    WHEN 'system.admin'       THEN 14
+    ELSE -1
+END;
+
+CREATE UNIQUE INDEX idx_authz_actions_bit_index
+ON authz_actions(bit_index);
+
+-- streams.camera_uuid defaults to '' so the 0048 backfill could run, but the
+-- unique index then lets exactly one row hold '' and fails every later insert
+-- with a confusing constraint error. Reject the empty value outright so any
+-- code path that forgets to generate a UUID fails loudly on the first row.
+CREATE TRIGGER trg_streams_camera_uuid_insert
+BEFORE INSERT ON streams
+FOR EACH ROW WHEN NEW.camera_uuid IS NULL OR NEW.camera_uuid = ''
+BEGIN
+    SELECT RAISE(ABORT, 'streams.camera_uuid must be a generated UUID');
+END;
+
+CREATE TRIGGER trg_streams_camera_uuid_update
+BEFORE UPDATE OF camera_uuid ON streams
+FOR EACH ROW WHEN NEW.camera_uuid IS NULL OR NEW.camera_uuid = ''
+BEGIN
+    SELECT RAISE(ABORT, 'streams.camera_uuid must be a generated UUID');
+END;
+
+-- The 0050 legacy tag backfill is idempotent but rewrites every assignment on
+-- every startup. Record completion so it becomes a one-time migration step.
+INSERT OR IGNORE INTO system_settings (key, value)
+VALUES ('camera_tags_backfill_completed', '0');
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_streams_camera_uuid_update;
+DROP TRIGGER IF EXISTS trg_streams_camera_uuid_insert;
+DROP INDEX IF EXISTS idx_authz_actions_bit_index;
+DELETE FROM system_settings WHERE key = 'camera_tags_backfill_completed';
+SELECT 1;

--- a/docs/API.md
+++ b/docs/API.md
@@ -87,6 +87,22 @@ GET /api/authorization/actions
 Administrator-only. Returns the stable action key, category, description,
 whether a camera resource is required, and whether the action is destructive.
 
+Each entry also reports:
+
+- `enforced` — whether any request handler currently routes through the
+  centralized evaluator for this action. Actions are grantable ahead of their
+  enforcement work, so clients must label the unenforced ones rather than imply
+  a boundary that is not applied yet. See
+  `docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md` for the coverage map.
+- `mask_bit` — the bit position this action occupies in a persisted API token
+  `action_mask`. The position is frozen once an action ships; the daemon refuses
+  to start if the stored layout in `authz_actions` disagrees with the binary.
+
+A policy manager may only author roles, grants, and tokens whose actions are a
+subset of the authority it holds itself. Requests that would widen the
+requester's own authority are rejected with `403` and name the offending
+actions, so `users.manage` cannot be used as a path to `system.admin`.
+
 #### Simulate authorization
 
 ```

--- a/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
+++ b/docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md
@@ -44,6 +44,26 @@ List handlers must filter unauthorized cameras before calculating totals,
 facets, or collection membership. A request for one unauthorized camera returns
 `403` without disclosing camera metadata.
 
+`authorization_filter_visible_cameras()` implements that rule for every handler
+that loads the fleet inventory: `POST /api/fleet/cameras/query`,
+`POST /api/fleet/selectors/preview`, the collection reads and previews, and the
+collection-to-stream-name resolution used by recording filters. It evaluates
+`live.view` per camera through one shared evaluation context, so the whole page
+costs a single grant load. Legacy-mode principals keep their allowed-tags
+behaviour because the evaluator applies that restriction for them.
+
+Rows still marked "Existing" below have not moved to the centralized evaluator.
+Their actions are reported with `"enforced": false` by
+`GET /api/authorization/actions` so an operator authoring a policy can see which
+boundaries the daemon does not apply yet.
+
+Scoped API tokens authenticate only on routes that call
+`httpd_check_action_access()`. A route still using `httpd_check_viewer_access()`
+rejects a scoped token with `401` rather than ignoring its scope, which is the
+fail-closed behaviour but also means a token carrying an unenforced action
+cannot be used at all. The token UI therefore offers only actions that are both
+enforced and reachable with a scoped token.
+
 ## Camera administration
 
 | Routes | Required action | Current enforcement |

--- a/include/core/authorization.h
+++ b/include/core/authorization.h
@@ -39,6 +39,14 @@ typedef struct {
     const char *description;
     bool camera_scoped;
     bool destructive;
+    /*
+     * True once at least one request handler routes this action through the
+     * centralized evaluator. Unenforced actions are still grantable so that a
+     * policy can be authored ahead of the enforcement work, but they must be
+     * reported as unenforced so operators are not told a boundary exists
+     * before it does. See docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md.
+     */
+    bool enforced;
 } authorization_action_metadata_t;
 
 typedef enum {
@@ -70,6 +78,54 @@ const authorization_action_metadata_t *authorization_action_metadata(
 authorization_action_t authorization_action_from_key(const char *key);
 const char *authorization_decision_source_name(
     authorization_decision_source_t source);
+
+/*
+ * Bit position of an action inside a persisted action mask. The mask is stored
+ * in authz_api_tokens.action_mask, so the position must never change for an
+ * action that has shipped. db_authorization_verify_action_catalog() checks the
+ * running catalog against the authz_actions table at startup.
+ */
+uint64_t authorization_action_bit(authorization_action_t action);
+
+/*
+ * Union of every action reachable by a principal, ignoring resource scope.
+ * Used to stop a policy manager from minting authority it does not itself
+ * hold. Returns 0 on success and -1 on evaluation failure.
+ */
+int authorization_effective_action_mask(const user_t *user, uint64_t *mask);
+
+/*
+ * Reusable evaluation state for callers that authorize many resources in one
+ * request. The context memoizes the grants loaded for a user/action, the
+ * selectors parsed from those grants, the collection filters they reference,
+ * and the scoped API token, none of which change while a request is running.
+ * A context is owned by one thread and must not be shared between requests.
+ */
+typedef struct authorization_context authorization_context_t;
+
+authorization_context_t *authorization_context_create(void);
+void authorization_context_free(authorization_context_t *context);
+
+int authorization_evaluate_in_context(authorization_context_t *context,
+                                      const user_t *user,
+                                      authorization_action_t action,
+                                      const fleet_camera_t *camera,
+                                      authorization_evaluation_t *evaluation);
+
+/*
+ * Reduce a loaded fleet inventory in place to the cameras a user may see.
+ *
+ * Applies the same centralized live.view decision the per-camera endpoints
+ * use, so list handlers cannot disclose cameras outside a policy grant while
+ * computing totals, facets, or collection membership. Legacy-mode principals
+ * keep their allowed-tags behaviour because the evaluator applies it for them.
+ * Uses one shared context, so the cost is one grant load for the whole page.
+ *
+ * Returns 0 with *count reduced, or -1 on evaluation failure. Callers must
+ * fail closed rather than serving an unfiltered list.
+ */
+int authorization_filter_visible_cameras(const user_t *user,
+                                         fleet_camera_t *cameras, int *count);
 
 /*
  * Evaluate one user/action/resource tuple. A NULL camera is valid for global

--- a/include/database/db_authorization.h
+++ b/include/database/db_authorization.h
@@ -97,6 +97,13 @@ int db_authorization_create_user_grant(
     const char *selector_json, const char *collection_uuid,
     char grant_uuid[CAMERA_UUID_STRING_SIZE]);
 
+/*
+ * Fail startup when authz_actions disagrees with the compiled action catalog.
+ * The table records the persisted action-mask bit layout, so drift would
+ * silently re-map the permissions of every already-issued API token.
+ */
+int db_authorization_verify_action_catalog(void);
+
 /* Switch a user only after valid grants have been created and previewed. */
 int db_authorization_set_user_mode(int64_t user_id, const char *mode);
 

--- a/include/database/db_camera_tags.h
+++ b/include/database/db_camera_tags.h
@@ -48,6 +48,14 @@ db_camera_tag_result_t db_camera_tag_set_for_camera(
  * startup immediately after migrations. */
 int db_camera_tags_backfill_legacy(void);
 
+/*
+ * Run the legacy backfill only the first time this schema version starts.
+ * The backfill rewrites every assignment for every camera, and both tag
+ * writers keep streams.tags and the normalized tables consistent afterwards,
+ * so repeating it on each boot is pure churn.
+ */
+int db_camera_tags_backfill_legacy_once(void);
+
 /* Compatibility bridge used by db_streams.c while the database mutex is held.
  * The normalized assignments are replaced from the legacy comma-separated
  * value. The caller must already own get_db_mutex(). */

--- a/include/database/db_embedded_migrations.h
+++ b/include/database/db_embedded_migrations.h
@@ -1048,6 +1048,51 @@ static const char migration_0055_down[] =
     "DROP TABLE IF EXISTS audit_events;\n"
     "SELECT 1;";
 
+static const char migration_0056_up[] =
+    "ALTER TABLE authz_actions "
+    "ADD COLUMN bit_index INTEGER NOT NULL DEFAULT -1;\n"
+    "UPDATE authz_actions SET bit_index = CASE action_key "
+    "WHEN 'live.view' THEN 0 "
+    "WHEN 'audio.listen' THEN 1 "
+    "WHEN 'audio.talk' THEN 2 "
+    "WHEN 'recordings.replay' THEN 3 "
+    "WHEN 'recordings.export' THEN 4 "
+    "WHEN 'snapshot.create' THEN 5 "
+    "WHEN 'ptz.control' THEN 6 "
+    "WHEN 'evidence.protect' THEN 7 "
+    "WHEN 'recording.delete' THEN 8 "
+    "WHEN 'camera.configure' THEN 9 "
+    "WHEN 'fleet.execute_job' THEN 10 "
+    "WHEN 'storage.configure' THEN 11 "
+    "WHEN 'events.configure' THEN 12 "
+    "WHEN 'users.manage' THEN 13 "
+    "WHEN 'system.admin' THEN 14 "
+    "ELSE -1 END;\n"
+    "CREATE UNIQUE INDEX idx_authz_actions_bit_index "
+    "ON authz_actions(bit_index);\n"
+    "CREATE TRIGGER trg_streams_camera_uuid_insert "
+    "BEFORE INSERT ON streams "
+    "FOR EACH ROW WHEN NEW.camera_uuid IS NULL OR NEW.camera_uuid = '' "
+    "BEGIN "
+    "SELECT RAISE(ABORT, 'streams.camera_uuid must be a generated UUID'); "
+    "END;\n"
+    "CREATE TRIGGER trg_streams_camera_uuid_update "
+    "BEFORE UPDATE OF camera_uuid ON streams "
+    "FOR EACH ROW WHEN NEW.camera_uuid IS NULL OR NEW.camera_uuid = '' "
+    "BEGIN "
+    "SELECT RAISE(ABORT, 'streams.camera_uuid must be a generated UUID'); "
+    "END;\n"
+    "INSERT OR IGNORE INTO system_settings (key, value) "
+    "VALUES ('camera_tags_backfill_completed', '0');";
+
+static const char migration_0056_down[] =
+    "DROP TRIGGER IF EXISTS trg_streams_camera_uuid_update;\n"
+    "DROP TRIGGER IF EXISTS trg_streams_camera_uuid_insert;\n"
+    "DROP INDEX IF EXISTS idx_authz_actions_bit_index;\n"
+    "DELETE FROM system_settings "
+    "WHERE key = 'camera_tags_backfill_completed';\n"
+    "SELECT 1;";
+
 static const migration_t embedded_migrations_data[] = {
     {
         .version = "0001",
@@ -1434,8 +1479,15 @@ static const migration_t embedded_migrations_data[] = {
         .sql_down = migration_0055_down,
         .is_embedded = true
     },
+    {
+        .version = "0056",
+        .description = "harden_authorization_metadata",
+        .sql_up = migration_0056_up,
+        .sql_down = migration_0056_down,
+        .is_embedded = true
+    },
 };
 
-#define EMBEDDED_MIGRATIONS_COUNT 55
+#define EMBEDDED_MIGRATIONS_COUNT 56
 
 #endif /* DB_EMBEDDED_MIGRATIONS_H */

--- a/include/web/httpd_utils.h
+++ b/include/web/httpd_utils.h
@@ -11,6 +11,7 @@
 #define HTTPD_UTILS_H
 
 #include <cjson/cJSON.h>
+#include <stdbool.h>
 #include "web/request_response.h"
 #include "database/db_auth.h"
 #include "core/authorization.h"
@@ -53,6 +54,15 @@ int httpd_get_api_key(const http_request_t *req, char *api_key, size_t api_key_s
  * @return 0 on success, -1 on error
  */
 int httpd_get_effective_client_ip(const http_request_t *req, char *client_ip, size_t client_ip_size);
+
+/**
+ * @brief Whether the direct peer is inside trusted_proxy_cidrs.
+ *
+ * Request metadata that a client can set freely (forwarded addresses, an
+ * inbound correlation ID) may only be believed when it came from a proxy the
+ * operator declared. Defaults to false when no proxies are configured.
+ */
+bool httpd_peer_is_trusted_proxy(const http_request_t *req);
 
 /**
  * @brief Get the authenticated user from the HTTP request

--- a/src/core/authorization.c
+++ b/src/core/authorization.c
@@ -11,42 +11,49 @@
 #include "database/db_authorization.h"
 #include "utils/strings.h"
 
+/*
+ * Catalog order defines the persisted action-mask bit positions (see
+ * authorization_action_bit). Append new actions at the end of the enum in
+ * core/authorization.h; reordering silently re-maps every issued API token.
+ */
 static const authorization_action_metadata_t action_catalog[] = {
     {AUTHZ_LIVE_VIEW, "live.view", "Live video",
-     "View a camera live stream", true, false},
+     "View a camera live stream", true, false, true},
     {AUTHZ_AUDIO_LISTEN, "audio.listen", "Live video",
-     "Listen to camera audio", true, false},
+     "Listen to camera audio", true, false, false},
     {AUTHZ_AUDIO_TALK, "audio.talk", "Live video",
-     "Transmit audio to a camera", true, false},
+     "Transmit audio to a camera", true, false, false},
     {AUTHZ_RECORDINGS_REPLAY, "recordings.replay", "Recordings",
-     "Replay recorded video", true, false},
+     "Replay recorded video", true, false, false},
     {AUTHZ_RECORDINGS_EXPORT, "recordings.export", "Recordings",
-     "Download or export recorded video", true, false},
+     "Download or export recorded video", true, false, true},
     {AUTHZ_SNAPSHOT_CREATE, "snapshot.create", "Recordings",
-     "Create or download a camera snapshot", true, false},
+     "Create or download a camera snapshot", true, false, false},
     {AUTHZ_PTZ_CONTROL, "ptz.control", "Camera operation",
-     "Move PTZ cameras and manage presets", true, false},
+     "Move PTZ cameras and manage presets", true, false, true},
     {AUTHZ_EVIDENCE_PROTECT, "evidence.protect", "Recordings",
-     "Protect or release recordings from retention", true, true},
+     "Protect or release recordings from retention", true, true, true},
     {AUTHZ_RECORDING_DELETE, "recording.delete", "Recordings",
-     "Permanently delete recordings", true, true},
+     "Permanently delete recordings", true, true, true},
     {AUTHZ_CAMERA_CONFIGURE, "camera.configure", "Camera administration",
-     "Add, change, or remove camera configuration", true, true},
+     "Add, change, or remove camera configuration", true, true, false},
     {AUTHZ_FLEET_EXECUTE_JOB, "fleet.execute_job", "Camera administration",
-     "Execute a bulk fleet operation", true, true},
+     "Execute a bulk fleet operation", true, true, false},
     {AUTHZ_STORAGE_CONFIGURE, "storage.configure", "System administration",
-     "Change storage and retention configuration", false, true},
+     "Change storage and retention configuration", false, true, false},
     {AUTHZ_EVENTS_CONFIGURE, "events.configure", "System administration",
-     "Change event routes and destinations", false, true},
+     "Change event routes and destinations", false, true, false},
     {AUTHZ_USERS_MANAGE, "users.manage", "System administration",
-     "Manage users, roles, and grants", false, true},
+     "Manage users, roles, and grants", false, true, true},
     {AUTHZ_SYSTEM_ADMIN, "system.admin", "System administration",
-     "Change or control the lightNVR system", false, true},
+     "Change or control the lightNVR system", false, true, true},
 };
 
 _Static_assert(sizeof(action_catalog) / sizeof(action_catalog[0]) ==
                    AUTHZ_ACTION_COUNT,
                "authorization action catalog must match the enum");
+_Static_assert(AUTHZ_ACTION_COUNT <= 64,
+               "action masks are persisted as 64-bit integers");
 
 const authorization_action_metadata_t *authorization_action_catalog(
     int *action_count) {
@@ -68,6 +75,11 @@ authorization_action_t authorization_action_from_key(const char *key) {
         }
     }
     return AUTHZ_ACTION_INVALID;
+}
+
+uint64_t authorization_action_bit(authorization_action_t action) {
+    if (action < 0 || action >= AUTHZ_ACTION_COUNT) return 0;
+    return UINT64_C(1) << action;
 }
 
 const char *authorization_decision_source_name(
@@ -99,6 +111,187 @@ static bool legacy_role_allows(user_role_t role,
         default:
             return false;
     }
+}
+
+/* ------------------------------------------------------------------ */
+/* Evaluation context                                                  */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    char uuid[CAMERA_UUID_STRING_SIZE];
+    camera_collection_filter_t filter;
+    bool failed;
+} collection_cache_entry_t;
+
+typedef struct {
+    int64_t user_id;
+    authorization_action_t action;
+    authorization_grant_t *grants;
+    fleet_selector_t **selectors;
+    int grant_count;
+    int64_t policy_version;
+    bool failed;
+} grant_cache_entry_t;
+
+struct authorization_context {
+    grant_cache_entry_t *grants;
+    int grant_count;
+    int grant_capacity;
+    collection_cache_entry_t *collections;
+    int collection_count;
+    int collection_capacity;
+    bool token_loaded;
+    bool token_valid;
+    api_token_t token;
+};
+
+authorization_context_t *authorization_context_create(void) {
+    return calloc(1, sizeof(authorization_context_t));
+}
+
+void authorization_context_free(authorization_context_t *context) {
+    if (!context) return;
+    for (int i = 0; i < context->grant_count; i++) {
+        grant_cache_entry_t *entry = &context->grants[i];
+        if (entry->selectors) {
+            for (int j = 0; j < entry->grant_count; j++) {
+                fleet_selector_free(entry->selectors[j]);
+            }
+            free(entry->selectors);
+        }
+        free(entry->grants);
+    }
+    free(context->grants);
+    for (int i = 0; i < context->collection_count; i++) {
+        camera_collection_filter_free(&context->collections[i].filter);
+    }
+    free(context->collections);
+    free(context);
+}
+
+static void *grow_array(void *items, int *capacity, size_t item_size) {
+    int next_capacity = *capacity == 0 ? 4 : *capacity * 2;
+    void *resized = realloc(items, (size_t)next_capacity * item_size);
+    if (!resized) return NULL;
+    *capacity = next_capacity;
+    return resized;
+}
+
+/*
+ * Resolve a shared collection into a reusable filter. Returns NULL when the
+ * collection cannot be used as an authorization boundary, which the caller
+ * must treat as an evaluation failure rather than a deny.
+ */
+static const camera_collection_filter_t *context_collection_filter(
+    authorization_context_t *context, const char *collection_uuid) {
+    if (!collection_uuid || collection_uuid[0] == '\0') return NULL;
+    for (int i = 0; i < context->collection_count; i++) {
+        if (strcmp(context->collections[i].uuid, collection_uuid) == 0) {
+            return context->collections[i].failed
+                ? NULL : &context->collections[i].filter;
+        }
+    }
+    if (context->collection_count == context->collection_capacity) {
+        void *resized = grow_array(context->collections,
+                                   &context->collection_capacity,
+                                   sizeof(*context->collections));
+        if (!resized) return NULL;
+        context->collections = resized;
+    }
+    collection_cache_entry_t *entry =
+        &context->collections[context->collection_count++];
+    memset(entry, 0, sizeof(*entry));
+    safe_strcpy(entry->uuid, collection_uuid, sizeof(entry->uuid), 0);
+    entry->failed = camera_collection_filter_load_for_authorization(
+                        collection_uuid, &entry->filter) !=
+                    CAMERA_COLLECTION_FILTER_OK;
+    return entry->failed ? NULL : &entry->filter;
+}
+
+static fleet_selector_t *parse_selector(const char *serialized) {
+    if (!serialized || serialized[0] == '\0') return NULL;
+    cJSON *json = cJSON_Parse(serialized);
+    if (!json) return NULL;
+    char error[FLEET_SELECTOR_ERROR_MAX] = {0};
+    fleet_selector_t *selector =
+        fleet_selector_parse(json, error, sizeof(error));
+    cJSON_Delete(json);
+    return selector;
+}
+
+/*
+ * Load, and memoize, the enabled grants that carry an action for a user. The
+ * selectors are parsed once here instead of once per candidate camera.
+ */
+static const grant_cache_entry_t *context_grants(
+    authorization_context_t *context, int64_t user_id,
+    authorization_action_t action, const char *action_key) {
+    for (int i = 0; i < context->grant_count; i++) {
+        if (context->grants[i].user_id == user_id &&
+            context->grants[i].action == action) {
+            return context->grants[i].failed ? NULL : &context->grants[i];
+        }
+    }
+    if (context->grant_count == context->grant_capacity) {
+        void *resized = grow_array(context->grants, &context->grant_capacity,
+                                   sizeof(*context->grants));
+        if (!resized) return NULL;
+        context->grants = resized;
+    }
+    grant_cache_entry_t *entry = &context->grants[context->grant_count++];
+    memset(entry, 0, sizeof(*entry));
+    entry->user_id = user_id;
+    entry->action = action;
+
+    if (db_authorization_load_user_grants(user_id, action_key, &entry->grants,
+                                          &entry->grant_count,
+                                          &entry->policy_version) != 0) {
+        entry->failed = true;
+        entry->grants = NULL;
+        entry->grant_count = 0;
+        return NULL;
+    }
+    if (entry->grant_count > 0) {
+        entry->selectors = calloc((size_t)entry->grant_count,
+                                  sizeof(*entry->selectors));
+        if (!entry->selectors) {
+            entry->failed = true;
+            return NULL;
+        }
+        for (int i = 0; i < entry->grant_count; i++) {
+            if (strcmp(entry->grants[i].scope_type, "selector") != 0) continue;
+            entry->selectors[i] = parse_selector(entry->grants[i].selector_json);
+            if (!entry->selectors[i]) {
+                entry->failed = true;
+                return NULL;
+            }
+        }
+    }
+    return entry;
+}
+
+/* Returns 0 with *matches set, or -1 when the scope cannot be resolved. */
+static int grant_matches(authorization_context_t *context,
+                         const authorization_grant_t *grant,
+                         fleet_selector_t *selector,
+                         const fleet_camera_t *camera, bool *matches) {
+    *matches = false;
+    if (strcmp(grant->scope_type, "all") == 0) {
+        *matches = true;
+        return 0;
+    }
+    if (strcmp(grant->scope_type, "collection") == 0) {
+        if (!camera) return 0;
+        const camera_collection_filter_t *filter =
+            context_collection_filter(context, grant->collection_uuid);
+        if (!filter) return -1;
+        *matches = camera_collection_filter_matches(filter, camera);
+        return 0;
+    }
+    if (strcmp(grant->scope_type, "selector") != 0) return -1;
+    if (!camera || !selector) return 0;
+    *matches = fleet_selector_matches(selector, camera, NULL);
+    return 0;
 }
 
 static int evaluate_legacy(const user_t *user,
@@ -136,42 +329,8 @@ static int evaluate_legacy(const user_t *user,
     return 0;
 }
 
-static int grant_matches(const authorization_grant_t *grant,
-                         const fleet_camera_t *camera, bool *matches) {
-    *matches = false;
-    if (strcmp(grant->scope_type, "all") == 0) {
-        *matches = true;
-        return 0;
-    }
-    if (strcmp(grant->scope_type, "collection") == 0) {
-        if (!camera || grant->collection_uuid[0] == '\0') return 0;
-        camera_collection_filter_t filter;
-        camera_collection_filter_result_t result =
-            camera_collection_filter_load_for_authorization(
-                grant->collection_uuid, &filter);
-        if (result != CAMERA_COLLECTION_FILTER_OK) return -1;
-        *matches = camera_collection_filter_matches(&filter, camera);
-        camera_collection_filter_free(&filter);
-        return 0;
-    }
-    if (strcmp(grant->scope_type, "selector") != 0 || !camera ||
-        grant->selector_json[0] == '\0') {
-        return strcmp(grant->scope_type, "selector") == 0 ? 0 : -1;
-    }
-
-    cJSON *selector_json = cJSON_Parse(grant->selector_json);
-    if (!selector_json) return -1;
-    char error[FLEET_SELECTOR_ERROR_MAX] = {0};
-    fleet_selector_t *selector =
-        fleet_selector_parse(selector_json, error, sizeof(error));
-    cJSON_Delete(selector_json);
-    if (!selector) return -1;
-    *matches = fleet_selector_matches(selector, camera, NULL);
-    fleet_selector_free(selector);
-    return 0;
-}
-
-static int evaluate_principal(const user_t *user,
+static int evaluate_principal(authorization_context_t *context,
+                              const user_t *user,
                               authorization_action_t action,
                               const fleet_camera_t *camera,
                               authorization_evaluation_t *evaluation) {
@@ -193,34 +352,31 @@ static int evaluate_principal(const user_t *user,
         return evaluate_legacy(user, metadata, camera, evaluation);
     }
 
-    authorization_grant_t *grants = NULL;
-    int grant_count = 0;
-    if (db_authorization_load_user_grants(
-            user->id, metadata->key, &grants, &grant_count,
-            &evaluation->policy_version) != 0) {
-        return -1;
-    }
-    for (int i = 0; i < grant_count; i++) {
+    const grant_cache_entry_t *entry =
+        context_grants(context, user->id, action, metadata->key);
+    if (!entry) return -1;
+    evaluation->policy_version = entry->policy_version;
+
+    for (int i = 0; i < entry->grant_count; i++) {
         bool matches = false;
-        if (grant_matches(&grants[i], camera, &matches) != 0) {
-            free(grants);
+        if (grant_matches(context, &entry->grants[i],
+                          entry->selectors ? entry->selectors[i] : NULL,
+                          camera, &matches) != 0) {
             return -1;
         }
         if (!matches) continue;
         evaluation->decision = AUTHZ_DECISION_ALLOW;
         evaluation->source = AUTHZ_SOURCE_POLICY_GRANT;
-        safe_strcpy(evaluation->grant_uuid, grants[i].uuid,
+        safe_strcpy(evaluation->grant_uuid, entry->grants[i].uuid,
                     sizeof(evaluation->grant_uuid), 0);
-        safe_strcpy(evaluation->role_uuid, grants[i].role_uuid,
+        safe_strcpy(evaluation->role_uuid, entry->grants[i].role_uuid,
                     sizeof(evaluation->role_uuid), 0);
-        safe_strcpy(evaluation->role_name, grants[i].role_name,
+        safe_strcpy(evaluation->role_name, entry->grants[i].role_name,
                     sizeof(evaluation->role_name), 0);
         snprintf(evaluation->explanation, sizeof(evaluation->explanation),
-                 "Allowed by %s role grant", grants[i].role_name);
-        free(grants);
+                 "Allowed by %s role grant", entry->grants[i].role_name);
         return 0;
     }
-    free(grants);
     safe_strcpy(evaluation->explanation,
                 metadata->camera_scoped && !camera
                     ? "No all-fleet grant allows this action"
@@ -229,7 +385,8 @@ static int evaluate_principal(const user_t *user,
     return 0;
 }
 
-static int token_scope_matches(const api_token_t *token,
+static int token_scope_matches(authorization_context_t *context,
+                               const api_token_t *token,
                                const fleet_camera_t *camera, bool *matches) {
     *matches = false;
     if (strcmp(token->scope_type, "all") == 0) {
@@ -238,65 +395,79 @@ static int token_scope_matches(const api_token_t *token,
     }
     if (!camera) return 0;
     if (strcmp(token->scope_type, "collection") == 0) {
-        camera_collection_filter_t filter;
-        camera_collection_filter_result_t result =
-            camera_collection_filter_load_for_authorization(
-                token->collection_uuid, &filter);
-        if (result != CAMERA_COLLECTION_FILTER_OK) return -1;
-        *matches = camera_collection_filter_matches(&filter, camera);
-        camera_collection_filter_free(&filter);
+        const camera_collection_filter_t *filter =
+            context_collection_filter(context, token->collection_uuid);
+        if (!filter) return -1;
+        *matches = camera_collection_filter_matches(filter, camera);
         return 0;
     }
-    if (strcmp(token->scope_type, "selector") != 0 ||
-        token->selector_json[0] == '\0') {
-        return -1;
-    }
-    cJSON *json = cJSON_Parse(token->selector_json);
-    if (!json) return -1;
-    char error[FLEET_SELECTOR_ERROR_MAX] = {0};
-    fleet_selector_t *selector =
-        fleet_selector_parse(json, error, sizeof(error));
-    cJSON_Delete(json);
+    if (strcmp(token->scope_type, "selector") != 0) return -1;
+    fleet_selector_t *selector = parse_selector(token->selector_json);
     if (!selector) return -1;
     *matches = fleet_selector_matches(selector, camera, NULL);
     fleet_selector_free(selector);
     return 0;
 }
 
-int authorization_evaluate(const user_t *user, authorization_action_t action,
-                           const fleet_camera_t *camera,
-                           authorization_evaluation_t *evaluation) {
-    int result = evaluate_principal(user, action, camera, evaluation);
+static const api_token_t *context_token(authorization_context_t *context,
+                                        const user_t *user) {
+    if (context->token_loaded) {
+        return context->token_valid ? &context->token : NULL;
+    }
+    context->token_loaded = true;
+    db_api_token_result_t result =
+        db_api_token_get_active(user->api_token_uuid, &context->token);
+    context->token_valid =
+        result == DB_API_TOKEN_OK && context->token.user_id == user->id;
+    return context->token_valid ? &context->token : NULL;
+}
+
+int authorization_evaluate_in_context(authorization_context_t *context,
+                                      const user_t *user,
+                                      authorization_action_t action,
+                                      const fleet_camera_t *camera,
+                                      authorization_evaluation_t *evaluation) {
+    authorization_context_t *owned = NULL;
+    if (!context) {
+        owned = authorization_context_create();
+        if (!owned) return -1;
+        context = owned;
+    }
+
+    int result = evaluate_principal(context, user, action, camera, evaluation);
     if (result != 0 || !user || !evaluation ||
         evaluation->decision != AUTHZ_DECISION_ALLOW ||
         !user->authenticated_via_scoped_token) {
+        authorization_context_free(owned);
         return result;
     }
 
-    api_token_t token;
-    db_api_token_result_t token_result =
-        db_api_token_get_active(user->api_token_uuid, &token);
-    if (token_result == DB_API_TOKEN_ERROR) return -1;
-    if (token_result != DB_API_TOKEN_OK || token.user_id != user->id) {
+    const api_token_t *token = context_token(context, user);
+    if (!token) {
         evaluation->decision = AUTHZ_DECISION_DENY;
         evaluation->source = AUTHZ_SOURCE_NONE;
         safe_strcpy(evaluation->explanation,
                     "Scoped API token is expired, revoked, or unavailable",
                     sizeof(evaluation->explanation), 0);
+        authorization_context_free(owned);
         return 0;
     }
-    safe_strcpy(evaluation->token_uuid, token.uuid,
+    safe_strcpy(evaluation->token_uuid, token->uuid,
                 sizeof(evaluation->token_uuid), 0);
-    if ((token.action_mask & (UINT64_C(1) << action)) == 0) {
+    if ((token->action_mask & authorization_action_bit(action)) == 0) {
         evaluation->decision = AUTHZ_DECISION_DENY;
         evaluation->source = AUTHZ_SOURCE_NONE;
         safe_strcpy(evaluation->explanation,
                     "Scoped API token does not include this action",
                     sizeof(evaluation->explanation), 0);
+        authorization_context_free(owned);
         return 0;
     }
     bool matches = false;
-    if (token_scope_matches(&token, camera, &matches) != 0) return -1;
+    if (token_scope_matches(context, token, camera, &matches) != 0) {
+        authorization_context_free(owned);
+        return -1;
+    }
     if (!matches) {
         evaluation->decision = AUTHZ_DECISION_DENY;
         evaluation->source = AUTHZ_SOURCE_NONE;
@@ -304,14 +475,96 @@ int authorization_evaluate(const user_t *user, authorization_action_t action,
                     camera ? "Camera is outside the scoped API token"
                            : "Scoped API token is not valid for global actions",
                     sizeof(evaluation->explanation), 0);
+        authorization_context_free(owned);
         return 0;
     }
-    char principal_explanation[AUTHORIZATION_EXPLANATION_MAX];
-    safe_strcpy(principal_explanation, evaluation->explanation,
-                sizeof(principal_explanation), 0);
-    safe_strcpy(evaluation->explanation, principal_explanation,
-                sizeof(evaluation->explanation), 0);
     safe_strcat(evaluation->explanation, "; narrowed by scoped API token",
                 sizeof(evaluation->explanation));
+    authorization_context_free(owned);
+    return 0;
+}
+
+int authorization_evaluate(const user_t *user, authorization_action_t action,
+                           const fleet_camera_t *camera,
+                           authorization_evaluation_t *evaluation) {
+    return authorization_evaluate_in_context(NULL, user, action, camera,
+                                             evaluation);
+}
+
+int authorization_filter_visible_cameras(const user_t *user,
+                                         fleet_camera_t *cameras, int *count) {
+    if (!user || !count) return -1;
+    if (!cameras || *count <= 0) return 0;
+    /* With authentication off there is no principal to evaluate: handlers on
+     * that path never populate a user, and the rest of the codebase treats the
+     * request as an administrator. Filtering a zeroed user would instead hide
+     * every camera. */
+    if (!g_config.web_auth_enabled) return 0;
+
+    /* One context for the whole inventory: the grants, their selectors, and
+     * any collection they reference are loaded once instead of per camera. */
+    authorization_context_t *context = authorization_context_create();
+    if (!context) return -1;
+
+    int visible = 0;
+    for (int i = 0; i < *count; i++) {
+        authorization_evaluation_t evaluation;
+        if (authorization_evaluate_in_context(context, user, AUTHZ_LIVE_VIEW,
+                                              &cameras[i], &evaluation) != 0) {
+            authorization_context_free(context);
+            return -1;
+        }
+        if (evaluation.decision != AUTHZ_DECISION_ALLOW) continue;
+        if (visible != i) cameras[visible] = cameras[i];
+        visible++;
+    }
+    authorization_context_free(context);
+    *count = visible;
+    return 0;
+}
+
+int authorization_effective_action_mask(const user_t *user, uint64_t *mask) {
+    if (!user || !mask) return -1;
+    *mask = 0;
+    if (!user->is_active) return 0;
+
+    if (strcmp(user->authorization_mode, "policy") != 0) {
+        for (int i = 0; i < AUTHZ_ACTION_COUNT; i++) {
+            if (legacy_role_allows(user->role, action_catalog[i].action)) {
+                *mask |= authorization_action_bit(action_catalog[i].action);
+            }
+        }
+    } else {
+        char mode[USER_AUTHORIZATION_MODE_MAX];
+        authorization_grant_t *grants = NULL;
+        int grant_count = 0;
+        int64_t policy_version = 0;
+        if (db_authorization_get_user_policy(user->id, mode, &grants,
+                                             &grant_count, &policy_version) !=
+            DB_AUTHORIZATION_OK) {
+            return -1;
+        }
+        for (int i = 0; i < grant_count; i++) {
+            if (!grants[i].enabled) continue;
+            authorization_role_t role;
+            if (db_authorization_role_get(grants[i].role_uuid, &role) !=
+                DB_AUTHORIZATION_OK) {
+                free(grants);
+                return -1;
+            }
+            *mask |= role.action_mask;
+        }
+        free(grants);
+    }
+
+    /* A scoped token can never widen the authority it was minted from. */
+    if (user->authenticated_via_scoped_token) {
+        api_token_t token;
+        db_api_token_result_t result =
+            db_api_token_get_active(user->api_token_uuid, &token);
+        if (result == DB_API_TOKEN_ERROR) return -1;
+        *mask = (result == DB_API_TOKEN_OK && token.user_id == user->id)
+            ? (*mask & token.action_mask) : 0;
+    }
     return 0;
 }

--- a/src/core/camera_collection_filter.c
+++ b/src/core/camera_collection_filter.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <strings.h>
 
+#include "core/authorization.h"
 #include "core/camera_collection_filter.h"
 #include "database/db_camera_collections.h"
 #include "database/db_fleet_query.h"
@@ -122,12 +123,16 @@ camera_collection_filter_result_t camera_collection_filter_resolve_stream_names(
         camera_collection_filter_free(&filter);
         return CAMERA_COLLECTION_FILTER_OUT_OF_MEMORY;
     }
+    /* Resolving a collection to stream names hands the caller the cameras it
+     * will act on, so it is subject to the same live.view decision as a list. */
+    if (authorization_filter_visible_cameras(user, cameras, &camera_count) != 0) {
+        free(names);
+        free(cameras);
+        camera_collection_filter_free(&filter);
+        return CAMERA_COLLECTION_FILTER_DATABASE_ERROR;
+    }
     for (int i = 0; i < camera_count; i++) {
         if (!camera_collection_filter_matches(&filter, &cameras[i])) continue;
-        if (user->has_tag_restriction &&
-            !db_auth_stream_allowed_for_user(user, cameras[i].legacy_tags)) {
-            continue;
-        }
         size_t name_size = strlen(cameras[i].name) + 1;
         names[*stream_count] = malloc(name_size);
         if (!names[*stream_count]) {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -60,6 +60,7 @@ void init_recordings_system(void);
 #include "database/database_manager.h"
 #include "database/db_schema_cache.h"
 #include "database/db_core.h"
+#include "database/db_authorization.h"
 #include "database/db_recordings_sync.h"
 #include <sqlite3.h>
 #include "web/http_server.h"
@@ -701,6 +702,14 @@ int main(int argc, char *argv[]) {
     // Initialize database
     if (init_database(config.db_path) != 0) {
         log_error("Failed to initialize database");
+        goto cleanup;
+    }
+
+    // authz_actions records the bit layout every issued API token was minted
+    // against. Refuse to serve a policy this binary would read differently
+    // than it was authored, rather than silently re-mapping permissions.
+    if (db_authorization_verify_action_catalog() != 0) {
+        log_error("Authorization action catalog does not match this build");
         goto cleanup;
     }
 

--- a/src/database/db_audit.c
+++ b/src/database/db_audit.c
@@ -305,9 +305,14 @@ int db_audit_query(const audit_query_t *query, audit_page_t *page) {
     if (rc == SQLITE_OK && !events) rc = SQLITE_NOMEM;
     int count = 0;
     if (rc == SQLITE_OK) {
-        while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        /* The SQL LIMIT already caps this, but the allocation is sized from
+         * page_size rather than from the statement, so bound the write here
+         * too instead of trusting the two to stay in step. */
+        while (count < query->page_size &&
+               (rc = sqlite3_step(stmt)) == SQLITE_ROW) {
             populate_event(stmt, &events[count++]);
         }
+        if (rc == SQLITE_ROW) rc = SQLITE_DONE;
     }
     if (stmt) sqlite3_finalize(stmt);
     pthread_mutex_unlock(mutex);

--- a/src/database/db_authorization.c
+++ b/src/database/db_authorization.c
@@ -1057,3 +1057,67 @@ db_authorization_result_t db_authorization_replace_user_policy(
     pthread_mutex_unlock(mutex);
     return committed ? DB_AUTHORIZATION_OK : DB_AUTHORIZATION_ERROR;
 }
+
+/*
+ * Reconcile the compiled action catalog with the authz_actions table.
+ *
+ * authz_actions is the referential target for authz_role_actions and records
+ * the bit position each action occupies inside a persisted API-token
+ * action_mask. Those positions are frozen once a token has been issued, so a
+ * mismatch between the table and the running binary means either the catalog
+ * was reordered or a migration did not apply. Both silently re-map existing
+ * token permissions, so refuse to start rather than serve a policy the
+ * operator did not author.
+ */
+int db_authorization_verify_action_catalog(void) {
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return -1;
+
+    int catalog_count = 0;
+    (void)authorization_action_catalog(&catalog_count);
+
+    pthread_mutex_lock(mutex);
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db, "SELECT action_key,bit_index FROM authz_actions;", -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        log_error("Failed to read the authorization action catalog: %s",
+                  sqlite3_errmsg(db));
+        if (stmt) sqlite3_finalize(stmt);
+        pthread_mutex_unlock(mutex);
+        return -1;
+    }
+
+    int matched = 0;
+    int mismatches = 0;
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+        const char *key = (const char *)sqlite3_column_text(stmt, 0);
+        int64_t bit_index = sqlite3_column_int64(stmt, 1);
+        authorization_action_t action = authorization_action_from_key(key);
+        if (action == AUTHZ_ACTION_INVALID) {
+            log_error("Action '%s' exists in authz_actions but not in this "
+                      "build's catalog", key ? key : "(null)");
+            mismatches++;
+            continue;
+        }
+        if (bit_index != (int64_t)action) {
+            log_error("Action '%s' is stored at mask bit %lld but this build "
+                      "uses bit %d; API token permissions would be re-mapped",
+                      key, (long long)bit_index, (int)action);
+            mismatches++;
+            continue;
+        }
+        matched++;
+    }
+    sqlite3_finalize(stmt);
+    pthread_mutex_unlock(mutex);
+
+    if (rc != SQLITE_DONE) return -1;
+    if (matched != catalog_count) {
+        log_error("Authorization action catalog has %d of %d expected actions",
+                  matched, catalog_count);
+        return -1;
+    }
+    return mismatches == 0 ? 0 : -1;
+}

--- a/src/database/db_camera_tags.c
+++ b/src/database/db_camera_tags.c
@@ -320,15 +320,20 @@ int db_camera_tags_backfill_legacy(void) {
                                 -1, &stmt, NULL);
     int result = rc == SQLITE_OK ? 0 : -1;
     while (result == 0 && (rc = sqlite3_step(stmt)) == SQLITE_ROW) {
-        char camera_uuid[CAMERA_UUID_STRING_SIZE];
+        char camera_uuid[CAMERA_UUID_STRING_SIZE] = {0};
         char legacy_tags[256];
-        safe_strcpy(camera_uuid,
-                    (const char *)sqlite3_column_text(stmt, 0),
+        const char *uuid_value = (const char *)sqlite3_column_text(stmt, 0);
+        safe_strcpy(camera_uuid, uuid_value ? uuid_value : "",
                     sizeof(camera_uuid), 0);
         const char *legacy_value =
             (const char *)sqlite3_column_text(stmt, 1);
         safe_strcpy(legacy_tags, legacy_value ? legacy_value : "",
                     sizeof(legacy_tags), 0);
+        if (!valid_uuid_string(camera_uuid)) {
+            log_error("Skipping tag backfill for a stream without a camera UUID");
+            result = -1;
+            break;
+        }
         if (sync_legacy_locked(db, camera_uuid, legacy_tags) != 0) result = -1;
     }
     if (stmt) sqlite3_finalize(stmt);
@@ -339,6 +344,68 @@ int db_camera_tags_backfill_legacy(void) {
         log_error("Failed to backfill normalized camera tags: %s",
                   sqlite3_errmsg(db));
         return -1;
+    }
+    return 0;
+}
+
+/*
+ * Read/write the marker that records whether the 0050 legacy tag import has
+ * already run. A missing row means an older database that predates migration
+ * 0056, which is treated as "not yet done" so the import still happens once.
+ */
+static int backfill_marker_locked(sqlite3 *db, bool *completed) {
+    *completed = false;
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(
+        db, "SELECT value FROM system_settings "
+            "WHERE key='camera_tags_backfill_completed' LIMIT 1;",
+        -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        if (stmt) sqlite3_finalize(stmt);
+        return -1;
+    }
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        const char *value = (const char *)sqlite3_column_text(stmt, 0);
+        *completed = value && strcmp(value, "1") == 0;
+    }
+    sqlite3_finalize(stmt);
+    return 0;
+}
+
+static int mark_backfill_complete_locked(sqlite3 *db) {
+    return sqlite3_exec(
+        db,
+        "INSERT INTO system_settings(key,value,updated_at) "
+        "VALUES('camera_tags_backfill_completed','1',strftime('%s','now')) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value,"
+        "updated_at=excluded.updated_at;",
+        NULL, NULL, NULL) == SQLITE_OK ? 0 : -1;
+}
+
+int db_camera_tags_backfill_legacy_once(void) {
+    sqlite3 *db = get_db_handle();
+    pthread_mutex_t *mutex = get_db_mutex();
+    if (!db || !mutex) return -1;
+
+    pthread_mutex_lock(mutex);
+    bool completed = false;
+    int rc = backfill_marker_locked(db, &completed);
+    pthread_mutex_unlock(mutex);
+    if (rc != 0) return -1;
+    if (completed) {
+        log_debug("Legacy camera tag backfill already completed; skipping");
+        return 0;
+    }
+
+    if (db_camera_tags_backfill_legacy() != 0) return -1;
+
+    pthread_mutex_lock(mutex);
+    rc = mark_backfill_complete_locked(db);
+    pthread_mutex_unlock(mutex);
+    if (rc != 0) {
+        /* The import itself succeeded and is idempotent, so a failed marker
+         * write only costs a repeat on the next start. */
+        log_warn("Failed to record camera tag backfill completion");
     }
     return 0;
 }

--- a/src/database/db_core.c
+++ b/src/database/db_core.c
@@ -801,8 +801,10 @@ int init_database(const char *db_path) {
     }
 
     /* Normalize legacy comma-separated camera tags after the schema exists.
-     * This is idempotent and also repairs an interrupted compatibility sync. */
-    if (db_camera_tags_backfill_legacy() != 0) {
+     * This rewrites every assignment, so it runs once rather than on every
+     * start; both tag writers keep streams.tags and the normalized tables in
+     * sync from then on. */
+    if (db_camera_tags_backfill_legacy_once() != 0) {
         log_error("Failed to backfill normalized camera tags");
         sqlite3_close_v2(db);
         db = NULL;

--- a/src/database/sqlite_migrate.c
+++ b/src/database/sqlite_migrate.c
@@ -220,6 +220,71 @@ static int validate_migration_file_security(const char *filepath) {
     return 0;
 }
 
+/*
+ * Return a pointer to the terminating semicolon of the statement starting at
+ * `start` (or to the trailing NUL when there is none).
+ *
+ * A CREATE TRIGGER body is a sequence of statements wrapped in BEGIN..END, so
+ * splitting on the first semicolon would cut it in half: the allowlist would
+ * reject the dangling END and sqlite3_exec would report "incomplete input".
+ * Treat the whole trigger, including nested CASE..END expressions, as one
+ * statement. Single-quoted literals are skipped everywhere.
+ */
+static bool is_word_char(char c) {
+    return isalnum((unsigned char)c) || c == '_';
+}
+
+/* Match `word` at `cursor` on identifier boundaries, so a column such as
+ * "MYBEGIN" or "ENDPOINT" is not mistaken for a block keyword. `start` marks
+ * the beginning of the buffer so the preceding character can be inspected. */
+static bool word_matches(const char *start, const char *cursor,
+                         const char *word, size_t length) {
+    if (cursor > start && is_word_char(cursor[-1])) return false;
+    if (strncasecmp(cursor, word, length) != 0) return false;
+    return !is_word_char(cursor[length]);
+}
+
+static const char *statement_end(const char *start) {
+    const char *cursor = start;
+    while (*cursor && isspace((unsigned char)*cursor)) cursor++;
+    bool trigger = word_matches(start, cursor, "CREATE", 6);
+    if (trigger) {
+        const char *after = cursor + 6;
+        while (*after && isspace((unsigned char)*after)) after++;
+        trigger = word_matches(start, after, "TRIGGER", 7);
+    }
+
+    int in_string = 0;
+    int depth = 0;          /* BEGIN/CASE blocks still open */
+    bool body_started = false;
+    for (cursor = start; *cursor; cursor++) {
+        if (*cursor == '\'') {
+            in_string = !in_string;
+            continue;
+        }
+        if (in_string) continue;
+        if (!trigger) {
+            if (*cursor == ';') return cursor;
+            continue;
+        }
+        if (word_matches(start, cursor, "BEGIN", 5) ||
+            word_matches(start, cursor, "CASE", 4)) {
+            depth++;
+            body_started = true;
+            continue;
+        }
+        if (word_matches(start, cursor, "END", 3)) {
+            if (depth > 0) depth--;
+            if (body_started && depth == 0) {
+                cursor += 3;
+                while (*cursor && isspace((unsigned char)*cursor)) cursor++;
+                return cursor;
+            }
+        }
+    }
+    return cursor;
+}
+
 /**
  * Validate that SQL from a migration file only contains allowlisted statement
  * types (DDL + safe DML).  This acts as a sanitization boundary between the
@@ -295,15 +360,10 @@ static int validate_migration_sql(const char *sql) {
             return -1;
         }
 
-        /* Advance past this statement (to the next semicolon),
-         * respecting single-quoted string literals.              */
-        int in_str = 0;
-        while (*p) {
-            if (*p == '\'' && !in_str) { in_str = 1; p++; continue; }
-            if (*p == '\'' &&  in_str) { in_str = 0; p++; continue; }
-            if (*p == ';'  && !in_str) { p++; break; }
-            p++;
-        }
+        /* Advance past this statement, including a trigger's BEGIN..END
+         * body, which carries semicolons of its own. */
+        p = statement_end(p);
+        if (*p == ';') p++;
     }
 
     return 0;
@@ -717,19 +777,9 @@ static int execute_sql(sqlite3 *db, const char *sql) {
             continue;
         }
 
-        // Find end of statement (semicolon)
-        end = start;
-        int in_string = 0;
-        while (*end) {
-            if (*end == '\'' && !in_string) {
-                in_string = 1;
-            } else if (*end == '\'' && in_string) {
-                in_string = 0;
-            } else if (*end == ';' && !in_string) {
-                break;
-            }
-            end++;
-        }
+        // Find end of statement. A trigger's BEGIN..END body carries its own
+        // semicolons, so it must be handed to SQLite whole.
+        end = statement_end(start);
 
         if (end == start) {
             start = end + 1;

--- a/src/web/api_handlers_authorization.c
+++ b/src/web/api_handlers_authorization.c
@@ -28,7 +28,22 @@ static cJSON *action_to_json(const authorization_action_metadata_t *metadata) {
     cJSON_AddStringToObject(item, "description", metadata->description);
     cJSON_AddBoolToObject(item, "camera_scoped", metadata->camera_scoped);
     cJSON_AddBoolToObject(item, "destructive", metadata->destructive);
+    /* Whether a request handler actually consults this action yet. Clients
+     * must surface unenforced actions so an operator is not shown a boundary
+     * that no endpoint applies. */
+    cJSON_AddBoolToObject(item, "enforced", metadata->enforced);
+    cJSON_AddNumberToObject(item, "mask_bit", (double)metadata->action);
     return item;
+}
+
+/*
+ * The database mutation has already committed by the time these handlers log,
+ * so only response assembly can still fail. Report the outcome the client
+ * actually received instead of recording "success" alongside a 500.
+ */
+static const char *response_outcome(const http_response_t *res) {
+    return res && res->status_code >= 200 && res->status_code < 300
+        ? "success" : "error";
 }
 
 static void set_json_response(http_response_t *res, cJSON *json) {
@@ -500,6 +515,46 @@ void handle_get_authorization_roles(const http_request_t *req,
     set_json_response(res, root);
 }
 
+/*
+ * A policy manager may only hand out authority it holds itself.
+ *
+ * Without this, users.manage is silently equivalent to system.admin: the
+ * holder can author a role containing any action and grant it to themselves.
+ * Comparing against the requester's own effective mask keeps a delegated
+ * "user administrator" role bounded by what it was actually given.
+ *
+ * Returns true when the request may proceed and writes the response otherwise.
+ */
+static bool requester_may_delegate(const user_t *requester,
+                                   uint64_t requested_mask,
+                                   http_response_t *res) {
+    uint64_t held_mask = 0;
+    if (authorization_effective_action_mask(requester, &held_mask) != 0) {
+        http_response_set_json_error(
+            res, 500, "Authorization policy evaluation failed");
+        return false;
+    }
+    uint64_t escalated = requested_mask & ~held_mask;
+    if (escalated == 0) return true;
+
+    char detail[256];
+    int written = snprintf(detail, sizeof(detail),
+                           "You cannot grant actions you do not hold:");
+    int count = 0;
+    const authorization_action_metadata_t *catalog =
+        authorization_action_catalog(&count);
+    for (int i = 0; i < count && written > 0 && written < (int)sizeof(detail);
+         i++) {
+        if ((escalated & authorization_action_bit(catalog[i].action)) == 0) {
+            continue;
+        }
+        written += snprintf(detail + written, sizeof(detail) - (size_t)written,
+                            " %s", catalog[i].key);
+    }
+    http_response_set_json_error(res, 403, detail);
+    return false;
+}
+
 static void set_role_mutation_response(http_response_t *res, int status,
                                        const char *uuid,
                                        int64_t policy_version) {
@@ -570,6 +625,7 @@ void handle_post_authorization_role(const http_request_t *req,
         return;
     }
     cJSON_Delete(body);
+    if (!requester_may_delegate(&requester, role.action_mask, res)) return;
     int64_t new_version = 0;
     db_authorization_result_t result = db_authorization_role_create(
         &role, expected_version, &new_version);
@@ -587,7 +643,7 @@ void handle_post_authorization_role(const http_request_t *req,
                                 (double)new_version);
     }
     audit_log_append(req, &requester, "authorization.role.create", "role",
-                     role.uuid, "success", details);
+                     role.uuid, response_outcome(res), details);
     cJSON_Delete(details);
 }
 
@@ -605,6 +661,9 @@ void handle_put_authorization_role(const http_request_t *req,
         return;
     }
     cJSON_Delete(body);
+    /* Lock-out is the more specific failure, so report it before the broader
+     * delegation check: an edit that strips the requester's own management
+     * access should say so rather than read as an escalation attempt. */
     int retains_management =
         retains_management_after_role_update(&requester, &role);
     if (retains_management <= 0) {
@@ -615,6 +674,7 @@ void handle_put_authorization_role(const http_request_t *req,
                 : "Failed to verify policy-management access");
         return;
     }
+    if (!requester_may_delegate(&requester, role.action_mask, res)) return;
     int64_t new_version = 0;
     db_authorization_result_t result = db_authorization_role_update(
         &role, expected_version, &new_version);
@@ -632,7 +692,7 @@ void handle_put_authorization_role(const http_request_t *req,
                                 (double)new_version);
     }
     audit_log_append(req, &requester, "authorization.role.update", "role",
-                     role.uuid, "success", details);
+                     role.uuid, response_outcome(res), details);
     cJSON_Delete(details);
 }
 
@@ -673,7 +733,7 @@ void handle_delete_authorization_role(const http_request_t *req,
                                 (double)new_version);
     }
     audit_log_append(req, &requester, "authorization.role.delete", "role",
-                     uuid, "success", details);
+                     uuid, response_outcome(res), details);
     cJSON_Delete(details);
 }
 
@@ -880,6 +940,29 @@ static bool grants_allow_self_management(
     return false;
 }
 
+/*
+ * Reject a policy update that would hand the target user a role carrying more
+ * authority than the requester holds. Roles are reusable, so constraining role
+ * authorship alone is not enough: granting a pre-existing Administrator role
+ * would escalate just as effectively.
+ */
+static bool grants_within_requester_authority(
+    const user_t *requester, const authorization_grant_input_t *grants,
+    int grant_count, http_response_t *res) {
+    uint64_t requested_mask = 0;
+    for (int i = 0; i < grant_count; i++) {
+        authorization_role_t role;
+        if (db_authorization_role_get(grants[i].role_uuid, &role) !=
+            DB_AUTHORIZATION_OK) {
+            http_response_set_json_error(res, 400, "Unknown role in grant");
+            return false;
+        }
+        requested_mask |= role.action_mask;
+    }
+    return requested_mask == 0 ||
+        requester_may_delegate(requester, requested_mask, res);
+}
+
 void handle_put_user_authorization(const http_request_t *req,
                                    http_response_t *res) {
     user_t requester;
@@ -910,6 +993,12 @@ void handle_put_user_authorization(const http_request_t *req,
     authorization_grant_input_t *grants = NULL;
     int grant_count = 0;
     if (!parse_grants(body, &grants, &grant_count, res)) {
+        cJSON_Delete(body);
+        return;
+    }
+    if (!grants_within_requester_authority(&requester, grants, grant_count,
+                                           res)) {
+        free(grants);
         cJSON_Delete(body);
         return;
     }
@@ -950,7 +1039,7 @@ void handle_put_user_authorization(const http_request_t *req,
     snprintf(target_user_id, sizeof(target_user_id), "%lld",
              (long long)user_id);
     audit_log_append(req, &requester, "authorization.policy.update", "user",
-                     target_user_id, "success", details);
+                     target_user_id, response_outcome(res), details);
     cJSON_Delete(details);
 }
 
@@ -1266,6 +1355,18 @@ void handle_post_user_api_token(const http_request_t *req,
         cJSON_Delete(body);
         return;
     }
+    /*
+     * A token minted for someone else returns its secret to the requester, so
+     * it must not carry authority the requester lacks. A self-service token is
+     * already bounded because evaluation intersects it with the owner's own
+     * decision.
+     */
+    if (requester.id != user_id &&
+        !requester_may_delegate(&requester, action_mask, res)) {
+        free(selector_json);
+        cJSON_Delete(body);
+        return;
+    }
     api_token_create_t input = {
         .user_id = user_id,
         .created_by_user_id = requester.id > 0 ? requester.id : user_id,
@@ -1329,7 +1430,7 @@ void handle_post_user_api_token(const http_request_t *req,
                                 token.scope_type);
     }
     audit_log_append(req, &requester, "api_token.create", "api_token",
-                     token.uuid, "success", audit_details);
+                     token.uuid, response_outcome(res), audit_details);
     cJSON_Delete(audit_details);
     secure_zero_memory(secret, sizeof(secret));
     free(response_body);

--- a/src/web/api_handlers_camera_collections.c
+++ b/src/web/api_handlers_camera_collections.c
@@ -102,15 +102,14 @@ static bool load_authorized_fleet(const user_t *user,
                                   fleet_camera_t **cameras, int *count) {
     if (db_fleet_camera_load(cameras, count) != 0) return false;
     fleet_camera_enrich_runtime_health(*cameras, *count);
-    if (!user->has_tag_restriction) return true;
-    int authorized = 0;
-    for (int i = 0; i < *count; i++) {
-        if (db_auth_stream_allowed_for_user(user, (*cameras)[i].legacy_tags)) {
-            if (authorized != i) (*cameras)[authorized] = (*cameras)[i];
-            authorized++;
-        }
+    /* Collection previews and membership lists are camera disclosures, so
+     * they use the same live.view decision as every other read path. */
+    if (authorization_filter_visible_cameras(user, *cameras, count) != 0) {
+        free(*cameras);
+        *cameras = NULL;
+        *count = 0;
+        return false;
     }
-    *count = authorized;
     return true;
 }
 

--- a/src/web/api_handlers_fleet.c
+++ b/src/web/api_handlers_fleet.c
@@ -546,6 +546,18 @@ static void handle_fleet_query(const http_request_t *req, http_response_t *res,
         return;
     }
     fleet_camera_enrich_runtime_health(cameras, camera_count);
+    /* Drop unauthorized cameras before anything derived from the inventory is
+     * computed, so totals, facets, and pagination cannot disclose cameras
+     * outside the caller's scope. */
+    if (authorization_filter_visible_cameras(&user, cameras, &camera_count) != 0) {
+        free(cameras);
+        camera_collection_filter_free(&collection_filter);
+        fleet_selector_free(selector);
+        cJSON_Delete(body);
+        http_response_set_json_error(res, 500,
+                                     "Authorization policy evaluation failed");
+        return;
+    }
     fleet_camera_t **matches = camera_count > 0 ?
         calloc((size_t)camera_count, sizeof(*matches)) : NULL;
     if (camera_count > 0 && !matches) {
@@ -559,10 +571,6 @@ static void handle_fleet_query(const http_request_t *req, http_response_t *res,
 
     int match_count = 0;
     for (int i = 0; i < camera_count; i++) {
-        if (user.has_tag_restriction &&
-            !db_auth_stream_allowed_for_user(&user, cameras[i].legacy_tags)) {
-            continue;
-        }
         if (options.camera_uuid[0] &&
             strcmp(options.camera_uuid, cameras[i].camera_uuid) != 0) {
             continue;

--- a/src/web/httpd_utils.c
+++ b/src/web/httpd_utils.c
@@ -230,6 +230,16 @@ int httpd_get_api_key(const http_request_t *req, char *api_key, size_t api_key_s
     return copy_trimmed_value(api_key, api_key_size, auth + 7, 0) ? 0 : -1;
 }
 
+bool httpd_peer_is_trusted_proxy(const http_request_t *req) {
+    if (!req || req->client_ip[0] == '\0') return false;
+    if (g_config.trusted_proxy_cidrs[0] == '\0') return false;
+    char peer_ip[INET6_ADDRSTRLEN] = {0};
+    if (!normalize_ip_literal(req->client_ip, peer_ip, sizeof(peer_ip))) {
+        return false;
+    }
+    return ip_matches_cidr_list(g_config.trusted_proxy_cidrs, peer_ip);
+}
+
 int httpd_get_effective_client_ip(const http_request_t *req, char *client_ip, size_t client_ip_size) {
     if (!req || !client_ip || client_ip_size == 0) {
         return -1;
@@ -484,15 +494,9 @@ static int check_viewer_access(const http_request_t *req, user_t *user,
         return 1;
     }
 
-    // If authentication is disabled entirely, grant viewer access
-    if (!g_config.web_auth_enabled) {
-        // Create a pseudo-user for unauthenticated access
-        memset(user, 0, sizeof(user_t));
-        safe_strcpy(user->username, "anonymous", sizeof(user->username), 0);
-        user->role = USER_ROLE_VIEWER;
-        user->is_active = true;
-        return 1;
-    }
+    // Authentication being disabled is already handled inside
+    // get_authenticated_user(), which returns a dummy admin, so there is no
+    // unauthenticated fall-through for that case to handle here.
 
     // If demo mode is enabled, grant viewer access to unauthenticated users
     if (g_config.demo_mode) {

--- a/src/web/libuv_connection.c
+++ b/src/web/libuv_connection.c
@@ -18,6 +18,7 @@
 #include "web/libuv_connection.h"
 #include "web/go2rtc_proxy_thread.h"
 #include "web/api_handlers_health.h"
+#include "web/httpd_utils.h"
 #define LOG_COMPONENT "HTTP"
 #include "core/logger.h"
 #include "utils/strings.h"
@@ -363,8 +364,14 @@ static int on_header_value(llhttp_t *parser, const char *at, size_t length) {
     } else if (strcasecmp(conn->current_header_field, "Connection") == 0) {
         conn->keep_alive = (strcasecmp(conn->request.headers[idx].value, "close") != 0);
     } else if (strcasecmp(conn->current_header_field, "X-Request-ID") == 0) {
-        (void)http_request_set_request_id(
-            &conn->request, conn->request.headers[idx].value);
+        /* The audit trail correlates on this value, so only adopt a caller's
+         * ID when it reached us through a declared trusted proxy. Anything
+         * else keeps the server-generated ID and cannot forge or collide with
+         * another principal's requests. */
+        if (httpd_peer_is_trusted_proxy(&conn->request)) {
+            (void)http_request_set_request_id(
+                &conn->request, conn->request.headers[idx].value);
+        }
     }
 
     return 0;

--- a/tests/unit/test_authorization.c
+++ b/tests/unit/test_authorization.c
@@ -1254,6 +1254,252 @@ void test_sensitive_handlers_enforce_camera_scoped_policy(void) {
     g_config.web_auth_enabled = false;
 }
 
+
+/*
+ * Regression: a policy-scoped principal must not be able to enumerate the
+ * whole fleet through a list endpoint. Filtering has to happen before totals
+ * and facets are derived, so the helper the list handlers share is the unit
+ * under test.
+ */
+void test_visible_camera_filter_hides_cameras_outside_grant(void) {
+    stream_config_t lobby = create_camera("Filter Lobby", "Lobby");
+    create_camera("Filter Vault", "Vault");
+    camera_tag_t lobby_tag = find_tag("Lobby");
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("listscoped", "password123", NULL,
+                               USER_ROLE_USER, true, &user_id));
+    TEST_ASSERT_EQUAL_INT(0,
+                          db_authorization_set_user_mode(user_id, "policy"));
+
+    char selector[512];
+    snprintf(selector, sizeof(selector),
+             "{\"version\":1,\"expression\":{\"op\":\"tag_any\","
+             "\"uuids\":[\"%s\"]}}",
+             lobby_tag.uuid);
+    char grant_uuid[CAMERA_UUID_STRING_SIZE];
+    create_grant(user_id, OPERATOR_ROLE_UUID, "selector", selector,
+                 grant_uuid);
+
+    user_t user;
+    TEST_ASSERT_EQUAL_INT(0, db_auth_get_user_by_id(user_id, &user));
+
+    fleet_camera_t *cameras = NULL;
+    int count = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_fleet_camera_load(&cameras, &count));
+    TEST_ASSERT_GREATER_THAN(1, count);
+    int total = count;
+
+    g_config.web_auth_enabled = true;
+    TEST_ASSERT_EQUAL_INT(
+        0, authorization_filter_visible_cameras(&user, cameras, &count));
+    TEST_ASSERT_EQUAL_INT(1, count);
+    TEST_ASSERT_EQUAL_STRING(lobby.camera_uuid, cameras[0].camera_uuid);
+    free(cameras);
+
+    /* An unscoped legacy admin still sees everything. */
+    user_t admin;
+    memset(&admin, 0, sizeof(admin));
+    admin.id = 999999;
+    admin.role = USER_ROLE_ADMIN;
+    admin.is_active = true;
+    cameras = NULL;
+    count = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_fleet_camera_load(&cameras, &count));
+    TEST_ASSERT_EQUAL_INT(
+        0, authorization_filter_visible_cameras(&admin, cameras, &count));
+    TEST_ASSERT_EQUAL_INT(total, count);
+    free(cameras);
+
+    /* With authentication off the handlers never populate a principal, so the
+     * filter must pass the inventory through rather than hide every camera. */
+    g_config.web_auth_enabled = false;
+    user_t unpopulated;
+    memset(&unpopulated, 0, sizeof(unpopulated));
+    cameras = NULL;
+    count = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_fleet_camera_load(&cameras, &count));
+    TEST_ASSERT_EQUAL_INT(
+        0, authorization_filter_visible_cameras(&unpopulated, cameras, &count));
+    TEST_ASSERT_EQUAL_INT(total, count);
+    free(cameras);
+}
+
+/*
+ * The effective mask is what stops a policy manager from minting authority it
+ * does not hold, so it must reflect grants, legacy roles, and token narrowing.
+ */
+void test_effective_action_mask_reflects_grants_and_tokens(void) {
+    int64_t user_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("maskuser", "password123", NULL,
+                               USER_ROLE_USER, true, &user_id));
+    TEST_ASSERT_EQUAL_INT(0,
+                          db_authorization_set_user_mode(user_id, "policy"));
+    char grant_uuid[CAMERA_UUID_STRING_SIZE];
+    create_grant(user_id, OPERATOR_ROLE_UUID, "all", NULL, grant_uuid);
+
+    user_t user;
+    TEST_ASSERT_EQUAL_INT(0, db_auth_get_user_by_id(user_id, &user));
+    uint64_t mask = 0;
+    TEST_ASSERT_EQUAL_INT(0, authorization_effective_action_mask(&user, &mask));
+    TEST_ASSERT_TRUE((mask & authorization_action_bit(AUTHZ_PTZ_CONTROL)) != 0);
+    /* Operator deliberately excludes policy administration. */
+    TEST_ASSERT_TRUE((mask & authorization_action_bit(AUTHZ_USERS_MANAGE)) == 0);
+    TEST_ASSERT_TRUE((mask & authorization_action_bit(AUTHZ_SYSTEM_ADMIN)) == 0);
+
+    /* A legacy administrator holds the entire catalog. */
+    user_t admin;
+    memset(&admin, 0, sizeof(admin));
+    admin.id = 1;
+    admin.role = USER_ROLE_ADMIN;
+    admin.is_active = true;
+    TEST_ASSERT_EQUAL_INT(0, authorization_effective_action_mask(&admin, &mask));
+    int catalog_count = 0;
+    const authorization_action_metadata_t *catalog =
+        authorization_action_catalog(&catalog_count);
+    for (int i = 0; i < catalog_count; i++) {
+        TEST_ASSERT_TRUE(
+            (mask & authorization_action_bit(catalog[i].action)) != 0);
+    }
+
+    /* An inactive principal holds nothing. */
+    admin.is_active = false;
+    TEST_ASSERT_EQUAL_INT(0, authorization_effective_action_mask(&admin, &mask));
+    TEST_ASSERT_EQUAL_UINT64(UINT64_C(0), mask);
+}
+
+/*
+ * users.manage must not be a back door to system.admin: authoring a role that
+ * carries more than the requester holds has to be refused.
+ */
+void test_policy_manager_cannot_grant_actions_it_lacks(void) {
+    int64_t manager_id = 0;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_create_user("limitedmanager", "password123", NULL,
+                               USER_ROLE_USER, true, &manager_id));
+    TEST_ASSERT_EQUAL_INT(
+        0, db_authorization_set_user_mode(manager_id, "policy"));
+
+    /* A role that can administer users but nothing else. */
+    authorization_role_t manager_role;
+    memset(&manager_role, 0, sizeof(manager_role));
+    safe_strcpy(manager_role.name, "User Administrator",
+                sizeof(manager_role.name), 0);
+    manager_role.action_mask = authorization_action_bit(AUTHZ_USERS_MANAGE);
+    int64_t version = 0;
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_get_policy_version(&version));
+    int64_t new_version = 0;
+    TEST_ASSERT_EQUAL_INT(
+        DB_AUTHORIZATION_OK,
+        db_authorization_role_create(&manager_role, version, &new_version));
+    char grant_uuid[CAMERA_UUID_STRING_SIZE];
+    create_grant(manager_id, manager_role.uuid, "all", NULL, grant_uuid);
+
+    char api_key[128] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, db_auth_generate_api_key(manager_id, api_key, sizeof(api_key)));
+
+    int64_t current_version = 0;
+    TEST_ASSERT_EQUAL_INT(0,
+                          db_authorization_get_policy_version(&current_version));
+
+    /* Escalating: a new role carrying system.admin is refused. */
+    char escalate_body[256];
+    snprintf(escalate_body, sizeof(escalate_body),
+             "{\"expected_policy_version\":%lld,\"name\":\"Escalate\","
+             "\"actions\":[\"system.admin\"]}",
+             (long long)current_version);
+    g_config.web_auth_enabled = true;
+    cJSON *denied = call_handler_path(
+        handle_post_authorization_role, HTTP_METHOD_POST,
+        "/api/authorization/roles", escalate_body, api_key, 403);
+    cJSON_Delete(denied);
+
+    /* Non-escalating: a role bounded by what the manager holds is accepted. */
+    char allowed_body[256];
+    snprintf(allowed_body, sizeof(allowed_body),
+             "{\"expected_policy_version\":%lld,"
+             "\"name\":\"Delegated User Admin\","
+             "\"actions\":[\"users.manage\"]}",
+             (long long)current_version);
+    cJSON *allowed = call_handler_path(
+        handle_post_authorization_role, HTTP_METHOD_POST,
+        "/api/authorization/roles", allowed_body, api_key, 201);
+    cJSON_Delete(allowed);
+    g_config.web_auth_enabled = false;
+}
+
+/*
+ * The persisted mask layout is a compatibility contract with every issued
+ * token, so the table and the compiled catalog must agree bit for bit.
+ */
+void test_action_catalog_bit_layout_matches_database(void) {
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_verify_action_catalog());
+
+    int count = 0;
+    const authorization_action_metadata_t *catalog =
+        authorization_action_catalog(&count);
+    sqlite3 *db = get_db_handle();
+    sqlite3_stmt *stmt = NULL;
+    TEST_ASSERT_EQUAL_INT(
+        SQLITE_OK,
+        sqlite3_prepare_v2(db,
+                           "SELECT bit_index FROM authz_actions "
+                           "WHERE action_key = ?;", -1, &stmt, NULL));
+    for (int i = 0; i < count; i++) {
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+        sqlite3_bind_text(stmt, 1, catalog[i].key, -1, SQLITE_TRANSIENT);
+        TEST_ASSERT_EQUAL_INT(SQLITE_ROW, sqlite3_step(stmt));
+        TEST_ASSERT_EQUAL_INT64((int64_t)catalog[i].action,
+                                sqlite3_column_int64(stmt, 0));
+        TEST_ASSERT_EQUAL_UINT64(UINT64_C(1) << catalog[i].action,
+                                 authorization_action_bit(catalog[i].action));
+    }
+    sqlite3_finalize(stmt);
+
+    /* Drift in the stored layout must fail startup rather than re-map tokens. */
+    TEST_ASSERT_EQUAL_INT(
+        SQLITE_OK,
+        sqlite3_exec(db,
+                     "UPDATE authz_actions SET bit_index = 63 "
+                     "WHERE action_key = 'system.admin';",
+                     NULL, NULL, NULL));
+    TEST_ASSERT_EQUAL_INT(-1, db_authorization_verify_action_catalog());
+    TEST_ASSERT_EQUAL_INT(
+        SQLITE_OK,
+        sqlite3_exec(db,
+                     "UPDATE authz_actions SET bit_index = 14 "
+                     "WHERE action_key = 'system.admin';",
+                     NULL, NULL, NULL));
+    TEST_ASSERT_EQUAL_INT(0, db_authorization_verify_action_catalog());
+}
+
+/*
+ * streams.camera_uuid defaults to '' so the 0048 backfill could run; the guard
+ * added in 0056 must reject that value instead of letting the unique index
+ * accept one row and fail every later insert.
+ */
+void test_streams_reject_empty_camera_uuid(void) {
+    sqlite3 *db = get_db_handle();
+    TEST_ASSERT_NOT_EQUAL(
+        SQLITE_DONE,
+        sqlite3_exec(db,
+                     "INSERT INTO streams (name,url) "
+                     "VALUES ('No UUID','rtsp://camera/live');",
+                     NULL, NULL, NULL));
+    sqlite3_stmt *stmt = NULL;
+    TEST_ASSERT_EQUAL_INT(
+        SQLITE_OK,
+        sqlite3_prepare_v2(db,
+                           "SELECT count(*) FROM streams WHERE name='No UUID';",
+                           -1, &stmt, NULL));
+    TEST_ASSERT_EQUAL_INT(SQLITE_ROW, sqlite3_step(stmt));
+    TEST_ASSERT_EQUAL_INT(0, sqlite3_column_int(stmt, 0));
+    sqlite3_finalize(stmt);
+}
+
 int main(void) {
     unlink(TEST_DB_PATH);
     if (init_database(TEST_DB_PATH) != 0) {
@@ -1286,6 +1532,11 @@ int main(void) {
     RUN_TEST(test_policy_role_update_cannot_lock_out_requester);
     RUN_TEST(test_users_api_reports_authorization_mode);
     RUN_TEST(test_sensitive_handlers_enforce_camera_scoped_policy);
+    RUN_TEST(test_visible_camera_filter_hides_cameras_outside_grant);
+    RUN_TEST(test_effective_action_mask_reflects_grants_and_tokens);
+    RUN_TEST(test_policy_manager_cannot_grant_actions_it_lacks);
+    RUN_TEST(test_action_catalog_bit_layout_matches_database);
+    RUN_TEST(test_streams_reject_empty_camera_uuid);
     int result = UNITY_END();
     batch_delete_progress_cleanup();
     shutdown_database();

--- a/tests/unit/test_db_streams.c
+++ b/tests/unit/test_db_streams.c
@@ -519,9 +519,10 @@ void test_repair_onvif_embedded_credentials_migration_normalizes_legacy_rows(voi
         "detection_based_recording, detection_model, detection_threshold, detection_interval, pre_detection_buffer, post_detection_buffer, "
         "detection_api_url, detection_object_filter, detection_object_filter_list, protocol, is_onvif, record_audio, backchannel_enabled, "
         "retention_days, detection_retention_days, max_storage_mb, tier_critical_multiplier, tier_important_multiplier, tier_ephemeral_multiplier, storage_priority, "
-        "ptz_enabled, ptz_max_x, ptz_max_y, ptz_max_z, ptz_has_home, onvif_username, onvif_password, onvif_profile, onvif_port, record_on_schedule, recording_schedule, tags) VALUES ("
+        "ptz_enabled, ptz_max_x, ptz_max_y, ptz_max_z, ptz_has_home, onvif_username, onvif_password, onvif_profile, onvif_port, record_on_schedule, recording_schedule, tags, camera_uuid) VALUES ("
         "'legacy_onvif', 'rtsp://legacy_user:legacy_pass@camera.example/live', 1, 1, 1920, 1080, 25, 'h264', 5, 1, 60, "
-        "0, '', 0.5, 10, 0, 3, '', 'none', '', 0, 1, 1, 0, 0, 0, 0, 3.0, 2.0, 0.25, 0, 0, 0.0, 0.0, 0.0, 0, '', '', 'profile1', 8899, 0, '', '');");
+        "0, '', 0.5, 10, 0, 3, '', 'none', '', 0, 1, 1, 0, 0, 0, 0, 3.0, 2.0, 0.25, 0, 0, 0.0, 0.0, 0.0, 0, '', '', 'profile1', 8899, 0, '', '', "
+        "'20000000-0000-4000-8000-000000000001');");
     exec_sql_or_fail(db, "DELETE FROM schema_migrations WHERE version = '0034';");
 
     shutdown_database();

--- a/web/js/components/preact/users/RoleManagerModal.jsx
+++ b/web/js/components/preact/users/RoleManagerModal.jsx
@@ -3,6 +3,7 @@ import { fetchJSON } from '../../../query-client.js';
 import { useI18n } from '../../../i18n.js';
 import { showStatusMessage } from '../ToastContainer.jsx';
 import {
+  actionIsEnforced,
   groupActionsByCategory,
   roleHasDestructiveActions,
 } from './authorizationPolicy.js';
@@ -184,7 +185,7 @@ export function RoleManagerModal({ onClose, getAuthHeaders }) {
                         return (
                           <label key={action.key} className={`flex gap-3 rounded-md border p-3 ${checked ? 'border-[hsl(var(--primary))] bg-[hsl(var(--primary)/0.06)]' : 'border-border'} ${draft.builtin ? 'cursor-default' : 'cursor-pointer'}`}>
                             <input type="checkbox" className="mt-1 h-4 w-4" checked={checked} disabled={draft.builtin} onChange={() => toggleAction(action.key)} />
-                            <span><span className="block text-sm font-medium">{action.key}</span><span className="mt-0.5 block text-xs text-muted-foreground">{action.description}</span>{action.destructive && <span className="mt-1 block text-xs font-medium text-[hsl(var(--danger))]">{t('access.roles.destructive')}</span>}</span>
+                            <span><span className="block text-sm font-medium">{action.key}</span><span className="mt-0.5 block text-xs text-muted-foreground">{action.description}</span>{action.destructive && <span className="mt-1 block text-xs font-medium text-[hsl(var(--danger))]">{t('access.roles.destructive')}</span>}{!actionIsEnforced(action) && <span className="mt-1 block text-xs font-medium text-[hsl(var(--warning))]">{t('access.roles.notEnforced')}</span>}</span>
                           </label>
                         );
                       })}

--- a/web/js/components/preact/users/apiTokenPolicy.js
+++ b/web/js/components/preact/users/apiTokenPolicy.js
@@ -28,8 +28,13 @@ export function createTokenDraft() {
   };
 }
 
+// Offer an action only when this client believes a scoped token can use it AND
+// the server agrees the action is enforced. Intersecting the two means the list
+// can only shrink toward reality: a client that is ahead of the daemon never
+// offers a token permission that would be silently ignored.
 export function selectableTokenActions(actions = []) {
-  return actions.filter((action) => ENFORCED_SCOPED_TOKEN_ACTIONS.has(action.key));
+  return actions.filter((action) =>
+    ENFORCED_SCOPED_TOKEN_ACTIONS.has(action.key) && action?.enforced !== false);
 }
 
 export function validateTokenDraft(

--- a/web/js/components/preact/users/authorizationPolicy.js
+++ b/web/js/components/preact/users/authorizationPolicy.js
@@ -95,3 +95,19 @@ export function roleHasDestructiveActions(roleActions = [], actionCatalog = []) 
 export function actionRequiresCamera(actionKey, actionCatalog = []) {
   return actionCatalog.find((action) => action.key === actionKey)?.camera_scoped === true;
 }
+
+// The action catalog is authored ahead of endpoint coverage: a role may include
+// an action that no handler consults yet. The server reports that per action so
+// the UI can say so instead of implying a boundary that is not applied. Treat a
+// missing flag as enforced so an older server does not paint every action as a
+// gap.
+export function actionIsEnforced(action) {
+  return action?.enforced !== false;
+}
+
+export function unenforcedActionKeys(roleActions = [], actionCatalog = []) {
+  const unenforced = new Set(
+    actionCatalog.filter((action) => !actionIsEnforced(action)).map((action) => action.key)
+  );
+  return (roleActions || []).filter((key) => unenforced.has(key));
+}

--- a/web/public/locales/en.json
+++ b/web/public/locales/en.json
@@ -554,6 +554,7 @@
   "access.roles.builtinHelp": "Built-in roles are fixed upgrade-safe templates. Clone one to customize it.",
   "access.roles.actionCount": "{count} actions",
   "access.roles.destructive": "Sensitive action",
+  "access.roles.notEnforced": "Not yet enforced by any endpoint",
   "access.roles.destructiveWarning": "This role can change configuration or evidence. Grant it only over the scopes where that authority is required.",
   "access.roles.created": "Role created",
   "access.roles.updated": "Role updated",

--- a/web/tests/apiTokenPolicy.spec.js
+++ b/web/tests/apiTokenPolicy.spec.js
@@ -23,6 +23,18 @@ describe('scoped API token UI helpers', () => {
     ]);
   });
 
+  test('drops actions the server reports as unenforced', () => {
+    const reported = [
+      { key: 'recordings.export', enforced: true },
+      { key: 'ptz.control', enforced: false },
+      { key: 'recording.delete' },
+    ];
+    expect(selectableTokenActions(reported).map((action) => action.key)).toEqual([
+      'recordings.export',
+      'recording.delete',
+    ]);
+  });
+
   test('validates required fields and scoped resources', () => {
     const draft = createTokenDraft();
     expect(validateTokenDraft(draft)).toBe('missing_description');

--- a/web/tests/authorizationPolicy.spec.js
+++ b/web/tests/authorizationPolicy.spec.js
@@ -1,4 +1,6 @@
 import {
+  actionIsEnforced,
+  unenforcedActionKeys,
   actionRequiresCamera,
   buildPolicyPayload,
   createDraftGrant,
@@ -98,5 +100,25 @@ describe('authorization policy UI helpers', () => {
     expect(roleHasDestructiveActions(['live.view'], catalog)).toBe(false);
     expect(actionRequiresCamera('live.view', catalog)).toBe(true);
     expect(actionRequiresCamera('users.manage', catalog)).toBe(false);
+  });
+});
+
+describe('action enforcement reporting', () => {
+  test('treats a missing enforced flag as enforced so old servers look normal', () => {
+    expect(actionIsEnforced({ key: 'live.view' })).toBe(true);
+    expect(actionIsEnforced({ key: 'live.view', enforced: true })).toBe(true);
+    expect(actionIsEnforced({ key: 'audio.talk', enforced: false })).toBe(false);
+  });
+
+  test('names the role actions no endpoint applies yet', () => {
+    const catalog = [
+      { key: 'live.view', enforced: true },
+      { key: 'audio.talk', enforced: false },
+      { key: 'storage.configure', enforced: false },
+    ];
+    expect(unenforcedActionKeys(['live.view', 'audio.talk'], catalog))
+      .toEqual(['audio.talk']);
+    expect(unenforcedActionKeys(['live.view'], catalog)).toEqual([]);
+    expect(unenforcedActionKeys([], catalog)).toEqual([]);
   });
 });


### PR DESCRIPTION
Follow-up to the Fleet 02 authorization stack merged yesterday (#496–#519). Everything here came out of reviewing that work; no new features.

## High

**Fleet query ignored policy scoping.** `POST /api/fleet/cameras/query` filtered only on the legacy allowed-tags restriction, so a policy-mode principal scoped to a handful of cameras could enumerate the entire fleet — names, locations, tags, health, vendor/model, credential-stripped addresses — plus facet counts over all of it. `docs/internal/AUTHORIZATION_ENDPOINT_INVENTORY.md`, shipped in #517, already states the rule ("List handlers must filter unauthorized cameras before calculating totals, facets, or collection membership") but no handler implemented it.

Added `authorization_filter_visible_cameras()`, which evaluates `live.view` per camera before anything is derived from the inventory, and applied it to the fleet query, selector preview, collection reads/previews, and the collection→stream-name resolution used by recording filters. Legacy-mode principals are unaffected: the evaluator applies their allowed-tags restriction for them.

**`users.manage` was silently equivalent to `system.admin`.** Its holder could author a role containing any action and grant it to themselves, grant a pre-existing Administrator role, or mint an API token for another user and receive the secret. All three now check the requester's own effective authority (`authorization_effective_action_mask()`) and return 403 naming the offending actions. No default role has `users.manage` except Administrator, so stock deployments were not exposed — this matters for anyone building a delegated "user administrator" role.

The lock-out guard still runs before the delegation check on role updates, so an edit that removes your own management access keeps reporting 409 rather than 403.

## Medium

**Persisted action-mask layout was undocumented.** `authz_api_tokens.action_mask` positions actions by `authorization_action_t` ordinal, but nothing recorded that. Inserting an action anywhere but the end of the enum would silently re-map every issued token's permissions. Migration 0056 stores the bit index in `authz_actions` — a table that until now was seeded and never read by any C code — and the daemon refuses to start if the stored layout disagrees with the binary. Note the asymmetry this resolves: `authz_role_actions` already persisted by key (robust); tokens persisted by ordinal.

**No caching in the evaluator.** Grants, their selectors, and any referenced collection were reloaded and re-parsed for every candidate camera. A 1000-item batch delete meant thousands of queries under the global DB mutex. Added a per-request `authorization_context_t`; a batch or a fleet page now costs one grant load. It is stack-scoped per request, so no cache-invalidation or thread-safety surface.

## Low

- **`X-Request-ID` was client-controlled** and written verbatim to `audit_events.request_id`, letting anyone pin or forge correlation IDs. Now only adopted behind `trusted_proxy_cidrs`, matching how `X-Forwarded-For` was already gated in the same file.
- **`streams.camera_uuid`** defaults to `''` with a unique index — verified that the first insert omitting it succeeds and every later one fails with a confusing constraint error. Rejected at the schema now. Only `add_stream_config()` inserts streams today, so nothing was broken; this closes the trap.
- **Legacy tag backfill** rewrote every assignment on every boot. Recorded completion so it runs once. Also zero-initialized and validated the UUID it reads (the neighbouring function already did both).
- **Audit outcome** reported `"success"` even when the handler returned 500. Now reports what the client received.
- **Audit page loop** was bounded only by the SQL `LIMIT`, with the bind return unchecked; bounded by `page_size` too.
- **Unenforced actions** are now flagged. 8 of 15 actions have no enforcement point yet — deliberate and documented as phased, but the role editor presented all 15 with no indication. `GET /api/authorization/actions` reports `enforced` and `mask_bit`; the role editor labels unenforced actions; the token UI intersects its curated list with the server flag so it can only shrink toward reality.
- Removed the unreachable auth-disabled branch in `check_viewer_access()` (`get_authenticated_user()` already returns a dummy admin and short-circuits) and a no-op copy round-trip in the evaluator.

## Incidental

`CREATE TRIGGER` was on the migration statement allowlist but could never pass it: both the validator and `execute_sql` split on the first semicolon, cutting a `BEGIN..END` body in half. Both now consume a trigger whole, with identifier-boundary keyword matching so a column named `ENDPOINT` isn't mistaken for a block keyword.

`authorization_filter_visible_cameras()` lives in `src/core/` rather than `src/web/` — putting it in `httpd_utils` made `camera_collection_filter.c` depend on the web layer and broke the `rebuild_recordings` link. Same reason the catalog check runs from `main.c` instead of `init_database()`: the rebuild tool does not serve policy.

## Verification

- Applied migrations 0047–0056 from **both** `db/migrations/*.sql` and the hand-maintained `db_embedded_migrations.h` into fresh DBs and diffed the resulting schemas — identical apart from whitespace, `PRAGMA foreign_key_check` clean on both, triggers and `bit_index` values matching.
- `ctest`: 64/65 pass. The one failure, `test_stream_detection`, is pre-existing and unrelated (needs SOD compiled in).
- `npx jest` in `web/`: 101/101 pass.
- Full rebuild with the project's warning set: no new warnings.
- 5 new C cases in `test_authorization` (fleet visibility filtering incl. the auth-disabled passthrough, effective mask, delegation refusal, mask-layout drift detection, `camera_uuid` guard) and 2 new web specs. The trigger-parsing change is covered end-to-end: `test_streams_reject_empty_camera_uuid` only passes if 0056 made it through both the validator and `execute_sql`.

Two existing test fixtures needed updating: `test_db_streams.c` inserted a stream without a `camera_uuid`, and my first cut of the visibility filter hid every camera on auth-disabled paths (handlers there never populate a `user_t`) — that branch is now explicit and tested.

## Not addressed

Scoped API tokens still get `401` rather than `403` on routes using `httpd_check_viewer_access()`, so a token carrying an unenforced action cannot be used at all. That is fail-closed and correct; making those actions usable means migrating the remaining ~15 endpoint families to the central evaluator, which is the phased work the inventory doc tracks. Both facts are now written down there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
