### PR TITLE
feat(events): publish storage target health transitions

### DIFF
--- a/docs/EVENT_CONTRACT.md
+++ b/docs/EVENT_CONTRACT.md
@@ -53,6 +53,8 @@ Every event uses a CloudEvents-inspired JSON envelope:
 | `io.lightnvr.stream.recording_gap.v1` | warning | operational | 7 days | low | reference allowed |
 | `io.lightnvr.storage.pressure.v1` | critical | internal | 7 days | low | forbidden |
 | `io.lightnvr.storage.recovered.v1` | info | internal | 7 days | low | forbidden |
+| `io.lightnvr.storage.target_unavailable.v1` | error | internal | 7 days | low | forbidden |
+| `io.lightnvr.storage.target_recovered.v1` | info | internal | 7 days | low | forbidden |
 
 Expiry is internal delivery metadata and is intentionally not part of the JSON
 payload. MQTT 5 delivery may carry it as a message-expiry property; the durable
@@ -177,6 +179,37 @@ and 100. `free_bytes` is optional.
 `previous_level` is `warning`, `critical`, or `emergency`. The event is emitted
 when the monitored recording filesystem returns to normal pressure.
 
+### `io.lightnvr.storage.target_unavailable.v1`
+
+```json
+{
+  "target_uuid": "33333333-3333-4333-8333-333333333333",
+  "previous_state": "healthy",
+  "reason": "mount_unavailable",
+  "is_default": false
+}
+```
+
+`previous_state` is `unknown`, `healthy`, or `degraded`. `reason` is one of
+`mount_unavailable`, `directory_unavailable`, `capacity_probe_failed`,
+`not_writable`, `write_probe_failed`, `probe_cleanup_failed`, or `unknown`.
+Probe errors and filesystem paths are intentionally normalized away.
+
+### `io.lightnvr.storage.target_recovered.v1`
+
+```json
+{
+  "target_uuid": "33333333-3333-4333-8333-333333333333",
+  "previous_state": "unavailable",
+  "current_state": "healthy",
+  "downtime_ms": 60000,
+  "is_default": false
+}
+```
+
+`current_state` is `healthy` or `degraded`, and `downtime_ms` is the
+non-negative observed interval since the last successful probe.
+
 ## Producer API
 
 The installation source is a UUID generated once and persisted in
@@ -194,11 +227,12 @@ Both normalize and enqueue only; neither performs MQTT, snapshot, or other
 network work on the caller thread.
 
 The same producer module exposes camera offline/recovered, stream
-degraded/recovered, recording-gap, and storage pressure/recovered facts. Stream
-producers resolve the current stream name to its immutable camera UUID. The
-health sampler and storage heartbeat emit only on observed state transitions;
-the recording producer runs only after the segment continuity detector finds a
-gap greater than five seconds.
+degraded/recovered, recording-gap, storage pressure/recovered, and storage-target
+unavailable/recovered facts. Stream producers resolve the current stream name
+to its immutable camera UUID. The health sampler and all operational target
+probe paths emit only on observed state transitions; the recording producer
+runs only after the segment continuity detector finds a gap greater than five
+seconds.
 
 ## Asynchronous in-process bus
 

--- a/docs/prd/FLEET_03_Event_Bus_MQTT_Routes.md
+++ b/docs/prd/FLEET_03_Event_Bus_MQTT_Routes.md
@@ -2,8 +2,10 @@
 
 **Status**: P0/P1/P2 complete; P3 in progress — camera offline/recovered,
 stream degraded/recovered and recording-gap, and storage pressure/recovered
-producers are wired to observed transitions. Target-health, security, ONVIF,
-and media-reference producers remain.
+producers are wired to observed transitions. Storage-target
+unavailable/recovered events are also wired across heartbeat, placement,
+cleanup, and manual-probe paths. Security, ONVIF, and media-reference producers
+remain.
 **Created**: 2026-08-22
 **Owner**: TBD
 **Priority**: 3 — integration foundation
@@ -168,8 +170,8 @@ without changing the durable routing and delivery path.
 ## 8. Acceptance criteria
 
 - Detection, camera offline/recovered, stream degraded/recovered and
-  recording-gap, and storage pressure/recovered fixtures validate against
-  documented schemas.
+  recording-gap, storage pressure/recovered, and storage-target
+  unavailable/recovered fixtures validate against documented schemas.
 - A broker outage during 1,000 generated critical events does not block recording;
   eligible events deliver after reconnection with unchanged IDs.
 - Duplicate delivery is safely recognizable by `source + id`.

--- a/include/core/event_producers.h
+++ b/include/core/event_producers.h
@@ -1,6 +1,7 @@
 #ifndef LIGHTNVR_CORE_EVENT_PRODUCERS_H
 #define LIGHTNVR_CORE_EVENT_PRODUCERS_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <time.h>
