### PR TITLE
build: add embedded profile for constrained targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,63 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Build profiles select conservative defaults without removing the individual
+# feature switches.  The full profile remains the default for existing builds.
+option(EMBEDDED_A1_DEVICE "Deprecated alias for LIGHTNVR_PROFILE=embedded" OFF)
+set(LIGHTNVR_PROFILE "full" CACHE STRING "Build profile: full or embedded")
+set_property(CACHE LIGHTNVR_PROFILE PROPERTY STRINGS full embedded)
+string(TOLOWER "${LIGHTNVR_PROFILE}" LIGHTNVR_PROFILE)
+
+if(EMBEDDED_A1_DEVICE)
+    message(DEPRECATION
+        "EMBEDDED_A1_DEVICE is deprecated; use -DLIGHTNVR_PROFILE=embedded")
+    set(LIGHTNVR_PROFILE "embedded")
+endif()
+
+if(NOT LIGHTNVR_PROFILE MATCHES "^(full|embedded)$")
+    message(FATAL_ERROR
+        "Invalid LIGHTNVR_PROFILE='${LIGHTNVR_PROFILE}'; expected full or embedded")
+endif()
+
+if(LIGHTNVR_PROFILE STREQUAL "embedded")
+    set(LIGHTNVR_OPTIONAL_FEATURE_DEFAULT OFF)
+    set(LIGHTNVR_DEFAULT_MAX_STREAMS 16)
+else()
+    set(LIGHTNVR_OPTIONAL_FEATURE_DEFAULT ON)
+    set(LIGHTNVR_DEFAULT_MAX_STREAMS 1024)
+endif()
+
+set(LIGHTNVR_MAX_STREAMS "auto" CACHE STRING
+    "Compile-time stream ceiling (auto, or an integer from 1 to 1024)")
+if(LIGHTNVR_MAX_STREAMS STREQUAL "auto")
+    set(LIGHTNVR_RESOLVED_MAX_STREAMS ${LIGHTNVR_DEFAULT_MAX_STREAMS})
+elseif(LIGHTNVR_MAX_STREAMS MATCHES "^[0-9]+$")
+    set(LIGHTNVR_RESOLVED_MAX_STREAMS ${LIGHTNVR_MAX_STREAMS})
+else()
+    message(FATAL_ERROR
+        "LIGHTNVR_MAX_STREAMS must be 'auto' or an integer from 1 to 1024")
+endif()
+
+if(LIGHTNVR_RESOLVED_MAX_STREAMS LESS 1 OR
+   LIGHTNVR_RESOLVED_MAX_STREAMS GREATER 1024)
+    message(FATAL_ERROR "LIGHTNVR_MAX_STREAMS must be between 1 and 1024")
+endif()
+if(LIGHTNVR_PROFILE STREQUAL "embedded" AND
+   LIGHTNVR_RESOLVED_MAX_STREAMS GREATER 16)
+    message(FATAL_ERROR "The embedded profile is limited to 16 streams")
+endif()
+
+add_definitions(-DLIGHTNVR_MAX_STREAMS=${LIGHTNVR_RESOLVED_MAX_STREAMS})
+
 # Option to enable/disable SOD
-option(ENABLE_SOD "Enable SOD library for object detection" ON)
+option(ENABLE_SOD "Enable SOD library for object detection" ${LIGHTNVR_OPTIONAL_FEATURE_DEFAULT})
 option(SOD_DYNAMIC_LINK "Dynamically link SOD library instead of static linking" OFF)
 
 # In-process LiteRT (TFLite) detection engine. Default ON, but auto-disabled at
 # configure time if the third_party/litert submodule isn't initialized, so a
 # fresh checkout still builds. When ON (and present), the vendored LiteRT
 # submodule is built and linked, and the litert_engine module is compiled.
-option(ENABLE_LITERT "Enable in-process LiteRT (TFLite) detection engine" ON)
+option(ENABLE_LITERT "Enable in-process LiteRT (TFLite) detection engine" ${LIGHTNVR_OPTIONAL_FEATURE_DEFAULT})
 option(LITERT_WITH_XNNPACK "Compile XNNPACK delegate into the LiteRT engine" ON)
 option(LITERT_WITH_GPU "Compile GPU (OpenCL/GLES) delegate into the LiteRT engine" OFF)
 
@@ -45,9 +93,14 @@ option(USE_WOLFSSL "Use WolfSSL instead of OpenSSL (if SSL is enabled)" OFF)
 set(HTTP_BACKEND "libuv" CACHE STRING "HTTP server backend")
 set_property(CACHE HTTP_BACKEND PROPERTY STRINGS libuv)
 
