### PR TITLE
fix(live): hide health overlay with stream labels

### DIFF
--- a/web/js/components/preact/HLSVideoCell.jsx
+++ b/web/js/components/preact/HLSVideoCell.jsx
@@ -766,7 +766,13 @@ export function HLSVideoCell({
         }}
       />
 
-      <LiveTileStatus stream={stream} isPlaying={isPlaying} isLoading={isLoading} error={error} />
+      <LiveTileStatus
+        stream={stream}
+        isPlaying={isPlaying}
+        isLoading={isLoading}
+        error={error}
+        showLabels={showLabels}
+      />
 
       <MobileTileContextMenu gestures={mobileGestures} audioEnabled={audioEnabled} />
 

--- a/web/js/components/preact/LiveTileStatus.jsx
+++ b/web/js/components/preact/LiveTileStatus.jsx
@@ -1,5 +1,9 @@
 import { useI18n } from '../../i18n.js';
-import { healthStateForStream, recordingModesForStream } from './liveTileStatus.js';
+import {
+  healthStateForStream,
+  recordingModesForStream,
+  shouldShowLiveTileStatus,
+} from './liveTileStatus.js';
 
 function RecordingGlyph({ modes }) {
   const hasConstant = modes.includes('constant');
@@ -58,8 +62,11 @@ function HealthGlyph({ state }) {
   );
 }
 
-export function LiveTileStatus({ stream, isPlaying, isLoading, error }) {
+export function LiveTileStatus({ stream, isPlaying, isLoading, error, showLabels = true }) {
   const { t } = useI18n();
+
+  if (!shouldShowLiveTileStatus(showLabels)) return null;
+
   const modes = recordingModesForStream(stream);
   const health = healthStateForStream(stream, { isPlaying, isLoading, error });
   const recordingLabel = modes.length > 0

--- a/web/js/components/preact/MSEVideoCell.jsx
+++ b/web/js/components/preact/MSEVideoCell.jsx
@@ -747,7 +747,13 @@ export function MSEVideoCell({
         }}
       />
 
-      <LiveTileStatus stream={stream} isPlaying={isPlaying} isLoading={isLoading} error={error} />
+      <LiveTileStatus
+        stream={stream}
+        isPlaying={isPlaying}
+        isLoading={isLoading}
+        error={error}
+        showLabels={showLabels}
+      />
 
       <MobileTileContextMenu gestures={mobileGestures} audioEnabled={audioEnabled} />
 

--- a/web/js/components/preact/WebRTCVideoCell.jsx
+++ b/web/js/components/preact/WebRTCVideoCell.jsx
@@ -1401,7 +1401,13 @@ export function WebRTCVideoCell({
         }}
       />
 
-      <LiveTileStatus stream={stream} isPlaying={isPlaying} isLoading={isLoading} error={error} />
+      <LiveTileStatus
+        stream={stream}
+        isPlaying={isPlaying}
+        isLoading={isLoading}
+        error={error}
+        showLabels={showLabels}
+      />
 
       <MobileTileContextMenu gestures={mobileGestures} audioEnabled={audioEnabled} />
 

--- a/web/js/components/preact/liveTileStatus.js
+++ b/web/js/components/preact/liveTileStatus.js
@@ -6,6 +6,10 @@ export function recordingModesForStream(stream = {}) {
   return modes;
 }
 
+export function shouldShowLiveTileStatus(showLabels = true) {
+  return showLabels !== false;
+}
+
 export function healthStateForStream(stream = {}, playback = {}) {
   const status = String(stream.status || stream.state || '').toLowerCase();
   if (playback.error || ['error', 'failed', 'stopped', 'offline'].includes(status)) {

--- a/web/tests/liveTileStatus.spec.js
+++ b/web/tests/liveTileStatus.spec.js
@@ -1,4 +1,8 @@
-import { healthStateForStream, recordingModesForStream } from '../js/components/preact/liveTileStatus.js';
+import {
+  healthStateForStream,
+  recordingModesForStream,
+  shouldShowLiveTileStatus,
+} from '../js/components/preact/liveTileStatus.js';
 
 describe('live tile status helpers', () => {
   test('preserves every recording mode in display order', () => {
@@ -13,5 +17,11 @@ describe('live tile status helpers', () => {
     expect(healthStateForStream({ status: 'Running' }, { isPlaying: true })).toBe('healthy');
     expect(healthStateForStream({ status: 'Reconnecting' }, { isLoading: true })).toBe('degraded');
     expect(healthStateForStream({ status: 'Running' }, { error: 'no frames' })).toBe('offline');
+  });
+
+  test('follows the stream-label visibility preference', () => {
+    expect(shouldShowLiveTileStatus()).toBe(true);
+    expect(shouldShowLiveTileStatus(true)).toBe(true);
+    expect(shouldShowLiveTileStatus(false)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- make the live health overlay follow the existing Show stream labels preference
- pass label visibility through each live playback renderer
- cover the hidden-label behavior in the live tile status tests

## Validation

- npm test -- --runInBand
- npm run build