### PR TITLE
fix(live): avoid fallback for offline sources

### DIFF
--- a/web/js/components/preact/PlaybackTransportCell.jsx
+++ b/web/js/components/preact/PlaybackTransportCell.jsx
@@ -6,6 +6,7 @@ import { useI18n } from '../../i18n.js';
 import {
   buildPlaybackTransportPlan,
   isPlaybackFallback,
+  shouldFallbackPlaybackTransport,
 } from '../../utils/playback-transport.js';
 
 const CELLS = {
@@ -47,11 +48,16 @@ export function PlaybackTransportCell({
 
   const activeTransport = plan.available[transportIndex];
   const hasRuntimeFallback = transportIndex + 1 < plan.available.length;
-  const handleTransportFailure = useCallback(() => {
-    if (hasRuntimeFallback) {
+  const sourceUnavailableMessage = t('live.cannotConnectToSource');
+  const handleTransportFailure = useCallback((failure) => {
+    if (hasRuntimeFallback && shouldFallbackPlaybackTransport(failure, {
+      streamStatus: stream?.status || stream?.state,
+      sourceUnavailableMessage,
+    })) {
       setTransportIndex((current) => Math.min(current + 1, plan.available.length - 1));
     }
-  }, [hasRuntimeFallback, plan.available.length]);
+  }, [hasRuntimeFallback, plan.available.length, sourceUnavailableMessage,
+    stream?.status, stream?.state]);
 
   if (!activeTransport) {
     const unavailable = plan.unavailable[0] || plan.requested[0];

--- a/web/js/utils/playback-transport.js
+++ b/web/js/utils/playback-transport.js
@@ -38,3 +38,27 @@ export function isPlaybackFallback(plan, activeTransport, runtimeFallbackIndex =
   if (runtimeFallbackIndex > 0) return true;
   return plan.profile !== 'auto' && plan.requested.indexOf(activeTransport) > 0;
 }
+
+const SOURCE_UNAVAILABLE_PATTERN = /(?:dial tcp|no route to host|host is unreachable|network is unreachable|connection refused|connect:|i\/o timeout)/i;
+const TERMINAL_STREAM_STATUSES = new Set(['error', 'failed', 'stopped', 'offline']);
+
+/**
+ * Runtime transport fallback is useful for browser/codec/transport failures,
+ * but cannot recover a camera source that is itself offline. In that case the
+ * active player should retain its normal backoff retry instead of probing each
+ * renderer in the transport chain.
+ */
+export function shouldFallbackPlaybackTransport(
+  failure,
+  { streamStatus, sourceUnavailableMessage } = {}
+) {
+  const status = String(streamStatus || '').trim().toLowerCase();
+  if (TERMINAL_STREAM_STATUSES.has(status)) return false;
+
+  if (failure?.kind === 'source-unavailable') return false;
+
+  const message = String(failure?.message || failure || '').trim();
+  if (!message) return false;
+  if (sourceUnavailableMessage && message === sourceUnavailableMessage) return false;
+  return !SOURCE_UNAVAILABLE_PATTERN.test(message);
+}

--- a/web/tests/playbackTransport.spec.js
+++ b/web/tests/playbackTransport.spec.js
@@ -2,6 +2,7 @@ import {
   buildPlaybackTransportPlan,
   isPlaybackFallback,
   normalizePlaybackTransport,
+  shouldFallbackPlaybackTransport,
 } from '../js/utils/playback-transport.js';
 
 describe('per-stream playback transport', () => {
@@ -42,5 +43,37 @@ describe('per-stream playback transport', () => {
       .toEqual(['mse', 'hls']);
     expect(buildPlaybackTransportPlan('auto', all, 'hls').available)
       .toEqual(['hls']);
+  });
+
+  test('does not change transports when the camera source is unavailable', () => {
+    const options = {
+      streamStatus: 'Running',
+      sourceUnavailableMessage: 'Cannot connect to camera source',
+    };
+
+    expect(shouldFallbackPlaybackTransport('Cannot connect to camera source', options))
+      .toBe(false);
+    expect(shouldFallbackPlaybackTransport(
+      'streams: dial tcp 192.0.2.10:554: connect: no route to host',
+      options
+    )).toBe(false);
+    expect(shouldFallbackPlaybackTransport(
+      { kind: 'source-unavailable', message: 'camera unavailable' },
+      options
+    )).toBe(false);
+  });
+
+  test('does not change transports for a stream already in a terminal state', () => {
+    expect(shouldFallbackPlaybackTransport('WebSocket error', { streamStatus: 'Error' }))
+      .toBe(false);
+    expect(shouldFallbackPlaybackTransport('WebSocket error', { streamStatus: 'Stopped' }))
+      .toBe(false);
+  });
+
+  test('still falls back for a transport-specific runtime failure', () => {
+    expect(shouldFallbackPlaybackTransport('Unsupported WebRTC codec', {
+      streamStatus: 'Running',
+      sourceUnavailableMessage: 'Cannot connect to camera source',
+    })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- keep the selected playback transport when the camera source itself is unavailable
- distinguish source/network failures from browser or codec failures
- preserve runtime MSE/HLS/WebRTC fallback for genuine transport failures

## Stack

Depends on #559. Repoint this PR to main after #559 merges.

## Validation

- npm test -- --runInBand
- npm run build