### PR TITLE
fix(live): enforce explicit transport modes

### DIFF
--- a/docs/prd/UXD_02_LiveViewErgonomics.md
+++ b/docs/prd/UXD_02_LiveViewErgonomics.md
@@ -52,6 +52,9 @@ Add a new field to `stream_config_t` (and `db_streams`) and a UI control on the 
 - **`playback_transport`** enum: `auto` (default), `webrtc_only`, `mse_only`, `hls_only`, `webrtc_then_mse`, `mse_then_hls`.
 - **`auto`** behavior matches today's: try WebRTC if globally enabled, else MSE, else HLS.
 - The Live View tile reads the per-stream value and only attempts the listed transports in order, surfacing a "fallback used" badge when it had to drop down.
+- The default **Auto** viewer honors those per-stream chains. Selecting the
+  WebRTC, HLS, or MSE viewer tab is an operator override that forces every tile
+  to that one transport; it does not silently substitute another renderer.
 
 UI:
 - Stream edit modal grows a "Playback transport" select, default Auto.

--- a/web/js/components/preact/LiveView.jsx
+++ b/web/js/components/preact/LiveView.jsx
@@ -13,7 +13,7 @@ import { isGo2rtcEnabled } from '../../utils/settings-utils.js';
 import { useCameraOrder } from './useCameraOrder.js';
 import { GridPicker, computeOptimalGrid, MAX_GRID_CELLS } from './GridPicker.jsx';
 import { useI18n } from '../../i18n.js';
-import { buildLiveViewHref } from '../../utils/live-view-url.js';
+import { buildLiveViewHref, resolveForcedLiveTransport } from '../../utils/live-view-url.js';
 import { useCollectionMembership } from './fleet/collectionMembership.js';
 import { AlwaysFullscreenToggle } from './AlwaysFullscreenToggle.jsx';
 import { useAlwaysFullscreenOnTap } from './useAlwaysFullscreenOnTap.js';
