### PR TITLE
Fleet 03 P3: emit operational events through MQTT routes

### DIFF
--- a/docs/EVENT_CONTRACT.md
+++ b/docs/EVENT_CONTRACT.md
@@ -47,8 +47,12 @@ Every event uses a CloudEvents-inspired JSON envelope:
 | --- | --- | --- | ---: | --- | --- |
 | `io.lightnvr.detection.object.v1` | info | operational | 1 hour | high | reference allowed |
 | `io.lightnvr.camera.offline.v1` | warning | operational | 1 day | low | forbidden |
+| `io.lightnvr.camera.recovered.v1` | info | operational | 1 day | low | forbidden |
+| `io.lightnvr.stream.degraded.v1` | warning | operational | 1 day | low | forbidden |
+| `io.lightnvr.stream.recovered.v1` | info | operational | 1 day | low | forbidden |
 | `io.lightnvr.stream.recording_gap.v1` | warning | operational | 7 days | low | reference allowed |
 | `io.lightnvr.storage.pressure.v1` | critical | internal | 7 days | low | forbidden |
+| `io.lightnvr.storage.recovered.v1` | info | internal | 7 days | low | forbidden |
 
 Expiry is internal delivery metadata and is intentionally not part of the JSON
 payload. MQTT 5 delivery may carry it as a message-expiry property; the durable
@@ -100,6 +104,42 @@ and an authorization-aware `snapshot_url` are optional.
 `reason` is a stable machine-readable value and `consecutive_failures` is at
 least one.
 
