### PR TITLE
fix(sod): guard gemm() target_clones to x86 only

### DIFF
--- a/src/sod/sod.c
+++ b/src/sod/sod.c
@@ -4762,9 +4762,13 @@ static inline void gemm_cpu(int TA, int TB, int M, int N, int K, float ALPHA,
 // Runtime CPU dispatch: compiles this hot path (the CNN's matrix-multiply
 // core) once per listed ISA plus a plain scalar fallback, and picks the
 // fastest one the actual CPU supports at load time via an ifunc resolver.
-// Safe on any x86-64 machine regardless of build host -- no blanket -mavx2
-// flag that would SIGILL on a CPU lacking it.
+// Safe on any x86/x86-64 machine regardless of build host -- no blanket
+// -mavx2 flag that would SIGILL on a CPU lacking it. "avx2"/"fma" are x86
+// feature names; the attribute must be gated to x86 targets or it's a hard
+// compile error on ARM/other architectures LightNVR also ships for.
+#if defined(__x86_64__) || defined(__i386__)
 __attribute__((target_clones("avx2,fma,default")))
+#endif
 static void gemm(int TA, int TB, int M, int N, int K, float ALPHA,
 	float *A, int lda,
 	float *B, int ldb,


### PR DESCRIPTION
#574's `__attribute__((target_clones("avx2,fma,default")))` on `gemm()` is a hard compile error on non-x86 architectures — `avx2`/`fma` are x86-specific feature names, and GCC validates them against the actual compilation target rather than treating them as inert hints elsewhere:

```
sod.c:4768:13: error: invalid feature modifier 'avx2' of value 'avx2' in 'target_version' attribute
```

This project's own CI (`docker-publish.yml`, `debian-package.yml`) builds for `linux/arm64` and `linux/arm/v7` in addition to `amd64`, so this broke real release targets, not just a theoretical platform.

**Fix:** wrap the attribute in `#if defined(__x86_64__) || defined(__i386__)`. On x86/x86-64, nothing changes — same three compiled clones and ifunc resolver as before. On other architectures, `gemm()` compiles as a plain function, identical to its pre-#574 form.

**Verified** with `aarch64-linux-gnu-gcc` and `arm-linux-gnueabihf-gcc` — both now compile `sod.c` cleanly (previously both failed with the error above). Native x86_64 build still shows all three `gemm` clones via `readelf -s`.

Built with Claude Code (Anthropic).