### PR TITLE
fix(recordings): keep mobile video modal usable

### DIFF
--- a/tests/integration/specs/recordings.ui.spec.ts
+++ b/tests/integration/specs/recordings.ui.spec.ts
@@ -374,6 +374,107 @@ test.describe('Recordings Page @ui @recordings', () => {
       await expect(page.locator('#video-preview-modal')).toBeVisible();
       await expect(page.locator('#recording-playback-position')).toHaveText('cam1 - 00:00:00');
     });
+
+    test('keeps the recording player visible and controls scrollable on mobile', async ({ page }) => {
+      const recordingsPage = new RecordingsPage(page);
+
+      await page.setViewportSize({ width: 360, height: 740 });
+      await page.addInitScript(() => {
+        localStorage.setItem('recordings_view_mode', 'grid');
+        localStorage.setItem('recordings_filters_collapsed', 'true');
+      });
+
+      await page.route('**/api/client-config*', route => route.fulfill({
+        json: { generate_thumbnails: true, thumbnails_per_recording: 1 }
+      }));
+      await page.route('**/api/streams*', route => route.fulfill({ json: [{ name: 'front-door' }] }));
+      await page.route('**/api/recordings/detection-labels*', route => route.fulfill({ json: { labels: [] } }));
+      await page.route('**/api/recordings/tags*', route => route.fulfill({ json: { tags: [] } }));
+      await page.route('**/api/recordings?**', route => route.fulfill({ json: {
+        recordings: [{
+          id: 602,
+          stream: 'front-door-camera-with-a-long-name',
+          capture_method: 'scheduled',
+          tags: [],
+          detection_labels: [],
+          start_time: '2026-08-26T14:23:17Z',
+          start_time_unix: 1787754197,
+          duration: 60,
+          size: '1 MB',
+          protected: false,
+          has_detections: false
+        }],
+        pagination: { total: 1, pages: 1, limit: 20 }
+      } }));
+      await page.route('**/api/recordings/thumbnail/602/**', route => route.fulfill({
+        contentType: 'image/svg+xml',
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect width="320" height="180" fill="#111827"/></svg>'
+      }));
+      await page.route('**/api/recordings/play/602*', route => route.fulfill({ status: 204, body: '' }));
+      await page.route('**/api/recordings/602', route => route.fulfill({ json: {
+        id: 602,
+        stream: 'front-door-camera-with-a-long-name',
+        start_time: '2026-08-26T14:23:17Z',
+        end_time: '2026-08-26T14:24:17Z',
+        protected: false,
+        has_detection: false,
+        detection_labels: []
+      } }));
+
+      await recordingsPage.goto();
+
+      const card = page.locator('.recording-card').first();
+      await expect(card).toBeVisible();
+      const cardBounds = await card.boundingBox();
+      expect(cardBounds).not.toBeNull();
+      expect(cardBounds!.x).toBeGreaterThanOrEqual(0);
+      expect(cardBounds!.x + cardBounds!.width).toBeLessThanOrEqual(360);
+
+      await card.getByTitle('Play').click();
+      await expect(page.locator('#video-preview-modal')).toBeVisible();
+
+      const layout = await page.evaluate(() => {
+        const modal = document.querySelector('#video-preview-modal .modal-content');
+        const video = document.querySelector('[data-testid="recording-video-container"]');
+        const controls = document.querySelector('#recordings-controls');
+        if (!modal || !video || !controls) return null;
+
+        const modalRect = modal.getBoundingClientRect();
+        const videoRect = video.getBoundingClientRect();
+        const controlsRect = controls.getBoundingClientRect();
+        return {
+          modalTop: modalRect.top,
+          modalBottom: modalRect.bottom,
+          modalRight: modalRect.right,
+          videoHeight: videoRect.height,
+          controlsBottom: controlsRect.bottom,
+          controlsOverflowY: getComputedStyle(controls).overflowY,
+          viewportHeight: window.innerHeight,
+          viewportWidth: window.innerWidth
+        };
+      });
+
+      expect(layout).not.toBeNull();
+      expect(layout!.modalTop).toBeGreaterThanOrEqual(0);
+      expect(layout!.modalBottom).toBeLessThanOrEqual(layout!.viewportHeight);
+      expect(layout!.modalRight).toBeLessThanOrEqual(layout!.viewportWidth);
+      expect(layout!.videoHeight).toBeGreaterThanOrEqual(140);
+      expect(layout!.controlsBottom).toBeLessThanOrEqual(layout!.modalBottom);
+      expect(layout!.controlsOverflowY).toBe('auto');
+
+      const controls = page.locator('#recordings-controls');
+      await controls.evaluate(element => element.scrollTo(0, element.scrollHeight));
+      const deleteButton = controls.getByRole('button', { name: 'Delete' });
+      await expect(deleteButton).toBeVisible();
+      const actionIsReachable = await deleteButton.evaluate(button => {
+        const controlsElement = button.closest('#recordings-controls');
+        if (!controlsElement) return false;
+        const buttonRect = button.getBoundingClientRect();
+        const controlsRect = controlsElement.getBoundingClientRect();
+        return buttonRect.top >= controlsRect.top && buttonRect.bottom <= controlsRect.bottom;
+      });
+      expect(actionIsReachable).toBe(true);
+    });
   });
 
   test.describe('Recording Actions', () => {

--- a/web/js/components/preact/UI.jsx
+++ b/web/js/components/preact/UI.jsx
@@ -842,9 +842,9 @@ export function VideoModal({ isOpen, onClose, videoUrl, title, downloadUrl }) {
       className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50"
       onClick={handleBackgroundClick}
     >
-      <div className={`modal-content bg-card text-card-foreground rounded-lg shadow-xl max-w-4xl max-h-[95vh] h-[95vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-out scale-95 opacity-0 w-full md:w-[90%]`}>
-        <div className="flex justify-between items-center p-3 border-b border-border flex-shrink-0">
-          <h3 id="video-preview-title" className="text-lg font-semibold text-gray-900 dark:text-white truncate mr-2">
+      <div className="modal-content bg-card text-card-foreground rounded-lg shadow-xl max-w-4xl max-h-[95vh] h-[95vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-out scale-95 opacity-0 w-full md:w-[90%]">
+        <div className="flex justify-between items-center p-2 sm:p-3 border-b border-border flex-shrink-0">
+          <h3 id="video-preview-title" className="text-base sm:text-lg font-semibold text-gray-900 dark:text-white truncate mr-2">
             {title || 'Video'}
           </h3>
           <button
@@ -856,15 +856,17 @@ export function VideoModal({ isOpen, onClose, videoUrl, title, downloadUrl }) {
         </div>
 
         <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-          <div className="flex-1 min-h-0 p-3 flex justify-center items-center">
+          <div className="flex-none p-2 sm:p-3 md:flex-1 md:min-h-0 flex justify-center items-center">
             <div
               ref={videoContainerRef}
               data-testid="recording-video-container"
-              className={isFullscreen ? 'relative w-screen h-screen bg-black' : 'relative inline-block max-w-full max-h-full h-full bg-black overflow-hidden'}
+              className={isFullscreen
+                ? 'relative w-screen h-screen bg-black'
+                : 'relative w-full aspect-video bg-black overflow-hidden md:h-full md:aspect-auto'}
             >
               <video
                 ref={videoRef}
-                className={isFullscreen ? 'w-full h-full object-contain' : 'w-full h-full max-w-full max-h-full object-contain'}
+                className="w-full h-full object-contain"
                 controls
                 controlsList="nofullscreen"
                 key={videoUrl} /* Add key to force re-render when URL changes */
@@ -886,7 +888,7 @@ export function VideoModal({ isOpen, onClose, videoUrl, title, downloadUrl }) {
             </div>
           </div>
 
-          <div className="px-3 pb-1 flex-shrink-0">
+          <div className="px-2 sm:px-3 pb-1 flex-shrink-0">
             <div
               id="recording-playback-position"
               data-testid="recording-playback-position"
@@ -896,7 +898,7 @@ export function VideoModal({ isOpen, onClose, videoUrl, title, downloadUrl }) {
             </div>
           </div>
 
-          <div id="recordings-controls" className="mx-3 mb-3 p-3 border border-green-500 rounded-lg bg-card text-card-foreground shadow-md relative z-10 flex-shrink-0 overflow-y-auto">
+          <div id="recordings-controls" className="mx-2 sm:mx-3 mb-2 sm:mb-3 p-2 sm:p-3 border border-green-500 rounded-lg bg-card text-card-foreground shadow-md relative z-10 flex-1 min-h-0 overflow-y-auto overscroll-contain md:flex-none">
             <h3 className="text-base font-bold text-center mb-2 text-foreground">
               PLAYBACK CONTROLS
             </h3>


### PR DESCRIPTION
## Summary

- preserve a 16:9 recording player on narrow viewports instead of allowing the controls to collapse it
- constrain the single-column playback controls to the remaining modal height and make them independently scrollable
- tighten mobile header/control spacing while retaining the existing desktop player and fullscreen behavior

## Investigation

At a Pixel 5 viewport on the live site, the recording card grid remained within the viewport, but opening a recording produced a 0x0 video container. The 638px controls panel extended beyond the 691px modal and was clipped by the modal overflow. The controls were marked non-shrinking, so their mobile single-column height consumed the entire flex body.

## Validation

- `npm run build` in `web/`
- new 360x740 mobile Playwright regression: player remains at least 140px tall, modal and controls stay bounded, and the Delete action is reachable by scrolling
- existing desktop fullscreen/detection-overlay Playwright regression

Fixes #564