+### `io.lightnvr.camera.recovered.v1`
+
+```json
+{
+  "previous_state": "offline",
+  "downtime_ms": 15000
+}
+```
+
+`downtime_ms` measures the observed offline interval and is non-negative.
+
+### `io.lightnvr.stream.degraded.v1`
+
+```json
+{
+  "reason": "low_fps",
+  "observed_fps": 7.5,
+  "expected_fps": 25.0
+}
+```
+
+`reason` is `low_fps` or `stale_frames`. FPS values are non-negative.
+
+### `io.lightnvr.stream.recovered.v1`
+
+```json
+{
+  "previous_state": "degraded",
+  "observed_fps": 24.5,
+  "expected_fps": 25.0
+}
+```
+
+This fact is emitted only when a previously degraded stream returns to the
+healthy threshold.
+
 ### `io.lightnvr.stream.recording_gap.v1`
 
 ```json
@@ -124,6 +164,19 @@ least one.
 `level` is `warning`, `critical`, or `emergency`; `used_percent` is between zero
 and 100. `free_bytes` is optional.
 
+### `io.lightnvr.storage.recovered.v1`
+
+```json
+{
+  "previous_level": "critical",
+  "used_percent": 72.0,
+  "free_bytes": 3221225472
+}
+```
+
+`previous_level` is `warning`, `critical`, or `emergency`. The event is emitted
+when the monitored recording filesystem returns to normal pressure.
+
 ## Producer API
 
 The installation source is a UUID generated once and persisted in
@@ -139,6 +192,13 @@ the immutable camera UUID, or
 `event_producer_publish_detection_for_stream()` at legacy name-only call sites.
 Both normalize and enqueue only; neither performs MQTT, snapshot, or other
 network work on the caller thread.
+
+The same producer module exposes camera offline/recovered, stream
+degraded/recovered, recording-gap, and storage pressure/recovered facts. Stream
+producers resolve the current stream name to its immutable camera UUID. The
+health sampler and storage heartbeat emit only on observed state transitions;
+the recording producer runs only after the segment continuity detector finds a
+gap greater than five seconds.
 
 ## Asynchronous in-process bus
 

--- a/docs/prd/FLEET_03_Event_Bus_MQTT_Routes.md
+++ b/docs/prd/FLEET_03_Event_Bus_MQTT_Routes.md
@@ -1,9 +1,9 @@
 # PRD — Event Bus & MQTT Routes
 
-**Status**: P0/P1 complete; P2 routing in progress — durable route definitions,
-catalog/CRUD API, selector preview, optimistic concurrency, runtime
-type/scope/predicate/schedule evaluation, and durable suppression implemented;
-multiple destinations and UI remain
+**Status**: P0/P1/P2 complete; P3 in progress — camera offline/recovered,
+stream degraded/recovered and recording-gap, and storage pressure/recovered
+producers are wired to observed transitions. Target-health, security, ONVIF,
+and media-reference producers remain.
 **Created**: 2026-08-22
 **Owner**: TBD
 **Priority**: 3 — integration foundation
@@ -161,13 +161,15 @@ producer thread and enforces event type, Fleet selector, detection predicate,
 and occurrence-time schedule before durable enqueue. Durable suppression now
 preserves the first event and enforces debounce, cooldown, grouping, and fixed
 per-minute limits by route/type/subject, committing allowed state only after
-outbox acceptance. The remaining slices add destination profiles and expose the
-workflow in the Streams-area UI.
+outbox acceptance. Destination profiles, delivery controls, and the
+Streams-area routing UI are implemented. P3 now broadens the producer catalog
+without changing the durable routing and delivery path.
 
 ## 8. Acceptance criteria
 
-- Detection, camera-offline, recording-gap, and storage-pressure fixtures validate
-  against documented schemas.
+- Detection, camera offline/recovered, stream degraded/recovered and
+  recording-gap, and storage pressure/recovered fixtures validate against
+  documented schemas.
 - A broker outage during 1,000 generated critical events does not block recording;
   eligible events deliver after reconnection with unchanged IDs.
 - Duplicate delivery is safely recognizable by `source + id`.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -30,7 +30,7 @@ and policy primitives established earlier.
 | --- | --- | --- | --- |
 | 1 | [Fleet 01 — Camera Identity & Organization](FLEET_01_Camera_Identity_Organization.md) | Stable camera identity, location hierarchy, tags, and smart collections | Now |
 | 2 | [Fleet 02 — Scoped Authorization & Audit](FLEET_02_Scoped_Authorization_Audit.md) | Action-level permissions over reusable fleet scopes | Now; SSO deferred |
-| 3 | [Fleet 03 — Event Bus & MQTT Routes](FLEET_03_Event_Bus_MQTT_Routes.md) | Durable provider-neutral events for cloud and automation consumers | Now |
+| 3 | [Fleet 03 — Event Bus & MQTT Routes](FLEET_03_Event_Bus_MQTT_Routes.md) | Durable provider-neutral events for cloud and automation consumers | Now — P3 producer expansion in progress |
 | 4 | [Fleet 04 — Fleet Explorer & Bulk Operations](FLEET_04_Fleet_Explorer_Bulk_Operations.md) | Operate hundreds of cameras through search, queues, templates, and jobs | Next |
 | 5 | [Storage 01 — Multi-Target Storage Lifecycle](STORAGE_01_Multi_Target_Lifecycle.md) | Policy-driven placement, migration, retention, and capacity management | In progress — P1b target pressure and policy simulation implemented |
 | 6 | [ONVIF 01 — Capability Onboarding & Events](ONVIF_01_Capability_Onboarding_Events.md) | Reliable discovery, profile pairing, capability inventory, and normalized events | Next |

--- a/include/core/event_producers.h
+++ b/include/core/event_producers.h
@@ -2,6 +2,7 @@
 #define LIGHTNVR_CORE_EVENT_PRODUCERS_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include <time.h>
 
 #include "video/detection_result.h"
@@ -19,6 +20,38 @@ int event_producer_publish_detection(
 /* Resolve the current stream name to its immutable UUID, then enqueue. */
 int event_producer_publish_detection_for_stream(
     const char *stream_name, const detection_result_t *result,
+    time_t occurred_at, char *error, size_t error_size);
+
+/*
+ * Operational producers resolve mutable stream names to immutable camera UUIDs
+ * before enqueueing. They perform no MQTT or other network I/O.
+ */
+int event_producer_publish_camera_offline_for_stream(
+    const char *stream_name, const char *reason, int consecutive_failures,
+    time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_camera_recovered_for_stream(
+    const char *stream_name, int64_t downtime_ms, time_t occurred_at,
+    char *error, size_t error_size);
+
+int event_producer_publish_stream_degraded_for_stream(
+    const char *stream_name, const char *reason, double observed_fps,
+    double expected_fps, time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_stream_recovered_for_stream(
+    const char *stream_name, double observed_fps, double expected_fps,
+    time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_recording_gap_for_stream(
+    const char *stream_name, time_t started_at, int64_t duration_ms,
+    time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_storage_pressure(
+    const char *level, const char *previous_level, double used_percent,
+    uint64_t free_bytes, time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_storage_recovered(
+    const char *previous_level, double used_percent, uint64_t free_bytes,
     time_t occurred_at, char *error, size_t error_size);
 
 #endif /* LIGHTNVR_CORE_EVENT_PRODUCERS_H */

--- a/include/telemetry/stream_metrics.h
+++ b/include/telemetry/stream_metrics.h
@@ -83,6 +83,8 @@ typedef struct {
     /* Health status (recomputed by sampler thread) */
     atomic_int health_status;             /* stream_health_status_t */
     atomic_int stream_up;                 /* 1 if UP, 0 otherwise */
+    bool health_observed;                 /* initial health sample completed */
+    time_t health_changed_at;             /* start of current health state */
 
     /* Gauges */
     atomic_int_fast64_t last_frame_ts;    /* unix epoch seconds of last frame */

--- a/src/core/event_envelope.c
+++ b/src/core/event_envelope.c
@@ -37,6 +37,39 @@ static const event_type_definition_t EVENT_TYPES[] = {
         .default_expiry_seconds = 86400,
     },
     {
+        .type = "io.lightnvr.camera.recovered.v1",
+        .family = "camera",
+        .description = "Camera connectivity recovered after an offline state",
+        .severity = EVENT_SEVERITY_INFO,
+        .sensitivity = EVENT_SENSITIVITY_OPERATIONAL,
+        .media_policy = EVENT_MEDIA_FORBIDDEN,
+        .expected_rate = EVENT_RATE_LOW,
+        .subject_kind = EVENT_SUBJECT_CAMERA,
+        .default_expiry_seconds = 86400,
+    },
+    {
+        .type = "io.lightnvr.stream.degraded.v1",
+        .family = "stream",
+        .description = "A camera stream crossed a degraded health threshold",
+        .severity = EVENT_SEVERITY_WARNING,
+        .sensitivity = EVENT_SENSITIVITY_OPERATIONAL,
+        .media_policy = EVENT_MEDIA_FORBIDDEN,
+        .expected_rate = EVENT_RATE_LOW,
+        .subject_kind = EVENT_SUBJECT_CAMERA,
+        .default_expiry_seconds = 86400,
+    },
+    {
+        .type = "io.lightnvr.stream.recovered.v1",
+        .family = "stream",
+        .description = "A degraded camera stream returned to healthy",
+        .severity = EVENT_SEVERITY_INFO,
+        .sensitivity = EVENT_SENSITIVITY_OPERATIONAL,
+        .media_policy = EVENT_MEDIA_FORBIDDEN,
+        .expected_rate = EVENT_RATE_LOW,
+        .subject_kind = EVENT_SUBJECT_CAMERA,
+        .default_expiry_seconds = 86400,
+    },
+    {
         .type = "io.lightnvr.stream.recording_gap.v1",
         .family = "stream",
         .description = "A gap was detected in a camera recording",
@@ -52,6 +85,17 @@ static const event_type_definition_t EVENT_TYPES[] = {
         .family = "storage",
         .description = "Storage usage crossed an operational threshold",
         .severity = EVENT_SEVERITY_CRITICAL,
+        .sensitivity = EVENT_SENSITIVITY_INTERNAL,
+        .media_policy = EVENT_MEDIA_FORBIDDEN,
+        .expected_rate = EVENT_RATE_LOW,
+        .subject_kind = EVENT_SUBJECT_STORAGE,
+        .default_expiry_seconds = 604800,
+    },
+    {
+        .type = "io.lightnvr.storage.recovered.v1",
+        .family = "storage",
+        .description = "Storage returned to normal after pressure",
+        .severity = EVENT_SEVERITY_INFO,
         .sensitivity = EVENT_SENSITIVITY_INTERNAL,
         .media_policy = EVENT_MEDIA_FORBIDDEN,
         .expected_rate = EVENT_RATE_LOW,
@@ -303,8 +347,48 @@ static int validate_type_data(const char *type, const cJSON *data,
         const cJSON *failures = required_field(
             data, "consecutive_failures", cJSON_Number, error, error_size);
         if (!reason || !failures) return -1;
-        if (!reason->valuestring[0] || failures->valueint < 1) {
+        if (!reason->valuestring[0] || failures->valueint < 1 ||
+            failures->valuedouble != (double)failures->valueint) {
             set_error(error, error_size, "camera offline data is invalid");
+            return -1;
+        }
+    } else if (strcmp(type, "io.lightnvr.camera.recovered.v1") == 0) {
+        const cJSON *previous = required_field(
+            data, "previous_state", cJSON_String, error, error_size);
+        const cJSON *downtime = required_field(
+            data, "downtime_ms", cJSON_Number, error, error_size);
+        if (!previous || !downtime) return -1;
+        if (strcmp(previous->valuestring, "offline") != 0 ||
+            downtime->valuedouble < 0) {
+            set_error(error, error_size, "camera recovered data is invalid");
+            return -1;
+        }
+    } else if (strcmp(type, "io.lightnvr.stream.degraded.v1") == 0) {
+        const cJSON *reason = required_field(data, "reason", cJSON_String,
+                                             error, error_size);
+        const cJSON *observed = required_field(
+            data, "observed_fps", cJSON_Number, error, error_size);
+        const cJSON *expected = required_field(
+            data, "expected_fps", cJSON_Number, error, error_size);
+        if (!reason || !observed || !expected) return -1;
+        bool valid_reason = strcmp(reason->valuestring, "low_fps") == 0 ||
+            strcmp(reason->valuestring, "stale_frames") == 0;
+        if (!valid_reason || observed->valuedouble < 0 ||
+            expected->valuedouble < 0) {
+            set_error(error, error_size, "stream degraded data is invalid");
+            return -1;
+        }
+    } else if (strcmp(type, "io.lightnvr.stream.recovered.v1") == 0) {
+        const cJSON *previous = required_field(
+            data, "previous_state", cJSON_String, error, error_size);
+        const cJSON *observed = required_field(
+            data, "observed_fps", cJSON_Number, error, error_size);
+        const cJSON *expected = required_field(
+            data, "expected_fps", cJSON_Number, error, error_size);
+        if (!previous || !observed || !expected) return -1;
+        if (strcmp(previous->valuestring, "degraded") != 0 ||
+            observed->valuedouble < 0 || expected->valuedouble < 0) {
+            set_error(error, error_size, "stream recovered data is invalid");
             return -1;
         }
     } else if (strcmp(type, "io.lightnvr.stream.recording_gap.v1") == 0) {
@@ -330,6 +414,20 @@ static int validate_type_data(const char *type, const cJSON *data,
         if (!valid_level || used->valuedouble < 0 ||
             used->valuedouble > 100) {
             set_error(error, error_size, "storage pressure data is invalid");
+            return -1;
+        }
+    } else if (strcmp(type, "io.lightnvr.storage.recovered.v1") == 0) {
+        const cJSON *previous = required_field(
+            data, "previous_level", cJSON_String, error, error_size);
+        const cJSON *used = required_field(data, "used_percent", cJSON_Number,
+                                           error, error_size);
+        if (!previous || !used) return -1;
+        bool valid_previous = strcmp(previous->valuestring, "warning") == 0 ||
+            strcmp(previous->valuestring, "critical") == 0 ||
+            strcmp(previous->valuestring, "emergency") == 0;
+        if (!valid_previous || used->valuedouble < 0 ||
+            used->valuedouble > 100) {
+            set_error(error, error_size, "storage recovered data is invalid");
             return -1;
         }
     }

--- a/src/core/event_producers.c
+++ b/src/core/event_producers.c
@@ -2,6 +2,8 @@
 
 #include "core/event_producers.h"
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -15,10 +17,87 @@
 #include "utils/uuid.h"
 
 #define DETECTION_EVENT_TYPE "io.lightnvr.detection.object.v1"
+#define CAMERA_OFFLINE_EVENT_TYPE "io.lightnvr.camera.offline.v1"
+#define CAMERA_RECOVERED_EVENT_TYPE "io.lightnvr.camera.recovered.v1"
+#define STREAM_DEGRADED_EVENT_TYPE "io.lightnvr.stream.degraded.v1"
+#define STREAM_RECOVERED_EVENT_TYPE "io.lightnvr.stream.recovered.v1"
+#define RECORDING_GAP_EVENT_TYPE "io.lightnvr.stream.recording_gap.v1"
+#define STORAGE_PRESSURE_EVENT_TYPE "io.lightnvr.storage.pressure.v1"
+#define STORAGE_RECOVERED_EVENT_TYPE "io.lightnvr.storage.recovered.v1"
 
 static void set_error(char *error, size_t error_size, const char *message) {
     if (!error || error_size == 0) return;
     snprintf(error, error_size, "%s", message ? message : "event producer error");
+}
+
+static bool valid_text(const char *value, size_t maximum) {
+    return value && value[0] != '\0' && strnlen(value, maximum) < maximum;
+}
+
+static int publish_event(const char *type, const char *subject,
+                         time_t occurred_at, const cJSON *data,
+                         char *error, size_t error_size) {
+    char source[EVENT_SOURCE_MAX];
+    if (event_identity_get_source(source, sizeof(source)) != 0) {
+        set_error(error, error_size, "event identity is not initialized");
+        return -1;
+    }
+
+    event_envelope_t event;
+    if (event_envelope_create(&event, type, source, subject, occurred_at, data,
+                              error, error_size) != 0) {
+        return -1;
+    }
+    event_bus_result_t publish_result =
+        event_bus_publish(&event, error, error_size);
+    event_envelope_clear(&event);
+    return publish_result == EVENT_BUS_OK ? 0 : -1;
+}
+
+static int camera_subject_for_stream(
+    const char *stream_name, char subject[EVENT_SUBJECT_MAX],
+    char *error, size_t error_size) {
+    if (!valid_text(stream_name, MAX_STREAM_NAME)) {
+        set_error(error, error_size, "stream name is required");
+        return -1;
+    }
+    stream_config_t stream;
+    if (get_stream_config_by_name(stream_name, &stream) != 0 ||
+        !lightnvr_uuid_is_valid(stream.camera_uuid)) {
+        set_error(error, error_size, "stream camera identity is unavailable");
+        return -1;
+    }
+    int written = snprintf(subject, EVENT_SUBJECT_MAX, "camera/%s",
+                           stream.camera_uuid);
+    if (written < 0 || written >= EVENT_SUBJECT_MAX) {
+        set_error(error, error_size, "camera event subject is too long");
+        return -1;
+    }
+    return 0;
+}
+
+static int publish_camera_event_for_stream(
+    const char *type, const char *stream_name, time_t occurred_at,
+    const cJSON *data, char *error, size_t error_size) {
+    char subject[EVENT_SUBJECT_MAX];
+    if (camera_subject_for_stream(stream_name, subject, error, error_size) != 0) {
+        return -1;
+    }
+    return publish_event(type, subject, occurred_at, data, error, error_size);
+}
+
+static int format_event_time(time_t value, char output[EVENT_TIME_MAX]) {
+    struct tm utc;
+    if (value <= 0 || !gmtime_r(&value, &utc)) return -1;
+    return strftime(output, EVENT_TIME_MAX, "%Y-%m-%dT%H:%M:%SZ", &utc) > 0
+        ? 0
+        : -1;
+}
+
+static bool valid_pressure_level(const char *level) {
+    return level && (strcmp(level, "warning") == 0 ||
+                     strcmp(level, "critical") == 0 ||
+                     strcmp(level, "emergency") == 0);
 }
 
 static bool add_detection_data(cJSON *data, const char *stream_name,
@@ -79,12 +158,7 @@ int event_producer_publish_detection(
         return -1;
     }
 
-    char source[EVENT_SOURCE_MAX];
     char subject[EVENT_SUBJECT_MAX];
-    if (event_identity_get_source(source, sizeof(source)) != 0) {
-        set_error(error, error_size, "event identity is not initialized");
-        return -1;
-    }
     int subject_length = snprintf(subject, sizeof(subject), "camera/%s",
                                   camera_uuid);
     if (subject_length < 0 || (size_t)subject_length >= sizeof(subject)) {
@@ -99,17 +173,10 @@ int event_producer_publish_detection(
         return -1;
     }
 
-    event_envelope_t event;
-    int create_result = event_envelope_create(
-        &event, DETECTION_EVENT_TYPE, source, subject, occurred_at, data,
-        error, error_size);
+    int create_result = publish_event(
+        DETECTION_EVENT_TYPE, subject, occurred_at, data, error, error_size);
     cJSON_Delete(data);
-    if (create_result != 0) return -1;
-
-    event_bus_result_t publish_result =
-        event_bus_publish(&event, error, error_size);
-    event_envelope_clear(&event);
-    return publish_result == EVENT_BUS_OK ? 0 : -1;
+    return create_result;
 }
 
 int event_producer_publish_detection_for_stream(
@@ -128,4 +195,178 @@ int event_producer_publish_detection_for_stream(
     return event_producer_publish_detection(
         stream.camera_uuid, stream_name, result, occurred_at, error,
         error_size);
+}
+
+int event_producer_publish_camera_offline_for_stream(
+    const char *stream_name, const char *reason, int consecutive_failures,
+    time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!valid_text(stream_name, MAX_STREAM_NAME) ||
+        !valid_text(reason, 128) || consecutive_failures < 1) {
+        set_error(error, error_size, "camera offline event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "stream_name", stream_name) ||
+        !cJSON_AddStringToObject(data, "reason", reason) ||
+        !cJSON_AddNumberToObject(data, "consecutive_failures",
+                                consecutive_failures)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "camera offline event allocation failed");
+        return -1;
+    }
+    int result = publish_camera_event_for_stream(
+        CAMERA_OFFLINE_EVENT_TYPE, stream_name, occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_camera_recovered_for_stream(
+    const char *stream_name, int64_t downtime_ms, time_t occurred_at,
+    char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!valid_text(stream_name, MAX_STREAM_NAME) || downtime_ms < 0) {
+        set_error(error, error_size, "camera recovered event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "stream_name", stream_name) ||
+        !cJSON_AddStringToObject(data, "previous_state", "offline") ||
+        !cJSON_AddNumberToObject(data, "downtime_ms", (double)downtime_ms)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "camera recovered event allocation failed");
+        return -1;
+    }
+    int result = publish_camera_event_for_stream(
+        CAMERA_RECOVERED_EVENT_TYPE, stream_name, occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_stream_degraded_for_stream(
+    const char *stream_name, const char *reason, double observed_fps,
+    double expected_fps, time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!valid_text(stream_name, MAX_STREAM_NAME) ||
+        !valid_text(reason, 128) || observed_fps < 0.0 || expected_fps < 0.0) {
+        set_error(error, error_size, "stream degraded event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "stream_name", stream_name) ||
+        !cJSON_AddStringToObject(data, "reason", reason) ||
+        !cJSON_AddNumberToObject(data, "observed_fps", observed_fps) ||
+        !cJSON_AddNumberToObject(data, "expected_fps", expected_fps)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "stream degraded event allocation failed");
+        return -1;
+    }
+    int result = publish_camera_event_for_stream(
+        STREAM_DEGRADED_EVENT_TYPE, stream_name, occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_stream_recovered_for_stream(
+    const char *stream_name, double observed_fps, double expected_fps,
+    time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!valid_text(stream_name, MAX_STREAM_NAME) || observed_fps < 0.0 ||
+        expected_fps < 0.0) {
+        set_error(error, error_size, "stream recovered event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "stream_name", stream_name) ||
+        !cJSON_AddStringToObject(data, "previous_state", "degraded") ||
+        !cJSON_AddNumberToObject(data, "observed_fps", observed_fps) ||
+        !cJSON_AddNumberToObject(data, "expected_fps", expected_fps)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "stream recovered event allocation failed");
+        return -1;
+    }
+    int result = publish_camera_event_for_stream(
+        STREAM_RECOVERED_EVENT_TYPE, stream_name, occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_recording_gap_for_stream(
+    const char *stream_name, time_t started_at, int64_t duration_ms,
+    time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    char started_at_text[EVENT_TIME_MAX];
+    if (!valid_text(stream_name, MAX_STREAM_NAME) || duration_ms < 0 ||
+        format_event_time(started_at, started_at_text) != 0) {
+        set_error(error, error_size, "recording gap event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "stream_name", stream_name) ||
+        !cJSON_AddStringToObject(data, "started_at", started_at_text) ||
+        !cJSON_AddNumberToObject(data, "duration_ms", (double)duration_ms)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "recording gap event allocation failed");
+        return -1;
+    }
+    int result = publish_camera_event_for_stream(
+        RECORDING_GAP_EVENT_TYPE, stream_name, occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_storage_pressure(
+    const char *level, const char *previous_level, double used_percent,
+    uint64_t free_bytes, time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!valid_pressure_level(level) ||
+        !valid_text(previous_level, 32) || used_percent < 0.0 ||
+        used_percent > 100.0) {
+        set_error(error, error_size, "storage pressure event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "level", level) ||
+        !cJSON_AddStringToObject(data, "previous_level", previous_level) ||
+        !cJSON_AddNumberToObject(data, "used_percent", used_percent) ||
+        !cJSON_AddNumberToObject(data, "free_bytes", (double)free_bytes)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "storage pressure event allocation failed");
+        return -1;
+    }
+    int result = publish_event(
+        STORAGE_PRESSURE_EVENT_TYPE, "system/storage", occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_storage_recovered(
+    const char *previous_level, double used_percent, uint64_t free_bytes,
+    time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!valid_pressure_level(previous_level) || used_percent < 0.0 ||
+        used_percent > 100.0) {
+        set_error(error, error_size, "storage recovered event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data ||
+        !cJSON_AddStringToObject(data, "previous_level", previous_level) ||
+        !cJSON_AddNumberToObject(data, "used_percent", used_percent) ||
+        !cJSON_AddNumberToObject(data, "free_bytes", (double)free_bytes)) {
+        cJSON_Delete(data);
+        set_error(error, error_size, "storage recovered event allocation failed");
+        return -1;
+    }
+    int result = publish_event(
+        STORAGE_RECOVERED_EVENT_TYPE, "system/storage", occurred_at, data,
+        error, error_size);
+    cJSON_Delete(data);
+    return result;
 }

--- a/src/storage/storage_manager.c
+++ b/src/storage/storage_manager.c
@@ -21,6 +21,7 @@
 #include "database/db_detections.h"
 #include "web/api_handlers_recordings_thumbnail.h"
 #include "core/config.h"
+#include "core/event_producers.h"
 #include "core/logger.h"
 #include "core/mqtt_client.h"
 #include "core/path_utils.h"
@@ -868,6 +869,16 @@ static disk_pressure_level_t evaluate_disk_pressure_level_cfg(double free_pct) {
     return DISK_PRESSURE_NORMAL;
 }
 
+static const char *disk_pressure_event_level(disk_pressure_level_t level) {
+    switch (level) {
+        case DISK_PRESSURE_WARNING: return "warning";
+        case DISK_PRESSURE_CRITICAL: return "critical";
+        case DISK_PRESSURE_EMERGENCY: return "emergency";
+        case DISK_PRESSURE_NORMAL: return "normal";
+    }
+    return "normal";
+}
+
 /**
  * Current free space as a fraction of total (0-100), or -1.0 on error.
  */
@@ -1172,6 +1183,24 @@ static void heartbeat_check_disk_pressure(void) {
             log_info("Disk pressure decreased: %s -> %s (%.1f%% free)",
                      disk_pressure_level_str(old_level), disk_pressure_level_str(new_level),
                      free_pct);
+        }
+
+        char event_error[256] = {0};
+        double used_pct = 100.0 - free_pct;
+        int event_result;
+        if (new_level == DISK_PRESSURE_NORMAL) {
+            event_result = event_producer_publish_storage_recovered(
+                disk_pressure_event_level(old_level), used_pct, avail,
+                time(NULL), event_error, sizeof(event_error));
+        } else {
+            event_result = event_producer_publish_storage_pressure(
+                disk_pressure_event_level(new_level),
+                disk_pressure_event_level(old_level), used_pct, avail,
+                time(NULL), event_error, sizeof(event_error));
+        }
+        if (event_result != 0) {
+            log_warn("Could not enqueue normalized storage pressure event: %s",
+                     event_error[0] ? event_error : "unknown error");
         }
 
         // Publish pressure change to MQTT: {prefix}/storage/pressure

--- a/src/telemetry/stream_metrics.c
+++ b/src/telemetry/stream_metrics.c
@@ -13,8 +13,10 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "telemetry/stream_metrics.h"
+#include "core/event_producers.h"
 #include "core/shutdown_coordinator.h"
 #define LOG_COMPONENT "Metrics"
 #include "core/logger.h"
@@ -96,6 +98,64 @@ metrics_counter_delta_t metrics_merge_source_deltas(
     return merged;
 }
 
+static void log_publish_failure(const char *type, const char *stream_name,
+                                const char *error) {
+    log_warn("Could not enqueue %s event for stream '%s': %s", type,
+             stream_name, error && error[0] ? error : "unknown error");
+}
+
+static void publish_health_transition(
+    const char *stream_name, stream_health_status_t old_status,
+    stream_health_status_t new_status, bool initial_observation,
+    time_t previous_changed_at, time_t now, double frame_age,
+    double observed_fps, double expected_fps) {
+    if ((!initial_observation && old_status == new_status) ||
+        !stream_name || stream_name[0] == '\0') {
+        return;
+    }
+
+    char error[256] = {0};
+    if (new_status == STREAM_HEALTH_DOWN) {
+        double failure_samples = frame_age / (double)SAMPLER_INTERVAL_SEC;
+        int failures = failure_samples > (double)INT_MAX
+            ? INT_MAX : (int)failure_samples;
+        if (failures < 1) failures = 1;
+        if (event_producer_publish_camera_offline_for_stream(
+                stream_name, "frame_timeout", failures, now,
+                error, sizeof(error)) != 0) {
+            log_publish_failure("camera offline", stream_name, error);
+        }
+        return;
+    }
+
+    if (!initial_observation && old_status == STREAM_HEALTH_DOWN) {
+        int64_t downtime_ms = previous_changed_at > 0 && now > previous_changed_at
+            ? (int64_t)(now - previous_changed_at) * 1000 : 0;
+        if (event_producer_publish_camera_recovered_for_stream(
+                stream_name, downtime_ms, now, error, sizeof(error)) != 0) {
+            log_publish_failure("camera recovered", stream_name, error);
+        }
+        error[0] = '\0';
+    }
+
+    if (new_status == STREAM_HEALTH_DEGRADED) {
+        const char *reason = frame_age > STREAM_HEALTH_FRAME_TIMEOUT_UP
+            ? "stale_frames" : "low_fps";
+        if (event_producer_publish_stream_degraded_for_stream(
+                stream_name, reason, observed_fps, expected_fps, now,
+                error, sizeof(error)) != 0) {
+            log_publish_failure("stream degraded", stream_name, error);
+        }
+    } else if (!initial_observation &&
+               old_status == STREAM_HEALTH_DEGRADED) {
+        if (event_producer_publish_stream_recovered_for_stream(
+                stream_name, observed_fps, expected_fps, now,
+                error, sizeof(error)) != 0) {
+            log_publish_failure("stream recovered", stream_name, error);
+        }
+    }
+}
+
 /* ------------------------------------------------------------------ */
 /*  Sampler thread                                                     */
 /* ------------------------------------------------------------------ */
@@ -172,8 +232,23 @@ static void *sampler_thread_func(void *arg) {
             } else {
                 status = STREAM_HEALTH_UP;
             }
+            stream_health_status_t previous_status =
+                (stream_health_status_t)atomic_load(&m->health_status);
+            bool initial_observation = !m->health_observed;
+            time_t previous_changed_at = m->health_changed_at;
+            bool health_changed = initial_observation ||
+                status != previous_status;
+            if (health_changed) {
+                m->health_observed = true;
+                m->health_changed_at = now;
+            }
             atomic_store(&m->health_status, (int)status);
             atomic_store(&m->stream_up, status == STREAM_HEALTH_UP ? 1 : 0);
+
+            char stream_name[MAX_STREAM_NAME];
+            safe_strcpy(stream_name, m->stream_name, sizeof(stream_name), 0);
+            double observed_fps = m->current_fps;
+            double expected_fps = cfg_fps;
 
             /* --- Append ring buffer sample --- */
             int idx = m->ring_head;
@@ -186,6 +261,13 @@ static void *sampler_thread_func(void *arg) {
             }
 
             pthread_rwlock_unlock(&m->lock);
+
+            if (health_changed) {
+                publish_health_transition(
+                    stream_name, previous_status, status, initial_observation,
+                    previous_changed_at, now, frame_age, observed_fps,
+                    expected_fps);
+            }
         }
     }
 
@@ -288,6 +370,8 @@ static int metrics_get_slot(const char *stream_name) {
                 m->configured_fps = 30.0; /* default, overridden by set_configured_fps */
                 atomic_store(&m->health_status, (int)STREAM_HEALTH_DOWN);
                 atomic_store(&m->stream_up, 0);
+                m->health_observed = false;
+                m->health_changed_at = 0;
                 atomic_store(&m->last_frame_ts, 0);
                 atomic_store(&m->frames_total, 0);
                 atomic_store(&m->frames_dropped, 0);
@@ -402,11 +486,15 @@ void metrics_record_segment_complete(const char *stream_name, time_t start_time,
     pthread_rwlock_wrlock(&m->lock);
 
     /* Gap detection: compare with previous segment end */
+    time_t gap_started_at = 0;
+    int64_t gap_duration_ms = 0;
     if (m->last_segment_end_time > 0 && start_time > 0) {
         double gap = difftime(start_time, m->last_segment_end_time);
         if (gap > RECORDING_GAP_THRESHOLD_SEC) {
             atomic_fetch_add(&m->recording_gaps_total, 1);
             log_warn("Recording gap detected for stream '%s': %.0fs gap", stream_name, gap);
+            gap_started_at = m->last_segment_end_time;
+            gap_duration_ms = (int64_t)(gap * 1000.0);
         }
     }
     if (end_time > 0) {
@@ -417,13 +505,35 @@ void metrics_record_segment_complete(const char *stream_name, time_t start_time,
     atomic_fetch_add(&m->recording_bytes_written, bytes);
 
     pthread_rwlock_unlock(&m->lock);
+
+    if (gap_started_at > 0) {
+        char error[256] = {0};
+        time_t occurred_at = start_time > 0 ? start_time : time(NULL);
+        if (event_producer_publish_recording_gap_for_stream(
+                stream_name, gap_started_at, gap_duration_ms, occurred_at,
+                error, sizeof(error)) != 0) {
+            log_publish_failure("recording gap", stream_name, error);
+        }
+    }
 }
 
 void metrics_set_recording_active(const char *stream_name, bool active) {
     if (!g_initialized || !stream_name) return;
     int idx = metrics_get_slot(stream_name);
     if (idx < 0) return;
-    atomic_store(&g_metrics[idx].recording_active, active ? 1 : 0);
+    stream_metrics_t *m = &g_metrics[idx];
+    pthread_rwlock_wrlock(&m->lock);
+    int next = active ? 1 : 0;
+    int previous = atomic_load(&m->recording_active);
+    if (previous != next) {
+        /* A deliberate stop/start begins a new continuity session. This keeps
+         * schedules, manual stops, and detection-only clips from becoming
+         * false recording-gap events while preserving gaps between segments
+         * inside one continuously active writer session. */
+        m->last_segment_end_time = 0;
+    }
+    atomic_store(&m->recording_active, next);
+    pthread_rwlock_unlock(&m->lock);
 }
 
 void metrics_set_connection_latency(const char *stream_name, double latency_ms) {

--- a/tests/unit/test_api_handlers_event_routes.c
+++ b/tests/unit/test_api_handlers_event_routes.c
@@ -157,7 +157,7 @@ void tearDown(void) {
 void test_catalog_and_route_crud_are_versioned_and_audited(void) {
     cJSON *json = call(handle_get_event_catalog, HTTP_METHOD_GET,
                        "/api/events/catalog", NULL, NULL, NULL, 200);
-    TEST_ASSERT_EQUAL_INT(4,
+    TEST_ASSERT_EQUAL_INT(8,
         cJSON_GetObjectItemCaseSensitive(json, "count")->valueint);
     cJSON_Delete(json);
 

--- a/tests/unit/test_event_detection_adapter.c
+++ b/tests/unit/test_event_detection_adapter.c
@@ -26,6 +26,7 @@
 #include "database/db_event_outbox.h"
 #include "database/db_streams.h"
 #include "database/db_system_settings.h"
+#include "telemetry/stream_metrics.h"
 #include "unity.h"
 #include "utils/strings.h"
 #include "utils/uuid.h"
@@ -45,6 +46,14 @@ typedef struct {
 static capture_t capture;
 static config_t mqtt_adapter_config;
 
+typedef struct {
+    int calls;
+    char types[8][EVENT_TYPE_MAX];
+    char subjects[8][EVENT_SUBJECT_MAX];
+} operational_capture_t;
+
+static operational_capture_t operational_capture;
+
 static int capture_event(const event_envelope_t *event, void *context) {
     capture_t *result = context;
     result->calls++;
@@ -55,6 +64,18 @@ static int capture_event(const event_envelope_t *event, void *context) {
     return mqtt_event_adapter_decode_detection(
         event, result->stream_name, sizeof(result->stream_name),
         &result->detections);
+}
+
+static int capture_operational_event(const event_envelope_t *event,
+                                     void *context) {
+    operational_capture_t *result = context;
+    if (result->calls >= 8) return -1;
+    safe_strcpy(result->types[result->calls], event->type,
+                sizeof(result->types[result->calls]), 0);
+    safe_strcpy(result->subjects[result->calls], event->subject,
+                sizeof(result->subjects[result->calls]), 0);
+    result->calls++;
+    return 0;
 }
 
 static stream_config_t create_camera(const char *name) {
@@ -141,8 +162,10 @@ static int outbox_topic_count(const char *destination, const char *topic) {
 #endif
 
 void setUp(void) {
+    metrics_shutdown();
     event_bus_shutdown(false);
     event_bus_unsubscribe("capture-detection");
+    event_bus_unsubscribe("capture-operational");
     mqtt_event_adapter_unregister();
     event_identity_shutdown();
     event_router_shutdown();
@@ -156,6 +179,7 @@ void setUp(void) {
                  "WHERE key='event_installation_uuid';",
                  NULL, NULL, NULL);
     memset(&capture, 0, sizeof(capture));
+    memset(&operational_capture, 0, sizeof(operational_capture));
     memset(&mqtt_adapter_config, 0, sizeof(mqtt_adapter_config));
     mqtt_adapter_config.mqtt_enabled = true;
     safe_strcpy(mqtt_adapter_config.mqtt_topic_prefix, "lightnvr",
@@ -163,8 +187,10 @@ void setUp(void) {
 }
 
 void tearDown(void) {
+    metrics_shutdown();
     event_bus_shutdown(false);
     event_bus_unsubscribe("capture-detection");
+    event_bus_unsubscribe("capture-operational");
     mqtt_event_adapter_unregister();
     event_identity_shutdown();
     event_router_shutdown();
@@ -278,6 +304,139 @@ void test_producer_fails_closed_without_identity_or_running_bus(void) {
                 "11111111-1111-4111-8111-111111111111", "camera",
                 &detections, 0, error, sizeof(error)));
     TEST_ASSERT_NOT_NULL(strstr(error, "not running"));
+}
+
+void test_operational_producers_use_registered_schemas_and_stable_subjects(void) {
+    stream_config_t camera = create_camera("Operational Camera");
+    TEST_ASSERT_EQUAL_INT(0, event_identity_init());
+    TEST_ASSERT_EQUAL_INT(
+        0, event_bus_subscribe("capture-operational",
+                               capture_operational_event,
+                               &operational_capture));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_init(0, 0));
+
+    const time_t occurred_at = 1787466600;
+    char error[256] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_camera_offline_for_stream(
+               camera.name, "frame_timeout", 3, occurred_at,
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_camera_recovered_for_stream(
+               camera.name, 15000, occurred_at, error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_stream_degraded_for_stream(
+               camera.name, "low_fps", 7.5, 25.0, occurred_at,
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_stream_recovered_for_stream(
+               camera.name, 24.5, 25.0, occurred_at,
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_recording_gap_for_stream(
+               camera.name, occurred_at - 12, 12000, occurred_at,
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_storage_pressure(
+               "critical", "warning", 94.5, 1073741824,
+               occurred_at, error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_storage_recovered(
+               "critical", 72.0, 3221225472ULL, occurred_at,
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_wait_until_idle(2000));
+
+    TEST_ASSERT_EQUAL_INT(7, operational_capture.calls);
+    const char *expected_types[] = {
+        "io.lightnvr.camera.offline.v1",
+        "io.lightnvr.camera.recovered.v1",
+        "io.lightnvr.stream.degraded.v1",
+        "io.lightnvr.stream.recovered.v1",
+        "io.lightnvr.stream.recording_gap.v1",
+        "io.lightnvr.storage.pressure.v1",
+        "io.lightnvr.storage.recovered.v1",
+    };
+    char camera_subject[EVENT_SUBJECT_MAX];
+    snprintf(camera_subject, sizeof(camera_subject), "camera/%s",
+             camera.camera_uuid);
+    for (int index = 0; index < 7; index++) {
+        TEST_ASSERT_EQUAL_STRING(expected_types[index],
+                                 operational_capture.types[index]);
+        TEST_ASSERT_EQUAL_STRING(index < 5 ? camera_subject : "system/storage",
+                                 operational_capture.subjects[index]);
+    }
+
+    TEST_ASSERT_EQUAL_INT(
+        -1, event_producer_publish_stream_degraded_for_stream(
+                camera.name, "unstable", 1.0, 25.0, occurred_at,
+                error, sizeof(error)));
+    TEST_ASSERT_NOT_NULL(strstr(error, "stream degraded data is invalid"));
+}
+
+void test_operational_event_route_persists_to_outbox(void) {
+#ifdef ENABLE_MQTT
+    stream_config_t camera = create_camera("Offline Route Camera");
+    event_route_t route;
+    memset(&route, 0, sizeof(route));
+    safe_strcpy(route.name, "Offline route", sizeof(route.name), 0);
+    route.enabled = true;
+    safe_strcpy(route.destination_key, EVENT_ROUTE_DEFAULT_DESTINATION,
+                sizeof(route.destination_key), 0);
+    safe_strcpy(route.scope_type, "all", sizeof(route.scope_type), 0);
+    safe_strcpy(route.predicate_json, "{\"version\":1}",
+                sizeof(route.predicate_json), 0);
+    safe_strcpy(route.schedule_json,
+                "{\"version\":1,\"timezone\":\"UTC\",\"windows\":[]}",
+                sizeof(route.schedule_json), 0);
+    safe_strcpy(route.event_types[0], "io.lightnvr.camera.offline.v1",
+                sizeof(route.event_types[0]), 0);
+    route.event_type_count = 1;
+    TEST_ASSERT_EQUAL_INT(DB_EVENT_ROUTE_OK, db_event_route_create(&route));
+
+    TEST_ASSERT_EQUAL_INT(0, event_identity_init());
+    TEST_ASSERT_EQUAL_INT(0,
+                          mqtt_event_adapter_register(&mqtt_adapter_config));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_init(0, 0));
+    char error[256] = {0};
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_camera_offline_for_stream(
+               camera.name, "frame_timeout", 3, time(NULL),
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_wait_until_idle(2000));
+
+    event_outbox_stats_t stats;
+    TEST_ASSERT_EQUAL_INT(
+        0, db_event_outbox_get_stats(MQTT_EVENT_OUTBOX_DESTINATION,
+                                     (int64_t)time(NULL), &stats));
+    TEST_ASSERT_EQUAL_INT64(1, stats.pending_rows);
+#endif
+}
+
+void test_recording_gap_hook_ignores_deliberate_session_boundaries(void) {
+    stream_config_t camera = create_camera("Gap Camera");
+    TEST_ASSERT_EQUAL_INT(0, event_identity_init());
+    TEST_ASSERT_EQUAL_INT(
+        0, event_bus_subscribe("capture-operational",
+                               capture_operational_event,
+                               &operational_capture));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_init(0, 0));
+    TEST_ASSERT_EQUAL_INT(0, metrics_init(8));
+
+    metrics_set_recording_active(camera.name, true);
+    metrics_record_segment_complete(camera.name, 100, 110, 1024);
+    metrics_record_segment_complete(camera.name, 120, 130, 2048);
+    TEST_ASSERT_EQUAL_INT(0, event_bus_wait_until_idle(2000));
+    TEST_ASSERT_EQUAL_INT(1, operational_capture.calls);
+    TEST_ASSERT_EQUAL_STRING("io.lightnvr.stream.recording_gap.v1",
+                             operational_capture.types[0]);
+
+    metrics_set_recording_active(camera.name, false);
+    metrics_set_recording_active(camera.name, true);
+    metrics_record_segment_complete(camera.name, 1000, 1010, 4096);
+    TEST_ASSERT_EQUAL_INT(0, event_bus_wait_until_idle(2000));
+    TEST_ASSERT_EQUAL_INT(1, operational_capture.calls);
+
+    metrics_shutdown();
 }
 
 void test_enabled_routes_gate_the_normalized_outbox(void) {
@@ -435,6 +594,9 @@ int main(void) {
     RUN_TEST(test_installation_identity_is_persisted_across_reinitialization);
     RUN_TEST(test_detection_producer_uses_camera_uuid_and_dispatches_off_thread);
     RUN_TEST(test_producer_fails_closed_without_identity_or_running_bus);
+    RUN_TEST(test_operational_producers_use_registered_schemas_and_stable_subjects);
+    RUN_TEST(test_operational_event_route_persists_to_outbox);
+    RUN_TEST(test_recording_gap_hook_ignores_deliberate_session_boundaries);
     RUN_TEST(test_enabled_routes_gate_the_normalized_outbox);
     RUN_TEST(test_managed_routes_fan_out_with_per_destination_suppression);
     int result = UNITY_END();

--- a/tests/unit/test_event_envelope.c
+++ b/tests/unit/test_event_envelope.c
@@ -44,6 +44,29 @@ static cJSON *camera_offline_fixture(void) {
     return data;
 }
 
+static cJSON *camera_recovered_fixture(void) {
+    cJSON *data = cJSON_CreateObject();
+    cJSON_AddStringToObject(data, "previous_state", "offline");
+    cJSON_AddNumberToObject(data, "downtime_ms", 15000);
+    return data;
+}
+
+static cJSON *stream_degraded_fixture(void) {
+    cJSON *data = cJSON_CreateObject();
+    cJSON_AddStringToObject(data, "reason", "low_fps");
+    cJSON_AddNumberToObject(data, "observed_fps", 7.5);
+    cJSON_AddNumberToObject(data, "expected_fps", 25.0);
+    return data;
+}
+
+static cJSON *stream_recovered_fixture(void) {
+    cJSON *data = cJSON_CreateObject();
+    cJSON_AddStringToObject(data, "previous_state", "degraded");
+    cJSON_AddNumberToObject(data, "observed_fps", 24.5);
+    cJSON_AddNumberToObject(data, "expected_fps", 25.0);
+    return data;
+}
+
 static cJSON *recording_gap_fixture(void) {
     cJSON *data = cJSON_CreateObject();
     cJSON_AddStringToObject(data, "started_at", "2026-08-23T06:30:00Z");
@@ -59,11 +82,19 @@ static cJSON *storage_pressure_fixture(void) {
     return data;
 }
 
+static cJSON *storage_recovered_fixture(void) {
+    cJSON *data = cJSON_CreateObject();
+    cJSON_AddStringToObject(data, "previous_level", "critical");
+    cJSON_AddNumberToObject(data, "used_percent", 72.0);
+    cJSON_AddNumberToObject(data, "free_bytes", 3221225472.0);
+    return data;
+}
+
 void test_registry_is_stable_and_versioned(void) {
     int count = 0;
     const event_type_definition_t *registry = event_registry_all(&count);
     TEST_ASSERT_NOT_NULL(registry);
-    TEST_ASSERT_EQUAL_INT(4, count);
+    TEST_ASSERT_EQUAL_INT(8, count);
     for (int index = 0; index < count; index++) {
         TEST_ASSERT_NOT_NULL(strstr(registry[index].type, "io.lightnvr."));
         size_t length = strlen(registry[index].type);
@@ -95,10 +126,18 @@ void test_required_fixtures_create_and_validate(void) {
          detection_fixture},
         {"io.lightnvr.camera.offline.v1", CAMERA_SUBJECT,
          camera_offline_fixture},
+        {"io.lightnvr.camera.recovered.v1", CAMERA_SUBJECT,
+         camera_recovered_fixture},
+        {"io.lightnvr.stream.degraded.v1", CAMERA_SUBJECT,
+         stream_degraded_fixture},
+        {"io.lightnvr.stream.recovered.v1", CAMERA_SUBJECT,
+         stream_recovered_fixture},
         {"io.lightnvr.stream.recording_gap.v1", CAMERA_SUBJECT,
          recording_gap_fixture},
         {"io.lightnvr.storage.pressure.v1", "system/storage",
          storage_pressure_fixture},
+        {"io.lightnvr.storage.recovered.v1", "system/storage",
+         storage_recovered_fixture},
     };
     for (size_t index = 0; index < sizeof(cases) / sizeof(cases[0]); index++) {
         cJSON *data = cases[index].fixture();


### PR DESCRIPTION
## Summary

- add versioned camera offline/recovered, stream degraded/recovered, recording-gap, and storage pressure/recovered event contracts and producers
- emit health and storage facts only on observed state transitions, asynchronously through the existing route and durable MQTT outbox pipeline
- reset recording continuity at deliberate stop/start boundaries so schedules and manual stops do not create false gap events
- preserve the legacy retained storage-pressure topic while normalized consumers migrate
- reconcile Fleet 03 documentation: P2 is complete and P3 producer expansion is in progress

## Verification

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` — 84/84 passed
- embedded profile configure and `lightnvr` build with `-DLIGHTNVR_PROFILE=embedded -DCMAKE_BUILD_TYPE=Release`
- `git diff --check`