@@ -41,6 +41,10 @@ function legacyLayoutToColsRowsHLS(layout) {
  */
 export function LiveView({isWebRTCDisabled, isHlsDisabled = false, isMseDisabled = false}) {
   const { t } = useI18n();
+  const forcedTransport = resolveForcedLiveTransport(
+    window.location.pathname,
+    window.location.search
+  );
   const [alwaysFullscreenOnTap, setAlwaysFullscreenOnTap] = useAlwaysFullscreenOnTap();
   // Use the snapshot manager hook
   useSnapshotManager();
@@ -97,16 +101,6 @@ export function LiveView({isWebRTCDisabled, isHlsDisabled = false, isMseDisabled
 
   // State for go2rtc availability
   const [go2rtcAvailable, setGo2rtcAvailable] = useState(false);
-
-  // State for go2rtc mode - determines whether to use MSE or HLS.
-  // Initialize from URL param, but if HLS is disabled via settings (#397)
-  // force MSE as the initial mode so the page has something to render.
-  const [useMSE, setUseMSE] = useState(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('mode') === 'mse') return true;
-    if (isHlsDisabled && !isMseDisabled) return true;
-    return false;
-  });
 
   // Initialize cols/rows from URL params, shared localStorage key, or legacy per-view keys.
   // All live views (WebRTC / HLS / MSE) share 'lightnvr-live-cols' / 'lightnvr-live-rows'
@@ -207,15 +201,9 @@ export function LiveView({isWebRTCDisabled, isHlsDisabled = false, isMseDisabled
         const go2rtcEnabled = await isGo2rtcEnabled();
         console.log(`[LiveView] go2rtc enabled: ${go2rtcEnabled}`);
         setGo2rtcAvailable(go2rtcEnabled);
-        // If user requested MSE via URL but go2rtc is not enabled, fall back to HLS
-        if (useMSE && !go2rtcEnabled) {
-          console.log('[LiveView] MSE requested but go2rtc not enabled, falling back to HLS');
-          setUseMSE(false);
-        }
       } catch (error) {
         console.error('[LiveView] Error checking go2rtc status:', error);
         setGo2rtcAvailable(false);
-        setUseMSE(false);
       }
     };
     checkGo2rtcMode();
@@ -578,49 +566,65 @@ export function LiveView({isWebRTCDisabled, isHlsDisabled = false, isMseDisabled
       />
 
       <div className="page-header flex justify-between items-center mb-4 p-4 bg-card text-card-foreground rounded-lg shadow" style={{ position: 'relative', zIndex: 10, pointerEvents: 'auto' }}>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <h2 className="text-xl font-bold whitespace-nowrap">{t('live.liveView')}</h2>
-          {/* View-mode tab strip: WebRTC | HLS | MSE — each tab only
-              renders if the corresponding method is enabled in settings
+          {/* Auto honors per-stream precedence; explicit modes force every
+              tile. Each transport only renders if enabled in settings
               (#397). MSE additionally requires go2rtc to be reachable. */}
           <div className="inline-flex items-center bg-muted rounded-lg p-1 gap-1" style={{ position: 'relative', zIndex: 50 }}>
-            {!isWebRTCDisabled && (
+            {forcedTransport === null ? (
+              <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                Auto
+              </span>
+            ) : (
               <a
                 href={buildLiveViewHref('/index.html', window.location.search)}
                 className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
               >
-                WebRTC
+                Auto
               </a>
             )}
+            {!isWebRTCDisabled && (
+              forcedTransport === 'webrtc' ? (
+                <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                  WebRTC
+                </span>
+              ) : (
+                <a
+                  href={buildLiveViewHref('/index.html', window.location.search, 'webrtc')}
+                  className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+                >
+                  WebRTC
+                </a>
+              )
+            )}
             {!isHlsDisabled && (
-              <button
-                className={`px-3 py-1.5 rounded text-sm font-medium transition-colors focus:outline-none ${!useMSE ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-background hover:text-foreground'}`}
-                onClick={() => {
-                  if (useMSE) {
-                    setUseMSE(false);
-                    const url = new URL(window.location);
-                    url.searchParams.delete('mode');
-                    window.history.replaceState({}, '', url);
-                  }
-                }}
-              >
-                {t('live.hlsShort')}
-              </button>
+              forcedTransport === 'hls' ? (
+                <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                  {t('live.hlsShort')}
+                </span>
+              ) : (
+                <a
+                  href={buildLiveViewHref('/hls.html', window.location.search)}
+                  className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+                >
+                  {t('live.hlsShort')}
+                </a>
+              )
             )}
             {!isMseDisabled && go2rtcAvailable && (
-              <button
-                className={`px-3 py-1.5 rounded text-sm font-medium transition-colors focus:outline-none ${useMSE ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-background hover:text-foreground'}`}
-                onClick={() => {
-                  if (!useMSE) {
-                    setUseMSE(true);
-                    const url = new URL(window.location);
-                    url.searchParams.set('mode', 'mse');
-                    window.history.replaceState({}, '', url);
-                  }
-                }}
-              >
-                {t('live.mseShort')}
-              </button>
+              forcedTransport === 'mse' ? (
+                <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                  {t('live.mseShort')}
+                </span>
+              ) : (
+                <a
+                  href={buildLiveViewHref('/hls.html', window.location.search, 'mse')}
+                  className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+                >
+                  {t('live.mseShort')}
+                </a>
+              )
             )}
           </div>
         </div>
@@ -898,7 +902,8 @@ export function LiveView({isWebRTCDisabled, isHlsDisabled = false, isMseDisabled
                       mse: !isMseDisabled,
                       hls: !isHlsDisabled,
                     }}
-                    defaultTransport={useMSE ? 'mse' : 'hls'}
+                    defaultTransport="webrtc"
+                    forcedTransport={forcedTransport}
                     useSubStream={!isSingleStream && fullscreenCellStream !== stream.name && (stream.has_sub_stream || !!stream.sub_stream_url)}
                     onToggleFullscreen={toggleStreamFullscreen}
                     streamId={stream.name}

--- a/web/js/components/preact/PlaybackTransportCell.jsx
+++ b/web/js/components/preact/PlaybackTransportCell.jsx
@@ -26,6 +26,7 @@ export function PlaybackTransportCell({
   stream,
   offerings,
   defaultTransport = 'webrtc',
+  forcedTransport = null,
   fullscreenUpgraded = false,
   ...cellProps
 }) {
@@ -34,17 +35,18 @@ export function PlaybackTransportCell({
     () => buildPlaybackTransportPlan(
       stream?.playback_transport,
       offerings,
-      defaultTransport
+      defaultTransport,
+      forcedTransport
     ),
     [stream?.playback_transport, offerings?.webrtc, offerings?.mse,
-      offerings?.hls, defaultTransport]
+      offerings?.hls, defaultTransport, forcedTransport]
   );
   const [transportIndex, setTransportIndex] = useState(0);
 
   useEffect(() => {
     setTransportIndex(0);
   }, [stream?.name, stream?.playback_transport, offerings?.webrtc,
-    offerings?.mse, offerings?.hls, defaultTransport]);
+    offerings?.mse, offerings?.hls, defaultTransport, forcedTransport]);
 
   const activeTransport = plan.available[transportIndex];
   const hasRuntimeFallback = transportIndex + 1 < plan.available.length;

--- a/web/js/components/preact/WebRTCView.jsx
+++ b/web/js/components/preact/WebRTCView.jsx
@@ -14,7 +14,7 @@ import { isGo2rtcEnabled } from '../../utils/settings-utils.js';
 import { useCameraOrder } from './useCameraOrder.js';
 import { GridPicker, computeOptimalGrid, MAX_GRID_CELLS } from './GridPicker.jsx';
 import { useI18n } from '../../i18n.js';
-import { buildLiveViewHref } from '../../utils/live-view-url.js';
+import { buildLiveViewHref, resolveForcedLiveTransport } from '../../utils/live-view-url.js';
 import { useCollectionMembership } from './fleet/collectionMembership.js';
 import { AlwaysFullscreenToggle } from './AlwaysFullscreenToggle.jsx';
 import { useAlwaysFullscreenOnTap } from './useAlwaysFullscreenOnTap.js';
@@ -42,6 +42,10 @@ function legacyLayoutToColsRowsWebRTC(layout) {
  */
 export function WebRTCView({ isWebRTCDisabled, isHlsDisabled, isMseDisabled }) {
   const { t } = useI18n();
+  const forcedTransport = resolveForcedLiveTransport(
+    window.location.pathname,
+    window.location.search
+  );
   const [alwaysFullscreenOnTap, setAlwaysFullscreenOnTap] = useAlwaysFullscreenOnTap();
 
   // Use the snapshot manager hook
@@ -579,32 +583,66 @@ export function WebRTCView({ isWebRTCDisabled, isHlsDisabled, isMseDisabled }) {
       />
 
       <div className="page-header flex justify-between items-center mb-4 p-4 bg-card text-card-foreground rounded-lg shadow" style={{ position: 'relative', zIndex: 10, pointerEvents: 'auto' }}>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <h2 className="text-xl font-bold whitespace-nowrap">{t('live.liveView')}</h2>
-          {/* View-mode tab strip: WebRTC | HLS | MSE */}
+          {/* Auto honors per-stream precedence; explicit modes force every tile. */}
           <div className="inline-flex items-center bg-muted rounded-lg p-1 gap-1" style={{ position: 'relative', zIndex: 50 }}>
-            <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
-              WebRTC
-            </span>
+            {forcedTransport === null ? (
+              <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                Auto
+              </span>
+            ) : (
+              <a
+                href={buildLiveViewHref('/index.html', window.location.search)}
+                className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+              >
+                Auto
+              </a>
+            )}
+
+            {forcedTransport === 'webrtc' ? (
+              <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                WebRTC
+              </span>
+            ) : (
+              <a
+                href={buildLiveViewHref('/index.html', window.location.search, 'webrtc')}
+                className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+              >
+                WebRTC
+              </a>
+            )}
 
             {/* Tab HLS */}
             {!isHlsDisabled && (
-              <a
-                href={buildLiveViewHref('/hls.html', window.location.search)}
-                className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
-              >
-                {t('live.hlsShort')}
-              </a>
+              forcedTransport === 'hls' ? (
+                <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                  {t('live.hlsShort')}
+                </span>
+              ) : (
+                <a
+                  href={buildLiveViewHref('/hls.html', window.location.search)}
+                  className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+                >
+                  {t('live.hlsShort')}
+                </a>
+              )
             )}
-    
+
             {/* Tab MSE */}
             {go2rtcAvailable && !isMseDisabled && (
-              <a
-                href={buildLiveViewHref('/hls.html', window.location.search, 'mse')}
-                className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
-              >
-                {t('live.mseShort')}
-              </a>
+              forcedTransport === 'mse' ? (
+                <span className="px-3 py-1.5 rounded text-sm font-medium bg-primary text-primary-foreground select-none">
+                  {t('live.mseShort')}
+                </span>
+              ) : (
+                <a
+                  href={buildLiveViewHref('/hls.html', window.location.search, 'mse')}
+                  className="px-3 py-1.5 rounded text-sm font-medium transition-colors no-underline text-muted-foreground hover:bg-background hover:text-foreground focus:outline-none"
+                >
+                  {t('live.mseShort')}
+                </a>
+              )
             )}
           </div>
         </div>
@@ -882,6 +920,7 @@ export function WebRTCView({ isWebRTCDisabled, isHlsDisabled, isMseDisabled }) {
                       hls: !isHlsDisabled,
                     }}
                     defaultTransport="webrtc"
+                    forcedTransport={forcedTransport}
                     useSubStream={!isSingleStream && fullscreenCellStream !== stream.name && (stream.has_sub_stream || !!stream.sub_stream_url)}
                     fullscreenUpgraded={!isSingleStream && fullscreenCellStream === stream.name && (stream.has_sub_stream || !!stream.sub_stream_url)}
                     onToggleFullscreen={toggleStreamFullscreen}

--- a/web/js/pages/index-page.jsx
+++ b/web/js/pages/index-page.jsx
@@ -79,11 +79,7 @@ function App() {
     // HLS / MSE remain. The LiveView component itself handles HLS↔MSE
     // tab switching and will hide tabs for disabled methods. #397
     const useWebRTC = !viewFlags.webrtcDisabled;
-    if (!useWebRTC) {
-        document.title = 'HLS View - LightNVR';
-    } else {
-        document.title = 'Live View - LightNVR';
-    }
+    document.title = 'Live View - LightNVR';
 
     return (
         <>

--- a/web/js/utils/live-view-url.js
+++ b/web/js/utils/live-view-url.js
@@ -5,3 +5,16 @@ export function buildLiveViewHref(path, currentSearch = '', mode = '') {
   const query = params.toString();
   return query ? `${path}?${query}` : path;
 }
+
+const FORCED_LIVE_TRANSPORTS = new Set(['webrtc', 'mse', 'hls']);
+
+/**
+ * Resolve a page-level playback override. The default live URL has no mode and
+ * therefore preserves each stream's configured transport chain. Legacy
+ * hls.html URLs imply an explicit HLS selection.
+ */
+export function resolveForcedLiveTransport(pathname = '', currentSearch = '') {
+  const mode = new URLSearchParams(currentSearch).get('mode');
+  if (FORCED_LIVE_TRANSPORTS.has(mode)) return mode;
+  return pathname.endsWith('/hls.html') ? 'hls' : null;
+}

--- a/web/js/utils/playback-transport.js
+++ b/web/js/utils/playback-transport.js
@@ -21,16 +21,22 @@ export function normalizePlaybackTransport(value) {
 export function buildPlaybackTransportPlan(
   preference,
   offerings = { webrtc: true, mse: true, hls: true },
-  defaultTransport = 'webrtc'
+  defaultTransport = 'webrtc',
+  forcedTransport = null
 ) {
   const profile = normalizePlaybackTransport(preference);
-  const requested = profile === 'auto'
-    ? [...(AUTO_CHAINS[defaultTransport] || AUTO_CHAINS.webrtc)]
-    : [...PLAYBACK_TRANSPORT_CHAINS[profile]];
+  const viewerOverride = Object.hasOwn(AUTO_CHAINS, forcedTransport)
+    ? forcedTransport
+    : null;
+  const requested = viewerOverride
+    ? [viewerOverride]
+    : profile === 'auto'
+      ? [...(AUTO_CHAINS[defaultTransport] || AUTO_CHAINS.webrtc)]
+      : [...PLAYBACK_TRANSPORT_CHAINS[profile]];
   const available = requested.filter((transport) => offerings[transport] !== false);
   const unavailable = requested.filter((transport) => offerings[transport] === false);
 
-  return { profile, requested, available, unavailable };
+  return { profile, forcedTransport: viewerOverride, requested, available, unavailable };
 }
 
 export function isPlaybackFallback(plan, activeTransport, runtimeFallbackIndex = 0) {

--- a/web/tests/liveViewUrl.spec.js
+++ b/web/tests/liveViewUrl.spec.js
@@ -1,4 +1,7 @@
-import { buildLiveViewHref } from '../js/utils/live-view-url.js';
+import {
+  buildLiveViewHref,
+  resolveForcedLiveTransport,
+} from '../js/utils/live-view-url.js';
 
 describe('live view links', () => {
   test('preserves collection and layout filters between playback modes', () => {
@@ -11,5 +14,16 @@ describe('live view links', () => {
   test('sets MSE mode while preserving the current collection', () => {
     expect(buildLiveViewHref('/hls.html', '?collection=collection-a', 'mse'))
       .toBe('/hls.html?collection=collection-a&mode=mse');
+  });
+
+  test('distinguishes default precedence from explicit transport modes', () => {
+    expect(resolveForcedLiveTransport('/index.html', '?collection=collection-a'))
+      .toBeNull();
+    expect(resolveForcedLiveTransport('/index.html', '?mode=webrtc'))
+      .toBe('webrtc');
+    expect(resolveForcedLiveTransport('/hls.html', ''))
+      .toBe('hls');
+    expect(resolveForcedLiveTransport('/hls.html', '?mode=mse'))
+      .toBe('mse');
   });
 });

--- a/web/tests/playbackTransport.spec.js
+++ b/web/tests/playbackTransport.spec.js
@@ -45,6 +45,43 @@ describe('per-stream playback transport', () => {
       .toEqual(['hls']);
   });
 
+  test.each(['webrtc', 'mse', 'hls'])(
+    'forces every stream to the explicit %s viewer transport',
+    (forcedTransport) => {
+      const plan = buildPlaybackTransportPlan(
+        'webrtc_then_mse',
+        all,
+        'webrtc',
+        forcedTransport
+      );
+      expect(plan.forcedTransport).toBe(forcedTransport);
+      expect(plan.requested).toEqual([forcedTransport]);
+      expect(plan.available).toEqual([forcedTransport]);
+    }
+  );
+
+  test('does not degrade an explicit viewer mode when it is unavailable', () => {
+    const plan = buildPlaybackTransportPlan(
+      'webrtc_then_mse',
+      { ...all, hls: false },
+      'webrtc',
+      'hls'
+    );
+    expect(plan.available).toEqual([]);
+    expect(plan.unavailable).toEqual(['hls']);
+  });
+
+  test('default viewer mode retains configured precedence after filtering offerings', () => {
+    expect(buildPlaybackTransportPlan(
+      'auto',
+      { webrtc: false, mse: true, hls: true }
+    ).available).toEqual(['mse', 'hls']);
+    expect(buildPlaybackTransportPlan(
+      'mse_then_hls',
+      all
+    ).available).toEqual(['mse', 'hls']);
+  });
+
   test('does not change transports when the camera source is unavailable', () => {
     const options = {
       streamStatus: 'Running',


### PR DESCRIPTION
## Summary

- make the default Auto live view honor each stream transport chain and the WebRTC -> MSE -> HLS precedence
- make explicit WebRTC, HLS, and MSE tabs force every tile to that single transport
- prevent forced modes from silently crossing into another renderer
- add a distinct Auto tab and keep the four-mode selector usable on mobile
- document the viewer override contract in the Live View Ergonomics PRD

## Validation

- 26 Jest suites / 173 tests passed
- npm run build
- git diff --check