-# Compiler flags for optimization and memory usage
-add_compile_options(-O2 -ffunction-sections -fdata-sections)
+# Compiler flags for optimization and memory usage.  Do not override the
+# toolchain's optimization level (Buildroot supplies -Os for target builds).
+add_compile_options(-ffunction-sections -fdata-sections)
 add_link_options(-Wl,--gc-sections)
+
+if(LIGHTNVR_PROFILE STREQUAL "embedded")
+    add_compile_options(-Os -fomit-frame-pointer)
+endif()
 
 # Security and quality warning flags
 add_compile_options(
@@ -78,16 +131,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     endif()
 endif()
 
-# Option to build for embedded A1 device
-option(EMBEDDED_A1_DEVICE "Build for embedded A1 device with limited memory" OFF)
-if(EMBEDDED_A1_DEVICE)
-    message(STATUS "Building for embedded A1 device with memory optimizations")
-    add_definitions(-DEMBEDDED_A1_DEVICE)
-    # Additional optimizations for embedded devices
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os -fno-exceptions -fomit-frame-pointer")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Os -fno-exceptions -fomit-frame-pointer")
-endif()
-
 # Create project-specific include directory
 set(LIGHTNVR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
@@ -115,7 +158,7 @@ else()
 endif()
 
 # MQTT support (optional, uses libmosquitto)
-option(ENABLE_MQTT "Enable MQTT support for detection event streaming" ON)
+option(ENABLE_MQTT "Enable MQTT support for detection event streaming" ${LIGHTNVR_OPTIONAL_FEATURE_DEFAULT})
 if(ENABLE_MQTT)
     pkg_check_modules(MOSQUITTO QUIET libmosquitto>=2.0)
     if(MOSQUITTO_FOUND)
@@ -781,6 +824,8 @@ add_dependencies(lightnvr generate_version_js)
 
 # Print build information
 message(STATUS "Building LightNVR ${PROJECT_VERSION} with the following configuration:")
+message(STATUS "- Build profile: ${LIGHTNVR_PROFILE}")
+message(STATUS "- Compile-time stream ceiling: ${LIGHTNVR_RESOLVED_MAX_STREAMS}")
 message(STATUS "- HTTP backend: libuv + llhttp")
 message(STATUS "- SOD object detection: ${ENABLE_SOD}")
 if(ENABLE_SOD)
@@ -801,7 +846,6 @@ if(ENABLE_GO2RTC)
     message(STATUS "  - go2rtc config directory: ${GO2RTC_CONFIG_DIR}")
     message(STATUS "  - go2rtc API port: ${GO2RTC_API_PORT}")
 endif()
-message(STATUS "- Embedded A1 device optimizations: ${EMBEDDED_A1_DEVICE}")
 if(YAML_FOUND)
     message(STATUS "- libyaml (YAML validation): ENABLED (${YAML_VERSION})")
 else()

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -104,6 +104,37 @@ When built without SOD, LightNVR will still function normally but will not have 
 
 For more information about SOD integration, see [SOD Integration](SOD_INTEGRATION.md).
 
+### Embedded build profile
+
+Resource-constrained targets can select the embedded profile without changing
+the defaults used by server-class installations:
+
+```bash
+cmake -S . -B build/embedded \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLIGHTNVR_PROFILE=embedded
+cmake --build build/embedded -- -j$(nproc)
+```
+
+The embedded profile caps compile-time stream storage at 16 streams, optimizes
+for size, and defaults SOD, LiteRT, and MQTT off. The individual feature
+switches remain available when an embedded target needs one of them. Full
+builds remain the default and retain the 1024-stream ceiling.
+
+`LIGHTNVR_MAX_STREAMS` can override the full-profile ceiling. Embedded builds
+accept values from 1 through 16 only. The older `EMBEDDED_A1_DEVICE=ON` option
+is retained as a deprecated alias for `LIGHTNVR_PROFILE=embedded`.
+
+Firmware packagers can also reduce web assets independently:
+
+```bash
+cd web
+LIGHTNVR_WEB_LEGACY=false LIGHTNVR_WEB_LOCALES=en npm run build
+```
+
+The first variable omits legacy-browser bundles. The second accepts a
+comma-separated locale list; English is always retained as the fallback.
+
 The build script will:
 1. Check for required dependencies
 2. Configure the build using CMake

--- a/docs/internal/MOTION_DETECTION_OPTIMIZATION.md
+++ b/docs/internal/MOTION_DETECTION_OPTIMIZATION.md
@@ -130,17 +130,19 @@ The A1 SoC has limited memory (256MB RAM), which can cause stack overflow issues
 1. **Heap Allocation**: Motion detection structures are now allocated on the heap instead of the stack
 2. **Reduced Buffer Sizes**: Frame history and grid sizes are automatically reduced
 3. **Increased Downscaling**: Default downscale factor is increased to 3x for A1 devices
-4. **Build with A1 Optimizations**: Use the `EMBEDDED_A1_DEVICE` CMake option
+4. **Build with the Embedded Profile**: Use the `LIGHTNVR_PROFILE` CMake option
 
 To build specifically for the A1 device:
 
 ```bash
 mkdir build && cd build
-cmake -DEMBEDDED_A1_DEVICE=ON ..
+cmake -DLIGHTNVR_PROFILE=embedded ..
 make
 ```
 
-This enables additional compiler optimizations and memory-saving techniques specifically for the A1 device.
+This selects size-oriented compiler flags, a 16-stream compile-time ceiling,
+and lightweight defaults for optional detection and messaging features. The
+older `EMBEDDED_A1_DEVICE=ON` spelling remains available as a deprecated alias.
 
 ## Implementation Details
 

--- a/include/core/config.h
+++ b/include/core/config.h
@@ -13,8 +13,13 @@
 // Maximum length for URLs
 #define MAX_URL_LENGTH 512
 // Compile-time ceiling for per-stream static arrays (pointer arrays, watchdog trackers, etc.).
-// The actual operational limit is g_config.max_streams (default 32, configurable up to this value).
-#define MAX_STREAMS 1024
+// The actual operational limit is g_config.max_streams (default 32 or this
+// ceiling, whichever is lower; configurable up to this value).
+#ifndef LIGHTNVR_MAX_STREAMS
+#define LIGHTNVR_MAX_STREAMS 1024
+#endif
+#define MAX_STREAMS LIGHTNVR_MAX_STREAMS
+#define DEFAULT_MAX_STREAMS ((MAX_STREAMS < 32) ? MAX_STREAMS : 32)
 #define WEB_TRUSTED_PROXY_CIDRS_MAX 1024
 
 // Stream protocol enum
@@ -244,7 +249,7 @@ typedef struct {
     char onvif_discovery_network[64]; // Network to scan for ONVIF devices (e.g., "192.168.1.0/24")
     
     // Stream settings
-    int max_streams;            // Runtime operational limit (default 32, max MAX_STREAMS, requires restart)
+    int max_streams;            // Runtime operational limit (default DEFAULT_MAX_STREAMS, max MAX_STREAMS, requires restart)
     stream_config_t *streams;   // Dynamically allocated array of max_streams entries
     
     // Memory optimization

--- a/src/core/config.c
+++ b/src/core/config.c
@@ -280,7 +280,7 @@ void load_default_config(config_t *config) {
     memset(config, 0, sizeof(config_t));
 
     // --- Runtime stream limit ---
-    config->max_streams = 32; // default; overridden by [streams] max_streams in INI
+    config->max_streams = DEFAULT_MAX_STREAMS; // overridden by [streams] max_streams in INI
     config->streams = calloc(config->max_streams, sizeof(stream_config_t));
     if (!config->streams) {
         // Fatal: we can't run without a streams array. Caller will detect NULL.
@@ -1721,8 +1721,8 @@ int save_config(const config_t *config, const char *path) {
 
     // Write stream settings
     fprintf(file, "[streams]\n");
-    fprintf(file, "max_streams = %d  ; Runtime stream slot limit (default: 32, ceiling: %d; requires restart)\n\n",
-            config->max_streams, MAX_STREAMS);
+    fprintf(file, "max_streams = %d  ; Runtime stream slot limit (default: %d, ceiling: %d; requires restart)\n\n",
+            config->max_streams, DEFAULT_MAX_STREAMS, MAX_STREAMS);
     
     // Write memory optimization settings
     fprintf(file, "[memory]\n");

--- a/src/video/go2rtc/go2rtc_integration.c
+++ b/src/video/go2rtc/go2rtc_integration.c
@@ -1486,7 +1486,7 @@ bool go2rtc_integration_register_all_streams(void) {
     }
 
     // Get all stream configurations (heap-allocated)
-    int ms = g_config.max_streams > 0 ? g_config.max_streams : 32;
+    int ms = configured_stream_slots();
     stream_config_t *streams = calloc(ms, sizeof(stream_config_t));
     if (!streams) return false;
     int count = get_all_stream_configs(streams, ms);
@@ -1571,7 +1571,7 @@ bool go2rtc_sync_streams_from_database(void) {
     }
 
     // Get all stream configurations from database (heap-allocated)
-    int ms2 = g_config.max_streams > 0 ? g_config.max_streams : 32;
+    int ms2 = configured_stream_slots();
     stream_config_t *db_streams = calloc(ms2, sizeof(stream_config_t));
     if (!db_streams) return false;
     int count = get_all_stream_configs(db_streams, ms2);

--- a/src/video/go2rtc/go2rtc_process.c
+++ b/src/video/go2rtc/go2rtc_process.c
@@ -1195,7 +1195,7 @@ static int write_stream_overrides(FILE *fp) {
     if (!fp) return 0;
     if (get_db_handle() == NULL) return 0;
 
-    int ms = g_config.max_streams > 0 ? g_config.max_streams : 32;
+    int ms = configured_stream_slots();
     stream_config_t *streams = calloc(ms, sizeof(stream_config_t));
     if (!streams) return 0;
 
@@ -1263,7 +1263,7 @@ static int write_publish_config(FILE *fp) {
     if (!fp) return 0;
     if (get_db_handle() == NULL) return 0;
 
-    int ms = g_config.max_streams > 0 ? g_config.max_streams : 32;
+    int ms = configured_stream_slots();
     stream_config_t *streams = calloc(ms, sizeof(stream_config_t));
     if (!streams) return 0;
 

--- a/src/video/streams.c
+++ b/src/video/streams.c
@@ -75,7 +75,7 @@ config_t* get_streaming_config(void) {
     memcpy(&db_config, &g_config, sizeof(config_t));
     
     // Load stream configurations from database
-    int ms = g_config.max_streams > 0 ? g_config.max_streams : 32;
+    int ms = configured_stream_slots();
     stream_config_t *db_streams = calloc(ms, sizeof(stream_config_t));
     if (db_streams) {
         int count = get_all_stream_configs(db_streams, ms);

--- a/src/web/api_handlers_detection_results.c
+++ b/src/web/api_handlers_detection_results.c
@@ -99,7 +99,7 @@ void debug_dump_detection_results(void) {
     log_debug("DEBUG: Current detection results (from database):");
 
     // Get all stream names (heap-allocated)
-    int ms = g_config.max_streams > 0 ? g_config.max_streams : 32;
+    int ms = configured_stream_slots();
     stream_config_t *streams = calloc(ms, sizeof(stream_config_t));
     if (!streams) return;
     int stream_count = get_all_stream_configs(streams, ms);

--- a/tests/unit/test_config.c
+++ b/tests/unit/test_config.c
@@ -57,8 +57,11 @@ void test_stream_config_t_size_under_16k(void) {
     TEST_ASSERT_LESS_THAN(16 * 1024, (int)sizeof(stream_config_t));
 }
 
-void test_max_stream_ceiling_is_1024(void) {
-    TEST_ASSERT_EQUAL_INT(1024, MAX_STREAMS);
+void test_max_stream_ceiling_is_valid(void) {
+    TEST_ASSERT_TRUE(MAX_STREAMS >= 1);
+    TEST_ASSERT_TRUE(MAX_STREAMS <= 1024);
+    TEST_ASSERT_EQUAL_INT(MAX_STREAMS < 32 ? MAX_STREAMS : 32,
+                          DEFAULT_MAX_STREAMS);
 }
 
 /* ================================================================
@@ -476,7 +479,7 @@ int main(void) {
     UNITY_BEGIN();
 
     RUN_TEST(test_stream_config_t_size_under_16k);
-    RUN_TEST(test_max_stream_ceiling_is_1024);
+    RUN_TEST(test_max_stream_ceiling_is_valid);
 
     RUN_TEST(test_default_config_web_port);
     RUN_TEST(test_default_config_log_level);

--- a/tests/unit/test_stream_manager.c
+++ b/tests/unit/test_stream_manager.c
@@ -45,10 +45,9 @@ void test_init_shutdown_lifecycle(void) {
 }
 
 /* compile-time ceiling is a usable runtime capacity */
-void test_init_supports_1024_slots(void) {
-    TEST_ASSERT_EQUAL_INT(1024, MAX_STREAMS);
+void test_init_supports_compile_time_ceiling(void) {
     TEST_ASSERT_EQUAL_INT(0, init_stream_manager(MAX_STREAMS));
-    TEST_ASSERT_EQUAL_INT(1024, get_stream_capacity());
+    TEST_ASSERT_EQUAL_INT(MAX_STREAMS, get_stream_capacity());
     shutdown_stream_manager();
 }
 
@@ -232,7 +231,7 @@ void test_independent_recording_schedules_use_current_hour(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_init_shutdown_lifecycle);
-    RUN_TEST(test_init_supports_1024_slots);
+    RUN_TEST(test_init_supports_compile_time_ceiling);
     RUN_TEST(test_double_shutdown);
     RUN_TEST(test_add_stream_returns_handle);
     RUN_TEST(test_get_stream_by_name);

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -14,6 +14,18 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const MISSING_APP_JS_IMPORTERS = ['streams.html'];
 const MIN_COMPRESSION_SIZE_BYTES = 1024;
+const legacyBrowserSupport = process.env.LIGHTNVR_WEB_LEGACY !== 'false';
+const configuredLocales = new Set(
+  (process.env.LIGHTNVR_WEB_LOCALES || '')
+    .split(',')
+    .map((locale) => locale.trim())
+    .filter(Boolean)
+);
+
+if (configuredLocales.size > 0) {
+  // English is the runtime fallback and must always be present.
+  configuredLocales.add('en');
+}
 
 /**
  * Check whether the given filesystem path exists.
@@ -85,6 +97,44 @@ const removeUseClientDirective = () => {
     }
   };
 };
+
+const filterLocalesPlugin = () => ({
+  name: 'filter-locales',
+  async writeBundle() {
+    const localesDir = resolve(__dirname, 'dist/locales');
+    if (!(await pathExists(localesDir))) {
+      throw new Error(`Locale output directory not found: ${localesDir}`);
+    }
+
+    const manifestPath = resolve(localesDir, 'manifest.json');
+    const manifest = JSON.parse(await fsPromises.readFile(manifestPath, 'utf8'));
+    const availableCodes = new Set(
+      (manifest.locales || []).map((locale) => locale.code)
+    );
+    const unknownLocales = [...configuredLocales].filter(
+      (locale) => !availableCodes.has(locale)
+    );
+    if (unknownLocales.length > 0) {
+      throw new Error(`Unknown LIGHTNVR_WEB_LOCALES: ${unknownLocales.join(', ')}`);
+    }
+
+    manifest.locales = manifest.locales.filter(
+      (locale) => configuredLocales.has(locale.code)
+    );
+    await fsPromises.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const entries = await fsPromises.readdir(localesDir, { withFileTypes: true });
+    await Promise.all(entries.map(async (entry) => {
+      if (!entry.isFile() || entry.name === 'manifest.json') {
+        return;
+      }
+      const localeCode = entry.name.replace(/\.(json|png)(\.gz)?$/, '');
+      if (localeCode !== entry.name && !configuredLocales.has(localeCode)) {
+        await fsPromises.unlink(resolve(localesDir, entry.name));
+      }
+    }));
+  },
+});
 
 export default defineConfig({
   // Vite 8 uses Oxc for JSX transforms. Target Preact directly so the build
@@ -169,11 +219,12 @@ export default defineConfig({
     removeUseClientDirective(),
     // Theme injection plugin - reads COLOR_THEMES from theme-init.js and injects into HTML
     themeInjectPlugin(),
-    // Add legacy browser support with explicit targets
-    legacy({
+    // Add legacy browser support with explicit targets unless a constrained
+    // package requests a modern-only bundle.
+    ...(legacyBrowserSupport ? [legacy({
       targets: ['defaults', 'not IE 11'],
       modernPolyfills: true
-    }),
+    })] : []),
     // Custom plugin to handle non-module scripts
     {
       name: 'handle-non-module-scripts',
@@ -307,6 +358,7 @@ export default defineConfig({
         }
       }
     },
+    ...(configuredLocales.size > 0 ? [filterLocalesPlugin()] : []),
     // Gzip compression for static assets - generates .gz files alongside originals
     viteCompression({
       verbose: true,


### PR DESCRIPTION
## Summary

- add a `full`/`embedded` CMake profile while preserving full as the default
- cap embedded builds at 16 streams and use the configured ceiling consistently at runtime
- default SOD, LiteRT, and MQTT off for embedded builds while keeping every feature overrideable
- let firmware builds omit legacy browser bundles and retain only selected locales
- stop overriding a cross-toolchain's `-Os` with project-wide `-O2`

`EMBEDDED_A1_DEVICE=ON` remains as a deprecated compatibility alias.

## Validation

- embedded native build completed (`LIGHTNVR_MAX_STREAMS=16`)
- full and embedded stream-ceiling unit tests passed
- 83/83 applicable embedded CTest tests passed (SOD-only stream-detection test excluded because SOD is disabled)
- Jest: 19 suites / 130 tests passed
- full web build retained all 18 locale JSON files and legacy assets
- embedded web build retained only English, emitted no legacy assets, and reduced `dist` from 7.37 MB to 2.81 MB
- embedded ceiling rejects values above 16 at configure time