@@ -53,5 +54,13 @@ int event_producer_publish_storage_pressure(
 int event_producer_publish_storage_recovered(
     const char *previous_level, double used_percent, uint64_t free_bytes,
     time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_storage_target_unavailable(
+    const char *target_uuid, const char *previous_state, const char *reason,
+    bool is_default, time_t occurred_at, char *error, size_t error_size);
+
+int event_producer_publish_storage_target_recovered(
+    const char *target_uuid, const char *current_state, int64_t downtime_ms,
+    bool is_default, time_t occurred_at, char *error, size_t error_size);
 
 #endif /* LIGHTNVR_CORE_EVENT_PRODUCERS_H */

--- a/include/storage/storage_target_health.h
+++ b/include/storage/storage_target_health.h
@@ -1,0 +1,19 @@
+#ifndef LIGHTNVR_STORAGE_STORAGE_TARGET_HEALTH_H
+#define LIGHTNVR_STORAGE_STORAGE_TARGET_HEALTH_H
+
+#include <stdbool.h>
+
+#include "database/db_storage_targets.h"
+
+/*
+ * Probe a configured target, persist its health, and publish a normalized
+ * event when availability changes. Event delivery failure never changes the
+ * database probe result.
+ */
+db_storage_target_result_t storage_target_probe_and_publish(
+    const char *uuid, bool write_test, storage_target_t *target);
+
+/* Refresh every configured target through the transition-aware probe. */
+int storage_target_refresh_health_and_publish(void);
+
+#endif /* LIGHTNVR_STORAGE_STORAGE_TARGET_HEALTH_H */

--- a/src/core/event_envelope.c
+++ b/src/core/event_envelope.c
@@ -102,6 +102,28 @@ static const event_type_definition_t EVENT_TYPES[] = {
         .subject_kind = EVENT_SUBJECT_STORAGE,
         .default_expiry_seconds = 604800,
     },
+    {
+        .type = "io.lightnvr.storage.target_unavailable.v1",
+        .family = "storage",
+        .description = "A configured storage target became unavailable",
+        .severity = EVENT_SEVERITY_ERROR,
+        .sensitivity = EVENT_SENSITIVITY_INTERNAL,
+        .media_policy = EVENT_MEDIA_FORBIDDEN,
+        .expected_rate = EVENT_RATE_LOW,
+        .subject_kind = EVENT_SUBJECT_STORAGE,
+        .default_expiry_seconds = 604800,
+    },
+    {
+        .type = "io.lightnvr.storage.target_recovered.v1",
+        .family = "storage",
+        .description = "An unavailable storage target became usable again",
+        .severity = EVENT_SEVERITY_INFO,
+        .sensitivity = EVENT_SENSITIVITY_INTERNAL,
+        .media_policy = EVENT_MEDIA_FORBIDDEN,
+        .expected_rate = EVENT_RATE_LOW,
+        .subject_kind = EVENT_SUBJECT_STORAGE,
+        .default_expiry_seconds = 604800,
+    },
 };
 
 static void set_error(char *error, size_t error_size, const char *message) {
@@ -428,6 +450,72 @@ static int validate_type_data(const char *type, const cJSON *data,
         if (!valid_previous || used->valuedouble < 0 ||
             used->valuedouble > 100) {
             set_error(error, error_size, "storage recovered data is invalid");
+            return -1;
+        }
+    } else if (strcmp(
+                   type,
+                   "io.lightnvr.storage.target_unavailable.v1") == 0) {
+        const cJSON *target_uuid = required_field(
+            data, "target_uuid", cJSON_String, error, error_size);
+        const cJSON *previous = required_field(
+            data, "previous_state", cJSON_String, error, error_size);
+        const cJSON *reason = required_field(
+            data, "reason", cJSON_String, error, error_size);
+        const cJSON *is_default = cJSON_GetObjectItemCaseSensitive(
+            data, "is_default");
+        if (!target_uuid || !previous || !reason ||
+            !cJSON_IsBool(is_default)) {
+            if (!is_default || !cJSON_IsBool(is_default)) {
+                set_error(error, error_size,
+                          "event data is missing required field 'is_default'");
+            }
+            return -1;
+        }
+        bool valid_previous = strcmp(previous->valuestring, "unknown") == 0 ||
+            strcmp(previous->valuestring, "healthy") == 0 ||
+            strcmp(previous->valuestring, "degraded") == 0;
+        bool valid_reason = strcmp(reason->valuestring,
+                                   "mount_unavailable") == 0 ||
+            strcmp(reason->valuestring, "directory_unavailable") == 0 ||
+            strcmp(reason->valuestring, "capacity_probe_failed") == 0 ||
+            strcmp(reason->valuestring, "not_writable") == 0 ||
+            strcmp(reason->valuestring, "write_probe_failed") == 0 ||
+            strcmp(reason->valuestring, "probe_cleanup_failed") == 0 ||
+            strcmp(reason->valuestring, "unknown") == 0;
+        if (!lightnvr_uuid_is_valid(target_uuid->valuestring) ||
+            !valid_previous || !valid_reason) {
+            set_error(error, error_size,
+                      "storage target unavailable data is invalid");
+            return -1;
+        }
+    } else if (strcmp(
+                   type,
+                   "io.lightnvr.storage.target_recovered.v1") == 0) {
+        const cJSON *target_uuid = required_field(
+            data, "target_uuid", cJSON_String, error, error_size);
+        const cJSON *previous = required_field(
+            data, "previous_state", cJSON_String, error, error_size);
+        const cJSON *current = required_field(
+            data, "current_state", cJSON_String, error, error_size);
+        const cJSON *downtime = required_field(
+            data, "downtime_ms", cJSON_Number, error, error_size);
+        const cJSON *is_default = cJSON_GetObjectItemCaseSensitive(
+            data, "is_default");
+        if (!target_uuid || !previous || !current || !downtime ||
+            !cJSON_IsBool(is_default)) {
+            if (!is_default || !cJSON_IsBool(is_default)) {
+                set_error(error, error_size,
+                          "event data is missing required field 'is_default'");
+            }
+            return -1;
+        }
+        bool valid_current = strcmp(current->valuestring, "healthy") == 0 ||
+            strcmp(current->valuestring, "degraded") == 0;
+        if (!lightnvr_uuid_is_valid(target_uuid->valuestring) ||
+            strcmp(previous->valuestring, "unavailable") != 0 ||
+            !valid_current || downtime->valuedouble < 0) {
+            set_error(error, error_size,
+                      "storage target recovered data is invalid");
             return -1;
         }
     }

--- a/src/core/event_producers.c
+++ b/src/core/event_producers.c
@@ -24,6 +24,10 @@
 #define RECORDING_GAP_EVENT_TYPE "io.lightnvr.stream.recording_gap.v1"
 #define STORAGE_PRESSURE_EVENT_TYPE "io.lightnvr.storage.pressure.v1"
 #define STORAGE_RECOVERED_EVENT_TYPE "io.lightnvr.storage.recovered.v1"
+#define STORAGE_TARGET_UNAVAILABLE_EVENT_TYPE \
+    "io.lightnvr.storage.target_unavailable.v1"
+#define STORAGE_TARGET_RECOVERED_EVENT_TYPE \
+    "io.lightnvr.storage.target_recovered.v1"
 
 static void set_error(char *error, size_t error_size, const char *message) {
     if (!error || error_size == 0) return;
@@ -98,6 +102,27 @@ static bool valid_pressure_level(const char *level) {
     return level && (strcmp(level, "warning") == 0 ||
                      strcmp(level, "critical") == 0 ||
                      strcmp(level, "emergency") == 0);
+}
+
+static bool valid_storage_target_previous_state(const char *state) {
+    return state && (strcmp(state, "unknown") == 0 ||
+                     strcmp(state, "healthy") == 0 ||
+                     strcmp(state, "degraded") == 0);
+}
+
+static bool valid_storage_target_current_state(const char *state) {
+    return state && (strcmp(state, "healthy") == 0 ||
+                     strcmp(state, "degraded") == 0);
+}
+
+static bool valid_storage_target_reason(const char *reason) {
+    return reason && (strcmp(reason, "mount_unavailable") == 0 ||
+                      strcmp(reason, "directory_unavailable") == 0 ||
+                      strcmp(reason, "capacity_probe_failed") == 0 ||
+                      strcmp(reason, "not_writable") == 0 ||
+                      strcmp(reason, "write_probe_failed") == 0 ||
+                      strcmp(reason, "probe_cleanup_failed") == 0 ||
+                      strcmp(reason, "unknown") == 0);
 }
 
 static bool add_detection_data(cJSON *data, const char *stream_name,
@@ -367,6 +392,63 @@ int event_producer_publish_storage_recovered(
     int result = publish_event(
         STORAGE_RECOVERED_EVENT_TYPE, "system/storage", occurred_at, data,
         error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_storage_target_unavailable(
+    const char *target_uuid, const char *previous_state, const char *reason,
+    bool is_default, time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!lightnvr_uuid_is_valid(target_uuid) ||
+        !valid_storage_target_previous_state(previous_state) ||
+        !valid_storage_target_reason(reason)) {
+        set_error(error, error_size,
+                  "storage target unavailable event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "target_uuid", target_uuid) ||
+        !cJSON_AddStringToObject(data, "previous_state", previous_state) ||
+        !cJSON_AddStringToObject(data, "reason", reason) ||
+        !cJSON_AddBoolToObject(data, "is_default", is_default)) {
+        cJSON_Delete(data);
+        set_error(error, error_size,
+                  "storage target unavailable event allocation failed");
+        return -1;
+    }
+    int result = publish_event(
+        STORAGE_TARGET_UNAVAILABLE_EVENT_TYPE, "system/storage", occurred_at,
+        data, error, error_size);
+    cJSON_Delete(data);
+    return result;
+}
+
+int event_producer_publish_storage_target_recovered(
+    const char *target_uuid, const char *current_state, int64_t downtime_ms,
+    bool is_default, time_t occurred_at, char *error, size_t error_size) {
+    if (error && error_size > 0) error[0] = '\0';
+    if (!lightnvr_uuid_is_valid(target_uuid) ||
+        !valid_storage_target_current_state(current_state) ||
+        downtime_ms < 0) {
+        set_error(error, error_size,
+                  "storage target recovered event input is invalid");
+        return -1;
+    }
+    cJSON *data = cJSON_CreateObject();
+    if (!data || !cJSON_AddStringToObject(data, "target_uuid", target_uuid) ||
+        !cJSON_AddStringToObject(data, "previous_state", "unavailable") ||
+        !cJSON_AddStringToObject(data, "current_state", current_state) ||
+        !cJSON_AddNumberToObject(data, "downtime_ms", (double)downtime_ms) ||
+        !cJSON_AddBoolToObject(data, "is_default", is_default)) {
+        cJSON_Delete(data);
+        set_error(error, error_size,
+                  "storage target recovered event allocation failed");
+        return -1;
+    }
+    int result = publish_event(
+        STORAGE_TARGET_RECOVERED_EVENT_TYPE, "system/storage", occurred_at,
+        data, error, error_size);
     cJSON_Delete(data);
     return result;
 }

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -36,6 +36,7 @@
 #include "video/stream_state_adapter.h"
 #include "storage/storage_manager.h"
 #include "storage/storage_manager_streams_cache.h"
+#include "storage/storage_target_health.h"
 #include "video/streams.h"
 #include "video/hls_streaming.h"
 #include "video/mp4_recording.h"
@@ -771,7 +772,7 @@ int main(int argc, char *argv[]) {
         goto cleanup;
     }
     set_retention_days(config.retention_days);
-    (void)db_storage_target_refresh_health();
+    (void)storage_target_refresh_health_and_publish();
     log_info("Storage manager initialized");
 
     // Start recording sync thread to ensure database file sizes are accurate

--- a/src/storage/storage_manager.c
+++ b/src/storage/storage_manager.c
@@ -13,6 +13,7 @@
 
 #include "storage/storage_manager.h"
 #include "storage/storage_manager_streams_cache.h"
+#include "storage/storage_target_health.h"
 #include "database/db_core.h"
 #include "database/db_auth.h"
 #include "database/db_streams.h"
@@ -219,7 +220,6 @@ int init_storage_manager(const char *storage_path, uint64_t max_size) {
     if (start_storage_manager_thread(3600) != 0) {
         log_warn("Failed to start storage manager thread, automatic tasks will not be performed");
     }
-
     return 0;
 }
 
@@ -1297,7 +1297,7 @@ int storage_cleanup_target_pressure(
     }
 
     storage_target_t target;
-    db_storage_target_result_t probe = db_storage_target_probe(
+    db_storage_target_result_t probe = storage_target_probe_and_publish(
         storage_target_uuid, false, &target);
     if (probe != DB_STORAGE_TARGET_OK || !target.enabled ||
         (target.mount_required &&
@@ -1379,7 +1379,7 @@ int storage_cleanup_target_pressure(
 
     (void)current_free_pct_at(target.root_path, &available, NULL);
     local_result.available_bytes_after = available;
-    (void)db_storage_target_probe(target.uuid, false, NULL);
+    (void)storage_target_probe_and_publish(target.uuid, false, NULL);
     log_info("Target pressure cleanup complete: target=%s, deleted=%d, "
              "freed=%llu MB, remaining=%llu MB",
              target.name, local_result.deleted_recordings,
@@ -1789,7 +1789,7 @@ static void* unified_storage_controller_func(void *arg) {
 
     // Initial heartbeat to establish baseline pressure
     heartbeat_check_disk_pressure();
-    if (db_storage_target_refresh_health() < 0) {
+    if (storage_target_refresh_health_and_publish() < 0) {
         log_warn("Initial storage target health refresh failed");
     }
     cleanup_pressured_targets();
@@ -1827,7 +1827,7 @@ static void* unified_storage_controller_func(void *arg) {
 
         // Always run heartbeat (disk pressure detection)
         heartbeat_check_disk_pressure();
-        if (db_storage_target_refresh_health() < 0) {
+        if (storage_target_refresh_health_and_publish() < 0) {
             log_warn("Storage target health refresh failed");
         }
         cleanup_pressured_targets();

--- a/src/storage/storage_placement.c
+++ b/src/storage/storage_placement.c
@@ -15,6 +15,7 @@
 #include "database/db_fleet_query.h"
 #include "database/db_storage_policies.h"
 #include "database/db_storage_targets.h"
+#include "storage/storage_target_health.h"
 #include "utils/strings.h"
 
 #define PLACEMENT_ASSIGNMENT_TTL_SECONDS 60
@@ -203,12 +204,13 @@ static bool target_is_eligible(const char *uuid, storage_target_t *target) {
         if (!db_storage_target_mount_guard_active(target)) {
             /* Persist the transition once without touching the target path. */
             if (!was_missing) {
-                (void)db_storage_target_probe(uuid, false, target);
+                (void)storage_target_probe_and_publish(
+                    uuid, false, target);
             }
             return false;
         }
         if (was_missing &&
-            db_storage_target_probe(uuid, false, target) !=
+            storage_target_probe_and_publish(uuid, false, target) !=
                 DB_STORAGE_TARGET_OK) {
             return false;
         }

--- a/src/storage/storage_target_health.c
+++ b/src/storage/storage_target_health.c
@@ -1,0 +1,148 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "storage/storage_target_health.h"
+
+#include <limits.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "core/event_producers.h"
+#include "core/logger.h"
+
+static pthread_mutex_t target_probe_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static bool state_is(const storage_target_t *target, const char *state) {
+    return target && strcmp(target->health_status, state) == 0;
+}
+
+static const char *normalized_previous_state(const storage_target_t *target) {
+    if (state_is(target, "healthy")) return "healthy";
+    if (state_is(target, "degraded")) return "degraded";
+    return "unknown";
+}
+
+static const char *normalized_unavailable_reason(const char *error) {
+    if (!error) return "unknown";
+    static const char missing_mount[] = "Required mount is absent:";
+    static const char no_mount[] = "No distinct mounted filesystem";
+    static const char directory[] = "Target directory is unavailable:";
+    static const char capacity[] = "Capacity probe failed:";
+    static const char not_writable[] = "Target directory is not writable:";
+    static const char long_path[] = "Probe path is too long";
+    static const char write_probe[] = "Write probe failed:";
+    static const char cleanup[] = "Probe cleanup failed:";
+
+    if (strncmp(error, missing_mount, sizeof(missing_mount) - 1) == 0 ||
+        strncmp(error, no_mount, sizeof(no_mount) - 1) == 0) {
+        return "mount_unavailable";
+    }
+    if (strncmp(error, directory, sizeof(directory) - 1) == 0) {
+        return "directory_unavailable";
+    }
+    if (strncmp(error, capacity, sizeof(capacity) - 1) == 0) {
+        return "capacity_probe_failed";
+    }
+    if (strncmp(error, not_writable, sizeof(not_writable) - 1) == 0) {
+        return "not_writable";
+    }
+    if (strncmp(error, long_path, sizeof(long_path) - 1) == 0 ||
+        strncmp(error, write_probe, sizeof(write_probe) - 1) == 0) {
+        return "write_probe_failed";
+    }
+    if (strncmp(error, cleanup, sizeof(cleanup) - 1) == 0) {
+        return "probe_cleanup_failed";
+    }
+    return "unknown";
+}
+
+static int64_t downtime_milliseconds(const storage_target_t *before,
+                                     const storage_target_t *after) {
+    if (!before || !after || before->last_success_at <= 0 ||
+        after->last_probe_at <= before->last_success_at) {
+        return 0;
+    }
+    int64_t seconds = after->last_probe_at - before->last_success_at;
+    return seconds > INT64_MAX / 1000 ? INT64_MAX : seconds * 1000;
+}
+
+static void publish_transition(const storage_target_t *before,
+                               const storage_target_t *after) {
+    bool was_unavailable = state_is(before, "unavailable");
+    bool is_unavailable = state_is(after, "unavailable");
+    bool is_recovered = state_is(after, "healthy") ||
+        state_is(after, "degraded");
+    time_t occurred_at = after->last_probe_at > 0
+        ? (time_t)after->last_probe_at : time(NULL);
+    char error[256] = {0};
+    int result = 0;
+
+    if (!was_unavailable && is_unavailable) {
+        result = event_producer_publish_storage_target_unavailable(
+            after->uuid, normalized_previous_state(before),
+            normalized_unavailable_reason(after->last_error),
+            after->is_default, occurred_at, error, sizeof(error));
+    } else if (was_unavailable && is_recovered) {
+        result = event_producer_publish_storage_target_recovered(
+            after->uuid, after->health_status,
+            downtime_milliseconds(before, after), after->is_default,
+            occurred_at, error, sizeof(error));
+    } else {
+        return;
+    }
+
+    if (result != 0) {
+        log_warn("Failed to enqueue storage target transition event for %s: %s",
+                 after->uuid, error[0] ? error : "event pipeline unavailable");
+    }
+}
+
+db_storage_target_result_t storage_target_probe_and_publish(
+    const char *uuid, bool write_test, storage_target_t *target) {
+    storage_target_t before;
+    storage_target_t after;
+    memset(&before, 0, sizeof(before));
+    memset(&after, 0, sizeof(after));
+
+    pthread_mutex_lock(&target_probe_mutex);
+    db_storage_target_result_t result = db_storage_target_get(uuid, &before);
+    if (result == DB_STORAGE_TARGET_OK) {
+        result = db_storage_target_probe(uuid, write_test, &after);
+        if (result == DB_STORAGE_TARGET_OK ||
+            result == DB_STORAGE_TARGET_UNAVAILABLE) {
+            publish_transition(&before, &after);
+            if (target) *target = after;
+        }
+    }
+    pthread_mutex_unlock(&target_probe_mutex);
+    return result;
+}
+
+int storage_target_refresh_health_and_publish(void) {
+    int total = db_storage_target_count();
+    if (total < 0 || total > STORAGE_TARGET_MAX_COUNT) return -1;
+    if (total == 0) return 0;
+
+    storage_target_t *targets = calloc((size_t)total, sizeof(*targets));
+    if (!targets) return -1;
+    int count = db_storage_target_list(targets, total);
+    if (count < 0) {
+        free(targets);
+        return -1;
+    }
+
+    int failures = 0;
+    for (int index = 0; index < count; index++) {
+        db_storage_target_result_t result =
+            storage_target_probe_and_publish(
+                targets[index].uuid, false, NULL);
+        if (result != DB_STORAGE_TARGET_OK &&
+            result != DB_STORAGE_TARGET_UNAVAILABLE) {
+            failures++;
+        }
+    }
+    free(targets);
+    return failures == 0 ? count : -1;
+}

--- a/src/web/api_handlers_storage_targets.c
+++ b/src/web/api_handlers_storage_targets.c
@@ -14,6 +14,7 @@
 #include "core/authorization.h"
 #include "database/db_storage_targets.h"
 #include "storage/storage_manager.h"
+#include "storage/storage_target_health.h"
 #include "utils/strings.h"
 #include "utils/uuid.h"
 #include "web/audit_log.h"
@@ -501,7 +502,7 @@ void handle_post_storage_target_probe(const http_request_t *req,
     storage_target_t target;
     memset(&target, 0, sizeof(target));
     db_storage_target_result_t result =
-        db_storage_target_probe(uuid, true, &target);
+        storage_target_probe_and_publish(uuid, true, &target);
     if (result != DB_STORAGE_TARGET_OK) {
         set_db_error(res, result,
                      target.last_error[0] ? target.last_error : NULL);

--- a/tests/unit/test_event_detection_adapter.c
+++ b/tests/unit/test_event_detection_adapter.c
@@ -6,8 +6,10 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <pthread.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -24,8 +26,10 @@
 #include "database/db_event_destinations.h"
 #include "database/db_event_routes.h"
 #include "database/db_event_outbox.h"
+#include "database/db_storage_targets.h"
 #include "database/db_streams.h"
 #include "database/db_system_settings.h"
+#include "storage/storage_target_health.h"
 #include "telemetry/stream_metrics.h"
 #include "unity.h"
 #include "utils/strings.h"
@@ -48,11 +52,12 @@ static config_t mqtt_adapter_config;
 
 typedef struct {
     int calls;
-    char types[8][EVENT_TYPE_MAX];
-    char subjects[8][EVENT_SUBJECT_MAX];
+    char types[12][EVENT_TYPE_MAX];
+    char subjects[12][EVENT_SUBJECT_MAX];
 } operational_capture_t;
 
 static operational_capture_t operational_capture;
+static char target_test_root[MAX_PATH_LENGTH];
 
 static int capture_event(const event_envelope_t *event, void *context) {
     capture_t *result = context;
@@ -69,7 +74,7 @@ static int capture_event(const event_envelope_t *event, void *context) {
 static int capture_operational_event(const event_envelope_t *event,
                                      void *context) {
     operational_capture_t *result = context;
-    if (result->calls >= 8) return -1;
+    if (result->calls >= 12) return -1;
     safe_strcpy(result->types[result->calls], event->type,
                 sizeof(result->types[result->calls]), 0);
     safe_strcpy(result->subjects[result->calls], event->subject,
@@ -170,6 +175,9 @@ void setUp(void) {
     event_identity_shutdown();
     event_router_shutdown();
     sqlite3 *db = get_db_handle();
+    sqlite3_exec(db, "DELETE FROM storage_policies;", NULL, NULL, NULL);
+    sqlite3_exec(db, "DELETE FROM recordings;", NULL, NULL, NULL);
+    sqlite3_exec(db, "DELETE FROM storage_targets;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM streams;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM event_outbox;", NULL, NULL, NULL);
     sqlite3_exec(db, "DELETE FROM event_routes;", NULL, NULL, NULL);
@@ -180,6 +188,7 @@ void setUp(void) {
                  NULL, NULL, NULL);
     memset(&capture, 0, sizeof(capture));
     memset(&operational_capture, 0, sizeof(operational_capture));
+    target_test_root[0] = '\0';
     memset(&mqtt_adapter_config, 0, sizeof(mqtt_adapter_config));
     mqtt_adapter_config.mqtt_enabled = true;
     safe_strcpy(mqtt_adapter_config.mqtt_topic_prefix, "lightnvr",
@@ -194,6 +203,10 @@ void tearDown(void) {
     mqtt_event_adapter_unregister();
     event_identity_shutdown();
     event_router_shutdown();
+    if (target_test_root[0]) {
+        rmdir(target_test_root);
+        target_test_root[0] = '\0';
+    }
 }
 
 void test_installation_identity_is_persisted_across_reinitialization(void) {
@@ -344,9 +357,18 @@ void test_operational_producers_use_registered_schemas_and_stable_subjects(void)
         0, event_producer_publish_storage_recovered(
                "critical", 72.0, 3221225472ULL, occurred_at,
                error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_storage_target_unavailable(
+               "33333333-3333-4333-8333-333333333333", "healthy",
+               "mount_unavailable", false, occurred_at,
+               error, sizeof(error)));
+    TEST_ASSERT_EQUAL_INT(
+        0, event_producer_publish_storage_target_recovered(
+               "33333333-3333-4333-8333-333333333333", "healthy",
+               60000, false, occurred_at, error, sizeof(error)));
     TEST_ASSERT_EQUAL_INT(0, event_bus_wait_until_idle(2000));
 
-    TEST_ASSERT_EQUAL_INT(7, operational_capture.calls);
+    TEST_ASSERT_EQUAL_INT(9, operational_capture.calls);
     const char *expected_types[] = {
         "io.lightnvr.camera.offline.v1",
         "io.lightnvr.camera.recovered.v1",
@@ -355,11 +377,13 @@ void test_operational_producers_use_registered_schemas_and_stable_subjects(void)
         "io.lightnvr.stream.recording_gap.v1",
         "io.lightnvr.storage.pressure.v1",
         "io.lightnvr.storage.recovered.v1",
+        "io.lightnvr.storage.target_unavailable.v1",
+        "io.lightnvr.storage.target_recovered.v1",
     };
     char camera_subject[EVENT_SUBJECT_MAX];
     snprintf(camera_subject, sizeof(camera_subject), "camera/%s",
              camera.camera_uuid);
-    for (int index = 0; index < 7; index++) {
+    for (int index = 0; index < 9; index++) {
         TEST_ASSERT_EQUAL_STRING(expected_types[index],
                                  operational_capture.types[index]);
         TEST_ASSERT_EQUAL_STRING(index < 5 ? camera_subject : "system/storage",
@@ -371,6 +395,74 @@ void test_operational_producers_use_registered_schemas_and_stable_subjects(void)
                 camera.name, "unstable", 1.0, 25.0, occurred_at,
                 error, sizeof(error)));
     TEST_ASSERT_NOT_NULL(strstr(error, "stream degraded data is invalid"));
+
+    TEST_ASSERT_EQUAL_INT(
+        -1, event_producer_publish_storage_target_unavailable(
+                "33333333-3333-4333-8333-333333333333", "healthy",
+                "raw_probe_error", false, occurred_at,
+                error, sizeof(error)));
+    TEST_ASSERT_NOT_NULL(strstr(error, "event input is invalid"));
+}
+
+void test_storage_target_health_emits_only_availability_transitions(void) {
+    char root_template[] = "/tmp/lightnvr-event-target-XXXXXX";
+    char *created_root = mkdtemp(root_template);
+    TEST_ASSERT_NOT_NULL(created_root);
+    safe_strcpy(target_test_root, created_root, sizeof(target_test_root), 0);
+
+    storage_target_t target;
+    memset(&target, 0, sizeof(target));
+    safe_strcpy(target.name, "Event target", sizeof(target.name), 0);
+    safe_strcpy(target.target_type, "filesystem",
+                sizeof(target.target_type), 0);
+    safe_strcpy(target.root_path, target_test_root,
+                sizeof(target.root_path), 0);
+    safe_strcpy(target.storage_class, "hot",
+                sizeof(target.storage_class), 0);
+    target.enabled = true;
+    target.high_watermark_pct = 99.0;
+    target.low_watermark_pct = 98.0;
+    TEST_ASSERT_EQUAL_INT(DB_STORAGE_TARGET_OK,
+                          db_storage_target_create(&target));
+
+    TEST_ASSERT_EQUAL_INT(0, event_identity_init());
+    TEST_ASSERT_EQUAL_INT(
+        0, event_bus_subscribe("capture-operational",
+                               capture_operational_event,
+                               &operational_capture));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_init(0, 0));
+
+    TEST_ASSERT_EQUAL_INT(
+        DB_STORAGE_TARGET_OK,
+        storage_target_probe_and_publish(target.uuid, false, NULL));
+    TEST_ASSERT_EQUAL_INT(0, rmdir(target_test_root));
+    TEST_ASSERT_EQUAL_INT(
+        DB_STORAGE_TARGET_UNAVAILABLE,
+        storage_target_probe_and_publish(target.uuid, false, NULL));
+    TEST_ASSERT_EQUAL_INT(
+        DB_STORAGE_TARGET_UNAVAILABLE,
+        storage_target_probe_and_publish(target.uuid, false, NULL));
+
+    TEST_ASSERT_EQUAL_INT(0, mkdir(target_test_root, 0700));
+    TEST_ASSERT_EQUAL_INT(
+        DB_STORAGE_TARGET_OK,
+        storage_target_probe_and_publish(target.uuid, false, NULL));
+    TEST_ASSERT_EQUAL_INT(
+        DB_STORAGE_TARGET_OK,
+        storage_target_probe_and_publish(target.uuid, false, NULL));
+    TEST_ASSERT_EQUAL_INT(0, event_bus_wait_until_idle(2000));
+
+    TEST_ASSERT_EQUAL_INT(2, operational_capture.calls);
+    TEST_ASSERT_EQUAL_STRING(
+        "io.lightnvr.storage.target_unavailable.v1",
+        operational_capture.types[0]);
+    TEST_ASSERT_EQUAL_STRING(
+        "io.lightnvr.storage.target_recovered.v1",
+        operational_capture.types[1]);
+    TEST_ASSERT_EQUAL_STRING("system/storage",
+                             operational_capture.subjects[0]);
+    TEST_ASSERT_EQUAL_STRING("system/storage",
+                             operational_capture.subjects[1]);
 }
 
 void test_operational_event_route_persists_to_outbox(void) {
@@ -595,6 +687,7 @@ int main(void) {
     RUN_TEST(test_detection_producer_uses_camera_uuid_and_dispatches_off_thread);
     RUN_TEST(test_producer_fails_closed_without_identity_or_running_bus);
     RUN_TEST(test_operational_producers_use_registered_schemas_and_stable_subjects);
+    RUN_TEST(test_storage_target_health_emits_only_availability_transitions);
     RUN_TEST(test_operational_event_route_persists_to_outbox);
     RUN_TEST(test_recording_gap_hook_ignores_deliberate_session_boundaries);
     RUN_TEST(test_enabled_routes_gate_the_normalized_outbox);

--- a/tests/unit/test_event_envelope.c
+++ b/tests/unit/test_event_envelope.c
@@ -3,6 +3,7 @@
  * @brief Versioned event registry, envelope, schema, and privacy tests.
  */
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -90,11 +91,32 @@ static cJSON *storage_recovered_fixture(void) {
     return data;
 }
 
+static cJSON *storage_target_unavailable_fixture(void) {
+    cJSON *data = cJSON_CreateObject();
+    cJSON_AddStringToObject(data, "target_uuid",
+                            "33333333-3333-4333-8333-333333333333");
+    cJSON_AddStringToObject(data, "previous_state", "healthy");
+    cJSON_AddStringToObject(data, "reason", "mount_unavailable");
+    cJSON_AddBoolToObject(data, "is_default", false);
+    return data;
+}
+
+static cJSON *storage_target_recovered_fixture(void) {
+    cJSON *data = cJSON_CreateObject();
+    cJSON_AddStringToObject(data, "target_uuid",
+                            "33333333-3333-4333-8333-333333333333");
+    cJSON_AddStringToObject(data, "previous_state", "unavailable");
+    cJSON_AddStringToObject(data, "current_state", "healthy");
+    cJSON_AddNumberToObject(data, "downtime_ms", 60000);
+    cJSON_AddBoolToObject(data, "is_default", false);
+    return data;
+}
+
 void test_registry_is_stable_and_versioned(void) {
     int count = 0;
     const event_type_definition_t *registry = event_registry_all(&count);
     TEST_ASSERT_NOT_NULL(registry);
-    TEST_ASSERT_EQUAL_INT(8, count);
+    TEST_ASSERT_EQUAL_INT(10, count);
     for (int index = 0; index < count; index++) {
         TEST_ASSERT_NOT_NULL(strstr(registry[index].type, "io.lightnvr."));
         size_t length = strlen(registry[index].type);
@@ -138,6 +160,10 @@ void test_required_fixtures_create_and_validate(void) {
          storage_pressure_fixture},
         {"io.lightnvr.storage.recovered.v1", "system/storage",
          storage_recovered_fixture},
+        {"io.lightnvr.storage.target_unavailable.v1", "system/storage",
+         storage_target_unavailable_fixture},
+        {"io.lightnvr.storage.target_recovered.v1", "system/storage",
+         storage_target_recovered_fixture},
     };
     for (size_t index = 0; index < sizeof(cases) / sizeof(cases[0]); index++) {
         cJSON *data = cases[index].fixture();


### PR DESCRIPTION
## Stack

1 of 5. Base: `main`.

Next: `prd-slices/fleet04-saved-views-health-queues`.

## Summary

- emit storage-target unavailable and recovered events from observed health transitions
- cover startup refresh, heartbeat, placement, cleanup, and manual probes
- extend the event contract and reconcile Fleet03 P3 status

## Test plan

- `test_event_envelope` — 7 passed
- `test_event_detection_adapter` — 9 passed
- `test_api_handlers_storage_targets` — 3 passed
- independent `lightnvr` build