### PR TITLE
perf(sod): SIMD-accelerate gemm() via runtime CPU dispatch

### DIFF
--- a/src/sod/sod.c
+++ b/src/sod/sod.c
@@ -4759,7 +4759,13 @@ static inline void gemm_cpu(int TA, int TB, int M, int N, int K, float ALPHA,
 		gemm_tt(M, N, K, ALPHA, A, lda, B, ldb, C, ldc);
 	}
 }
-static inline void gemm(int TA, int TB, int M, int N, int K, float ALPHA,
+// Runtime CPU dispatch: compiles this hot path (the CNN's matrix-multiply
+// core) once per listed ISA plus a plain scalar fallback, and picks the
+// fastest one the actual CPU supports at load time via an ifunc resolver.
+// Safe on any x86-64 machine regardless of build host -- no blanket -mavx2
+// flag that would SIGILL on a CPU lacking it.
+__attribute__((target_clones("avx2,fma,default")))
+static void gemm(int TA, int TB, int M, int N, int K, float ALPHA,
 	float *A, int lda,
 	float *B, int ldb,
 	float BETA,


### PR DESCRIPTION
`sod_cnn_predict()` dominates total detection time — roughly 97% on my hardware — and its matrix-multiply core, `gemm()`, is pure scalar C compiled with no arch-specific flags at all, despite most modern CPUs supporting AVX2/FMA.

This adds `__attribute__((target_clones("avx2,fma,default")))` to `gemm()` — GCC/Clang function multi-versioning. The compiler emits separate compiled copies for AVX2, FMA, and a plain scalar fallback, plus an automatic dispatcher that picks the fastest one the running CPU actually supports at load time. A machine without AVX2/FMA transparently gets the exact same scalar code that runs today — no blanket `-mavx2` flag that would crash on unsupported hardware.

Used the older `avx2,fma,default` clone-list syntax (GCC 6+) rather than the newer `arch=x86-64-v3,default` shorthand (GCC 11+, also tested, same performance) for wider toolchain compatibility.

**Testing:** three build variants (blanket flags, the arch-level clone, and this one) all produced bit-identical detection output against the unmodified baseline across several real camera images — same confidences and coordinates to 4 decimal places. Measured ~21-28% less per-detection wall time on a 2560x1920 frame, stacking with #573 since they touch different, non-overlapping parts of the pipeline.

Built with Claude Code (Anthropic).