### PR TITLE
fix(detection): don't default tiny80.sod to face-only architecture

### DIFF
--- a/src/video/sod_detection.c
+++ b/src/video/sod_detection.c
@@ -223,6 +223,10 @@ detection_model_t load_sod_model(const char *model_path, float threshold) {
         arch = ":voc";
         log_info("Detected VOC model by exact filename match, using :voc architecture: %s", filename);
     }
+    else if (strcmp(filename, "tiny80.sod") == 0) {
+        arch = ":tiny80";
+        log_info("Detected COCO-80 model by exact filename match, using :tiny80 architecture: %s", filename);
+    }
     else {
         // If we couldn't determine the architecture, default to face for .sod files
         // This is a fallback to ensure face detection works even if the filename doesn't contain "face"


### PR DESCRIPTION
Unrecognized `.sod` filenames fell through to the `:face` architecture
fallback, so the tiny80 COCO-80 object model was silently running as
a face-only detector. Adds an exact-match case routing `tiny80.sod` to
`:tiny80`, mirroring the existing `:voc` exact-match case.

## Test plan
- Confirmed via `journalctl -u lightnvr` that `tiny80.sod` now logs
  `Detected COCO-80 model by exact filename match, using :tiny80 architecture`
  instead of falling back to face detection, across all streams using this model.