### PR TITLE
fix(shutdown): restart/stop can hang for tens of minutes to indefinitely on a large DB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,6 +648,7 @@ set(REBUILD_RECORDINGS_SOURCES
     src/core/config.c
     src/core/logger.c
     src/core/path_utils.c
+    src/core/shutdown_coordinator.c
     src/utils/strings.c
     src/utils/uuid.c
     src/telemetry/system_health_policy.c

--- a/include/core/shutdown_coordinator.h
+++ b/include/core/shutdown_coordinator.h
@@ -76,4 +76,20 @@ bool wait_for_all_components_stopped(int timeout_seconds);
 // Get the global shutdown coordinator instance
 shutdown_coordinator_t *get_shutdown_coordinator(void);
 
+// Request that long-running background operations (e.g. the scheduled DB
+// backup) abort at their next opportunity. Distinct from initiate_shutdown():
+// this is a lightweight, independent flag with no component-teardown side
+// effects, so it is safe to raise the instant a restart or shutdown is first
+// requested -- from an async-signal-safe context (a signal handler) as well
+// as from an ordinary API handler thread -- well before the main loop
+// actually exits and initiate_shutdown() runs the real teardown sequence.
+void request_background_abort(void);
+
+// Check whether a background-abort has been requested. Long-running
+// operations that run outside the main loop (e.g. backup_database()'s
+// batched copy loop) should poll this between batches and bail out early
+// when it becomes true, rather than blocking a pending restart/shutdown
+// until the entire operation finishes.
+bool is_background_abort_requested(void);
+
 #endif /* SHUTDOWN_COORDINATOR_H */

--- a/include/database/db_backup.h
+++ b/include/database/db_backup.h
@@ -1,14 +1,25 @@
 #ifndef LIGHTNVR_DB_BACKUP_H
 #define LIGHTNVR_DB_BACKUP_H
 
+#include <stdbool.h>
+
 /**
  * Backup the database to a specified path
- * 
+ *
  * @param source_path Path to the source database file
  * @param dest_path Path to the destination backup file
+ * @param abortable When true, the copy bails out early (returning non-zero,
+ *     no partial file left behind) if a restart/shutdown is requested
+ *     mid-copy -- appropriate for a periodic/scheduled backup, where
+ *     finishing this run is never more important than letting the process
+ *     stop promptly. Pass false for a backup that must complete once
+ *     started (e.g. the deliberate one-time backup taken while already
+ *     shutting down) -- there, the request is already guaranteed to be
+ *     pending, so an abortable copy would always bail out immediately and
+ *     never actually produce a backup.
  * @return 0 on success, non-zero on failure
  */
-int backup_database(const char *source_path, const char *dest_path);
+int backup_database(const char *source_path, const char *dest_path, bool abortable);
 
 /**
  * Restore database from backup

--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -13,6 +13,7 @@
 #include <sys/socket.h>
 #include <sys/utsname.h>
 #include <pthread.h>
+#include <stdatomic.h>
 
 #include "web/web_server.h"
 #include "core/logger.h"
@@ -21,7 +22,7 @@
 #include "core/shutdown_coordinator.h"
 #include "utils/strings.h"
 
-extern volatile bool running; // Reference to the global variable defined in main.c
+extern _Atomic bool running; // Reference to the global variable defined in main.c
 
 // Global variable to store PID file path
 static char pid_file_path[MAX_PATH_LENGTH] = "/run/lightnvr.pid";

--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -18,6 +18,7 @@
 #include "core/logger.h"
 #include "core/daemon.h"
 #include "core/path_utils.h"
+#include "core/shutdown_coordinator.h"
 #include "utils/strings.h"
 
 extern volatile bool running; // Reference to the global variable defined in main.c
@@ -156,6 +157,17 @@ static void daemon_signal_handler(int sig) {
         // This is safe because running is declared as volatile bool
         running = false;
 
+        // Also wake up any long-running background operation (e.g. a
+        // scheduled DB backup) that isn't polling `running` itself, so it
+        // aborts promptly instead of blocking this shutdown until it
+        // finishes on its own. This handler is the one actually registered
+        // for SIGTERM/SIGINT in daemon mode -- daemonize() installs it via
+        // sigaction() *after* main.c's init_signals() already ran, silently
+        // overriding that handler's equivalent call for every real
+        // `systemctl stop`/`kill` in production. request_background_abort()
+        // is async-signal-safe (atomic store only).
+        request_background_abort();
+
         // Also signal the web server to shut down
         extern int web_server_socket;
         if (web_server_socket >= 0) {
@@ -165,9 +177,20 @@ static void daemon_signal_handler(int sig) {
             web_server_socket = -1; // Update the global reference
         }
 
-        // Set an alarm to force exit after 30 seconds if normal shutdown fails
-        // alarm() is async-signal-safe
-        alarm(30);
+        // Deliberately NOT using alarm() here as a "force exit if shutdown
+        // hangs" watchdog: alarm() is a single process-wide timer, and this
+        // codebase's HLS writer/context-close code (hls_unified_thread.c,
+        // hls_writer.c) uses alarm() extensively as a short per-operation
+        // timeout (save disposition, alarm(N), do the call, alarm(0),
+        // restore disposition). Any one of those firing during shutdown
+        // would silently discard whatever time was left on an alarm set
+        // here, since alarm() has no pause/resume -- confirmed live via
+        // gdb: a shutdown that should have had ~570s left was killed at 45s
+        // by one of those unrelated short-lived alarms, in this exact
+        // handler, right after this comment block previously called
+        // alarm(570) here. main.c's start_shutdown_watchdog_thread()
+        // (a dedicated thread polling `running`, spawned once at startup)
+        // now owns this responsibility instead, immune to that collision.
         break;
 
     case SIGHUP:
@@ -177,16 +200,18 @@ static void daemon_signal_handler(int sig) {
         break;
 
     case SIGALRM:
-        // Handle the alarm signal (fallback for forced exit)
-        daemon_signal_safe_write("[DAEMON] Alarm triggered - forcing exit\n");
-
-        // Force kill any child processes before exiting
-        // kill() is async-signal-safe
-        kill(0, SIGKILL); // Send SIGKILL to all processes in the process group
-
-        // Force exit without calling atexit handlers
-        // _exit() is async-signal-safe
-        _exit(EXIT_SUCCESS);
+        // No longer the shutdown watchdog (see main.c's
+        // start_shutdown_watchdog_thread()). Kept registered, and
+        // deliberately harmless, purely so SIGALRM has a caught
+        // (non-terminating) disposition as a safety net: the many
+        // hls_unified_thread.c/hls_writer.c call sites that use alarm() for
+        // their own short per-operation timeouts save whatever handler is
+        // installed here before temporarily switching it to SIG_IGN, and
+        // restore it afterward. If this weren't registered, SIGALRM's
+        // default disposition (process termination) would apply during any
+        // brief window where none of those local overrides happen to be
+        // active.
+        daemon_signal_safe_write("[DAEMON] Stray SIGALRM caught at top level (harmless, ignored)\n");
         break;
 
     default:

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -17,6 +17,8 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <limits.h>
+#include <pthread.h>
+#include <time.h>
 
 #include "core/version.h"
 #include "core/config.h"
@@ -163,43 +165,108 @@ static void signal_handler(int sig) {
     // This is safe because running is declared as volatile bool
     running = false;
 
-    // For Linux 4.4 embedded systems, we need a more robust approach
-    // Set an alarm to force exit if normal shutdown doesn't work
-    // Increased from 10 to 20 seconds to give more time for graceful shutdown
-    alarm(20);
+    // Also wake up any long-running background operation (e.g. a scheduled
+    // DB backup) that isn't polling `running` itself, so it aborts promptly
+    // instead of blocking this shutdown until it finishes on its own.
+    // request_background_abort() is async-signal-safe (atomic store only).
+    request_background_abort();
+
+    // Deliberately NOT using alarm() here as a "force exit if shutdown
+    // hangs" watchdog anymore -- see start_shutdown_watchdog_thread()'s
+    // comment for why: alarm() is a single process-wide timer, and this
+    // codebase's HLS writer/context-close code (hls_unified_thread.c,
+    // hls_writer.c) uses alarm() extensively as a short per-operation
+    // timeout (save disposition, alarm(N), do the call, alarm(0), restore
+    // disposition). Any one of those firing during shutdown would silently
+    // discard whatever time was left on an alarm set here, since alarm()
+    // has no pause/resume -- confirmed live via gdb: a shutdown that should
+    // have had ~570s left was killed at 45s by one of those unrelated
+    // short-lived alarms. A dedicated watchdog thread can't be clobbered
+    // this way. This handler now only sets flags and closes the listening
+    // socket, both async-signal-safe.
+    if (web_server_socket >= 0) {
+        close(web_server_socket);
+        web_server_socket = -1;
+    }
 }
 
-// Atomic flag to track emergency shutdown phase - must be volatile sig_atomic_t for signal safety
-static volatile sig_atomic_t emergency_shutdown_phase = 0;
-
-// Alarm signal handler for forced exit - MUST ONLY use async-signal-safe functions
-// NOTE: pthread_mutex_lock, log_*, malloc, etc. are NOT async-signal-safe and must NOT be used here
+// Alarm signal handler -- MUST ONLY use async-signal-safe functions.
+//
+// No longer the shutdown watchdog (see start_shutdown_watchdog_thread()).
+// Kept registered, and deliberately harmless, purely so SIGALRM has a
+// caught (non-terminating) disposition as a safety net: the many
+// hls_unified_thread.c/hls_writer.c call sites that use alarm() for their
+// own short per-operation timeouts save whatever handler is installed here
+// before temporarily switching it to SIG_IGN, and restore it afterward. If
+// this weren't registered, SIGALRM's default disposition (process
+// termination) would apply during any brief window where none of those
+// local overrides happen to be active.
 static void alarm_handler(int sig) {
-    (void)sig; // Suppress unused parameter warning
+    (void)sig;
+    signal_safe_write("[SIGNAL] Stray SIGALRM caught at top level (harmless, ignored)\n");
+}
 
-    // Increment the emergency phase atomically
-    emergency_shutdown_phase++;
+// How long a graceful shutdown gets before the watchdog force-kills the
+// process group. Must outlast the deliberate, non-abortable final backup
+// shutdown_database() takes before exiting (observed up to ~9 minutes on
+// this box's 2.6GB+ database) -- and must stay under the lightnvr.service
+// systemd override's TimeoutStopSec (600s as of 2026-09-03) so systemd never
+// has to SIGKILL first.
+// Was 570s, but a live test on 2026-09-04 showed the actual final backup
+// occasionally exceeding that (both watchdogs fired correctly, right at
+// 570s -- the collision/timing bugs were fixed, this was genuinely just not
+// enough margin above the observed ~9-9.5 minute backup duration on this
+// box's 2.6GB+ database). Bumped to give real headroom.
+#define SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS 900
 
-    if (emergency_shutdown_phase == 1) {
-        // Phase 1: Close the web server socket (close() is async-signal-safe)
-        if (web_server_socket >= 0) {
-            close(web_server_socket);
-            web_server_socket = -1;
+// Runs for the lifetime of the process, polling `running` once a second.
+// Once it goes false, starts counting down SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS
+// and force-kills the process group if the process hasn't exited on its own
+// by the time that elapses (this thread simply vanishes along with every
+// other thread on a normal exit, so it never fires in the common case).
+//
+// Deliberately NOT alarm()-based: alarm() is a single process-wide timer,
+// and hls_unified_thread.c/hls_writer.c use it extensively as a short
+// per-operation timeout (save disposition, alarm(N), do the call, alarm(0),
+// restore disposition) around individual writer/context close calls. Any
+// one of those firing during shutdown discards whatever time was left on an
+// outer alarm, since alarm() has no pause/resume -- confirmed live via gdb:
+// a shutdown that should have had ~570s left was killed at 45s by one of
+// those unrelated short-lived alarms. This thread runs independently of
+// SIGALRM entirely, so none of that matters here. Unlike a signal handler,
+// this runs in normal thread context, so log_error() and kill() are both
+// safe to call directly.
+static void *shutdown_watchdog_thread_func(void *arg) {
+    (void)arg;
+    time_t shutdown_started_at = 0;
+
+    while (1) {
+        sleep(1);
+
+        if (!running) {
+            if (shutdown_started_at == 0) {
+                shutdown_started_at = time(NULL);
+            } else if (time(NULL) - shutdown_started_at >= SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS) {
+                log_error("Shutdown watchdog: graceful shutdown did not complete within %d seconds, "
+                          "force-killing process group", SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS);
+                kill(0, SIGKILL);
+                _exit(EXIT_FAILURE);
+            }
         }
-
-        // Set another alarm for phase 2 (alarm() is async-signal-safe)
-        alarm(15);
-        return;
     }
 
-    if (emergency_shutdown_phase == 2) {
-        // Phase 2: Give it one more chance
-        alarm(10);
-        return;
-    }
+    return NULL;
+}
 
-    // Phase 3+: Force exit immediately (_exit is async-signal-safe)
-    _exit(EXIT_SUCCESS);
+static void start_shutdown_watchdog_thread(void) {
+    pthread_t thread;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    if (pthread_create(&thread, &attr, shutdown_watchdog_thread_func, NULL) != 0) {
+        log_error("Failed to start shutdown watchdog thread: %s", strerror(errno));
+    }
+    pthread_attr_destroy(&attr);
 }
 
 // Function to initialize signal handlers with improved signal handling
@@ -489,6 +556,10 @@ void request_restart(void) {
     log_info("request_restart() called - setting restart_requested=true and running=false");
     restart_requested = true;
     running = false;
+    // See signal_handler()'s call to the same function: this lets a
+    // long-running background operation (e.g. a scheduled DB backup) abort
+    // promptly instead of silently blocking this restart until it finishes.
+    request_background_abort();
     log_info("request_restart() completed - restart_requested=%d, running=%d", restart_requested, running);
 }
 
@@ -690,6 +761,11 @@ int main(int argc, char *argv[]) {
             return EXIT_FAILURE;
         }
     }
+
+    // Must start after daemonize(): daemonize() calls fork(), and fork()
+    // only duplicates the calling thread -- a thread started earlier would
+    // simply not exist in the daemonized child process.
+    start_shutdown_watchdog_thread();
 
     // Detect if we're running in a container
     container_mode = detect_container_mode();
@@ -1367,13 +1443,25 @@ cleanup:
         // Save the parent PID before it gets killed
         pid_t parent_pid = getppid();
 
-        sleep(30);  // 30 seconds for first phase timeout
-        log_error("Cleanup process phase 1 timed out after 30 seconds");
+        // Phase 1 must outlast the deliberate, non-abortable final backup
+        // shutdown_database() takes before exiting (observed up to ~9
+        // minutes on this box's 2.6GB+ database) -- same reasoning as
+        // SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS and the alarm() values in
+        // daemon.c/signal_handler(). This watchdog is fork+sleep()-based
+        // rather than alarm()-based, so unlike those it was never actually
+        // affected by the alarm()/SIGALRM collision with
+        // hls_unified_thread.c/hls_writer.c's per-operation timeouts --
+        // it was simply always too short (30s) on its own, and was in fact
+        // the one actually killing every real shutdown after those other
+        // fixes landed, confirmed via its distinct "phase 1/2 timed out"
+        // log lines.
+        sleep(SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS);
+        log_error("Cleanup process phase 1 timed out after %d seconds", SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS);
         kill(parent_pid, SIGUSR1);  // Send USR1 to parent to trigger emergency cleanup
 
-        // Wait another 15 seconds for emergency cleanup
+        // Wait a bit longer for emergency cleanup before giving up entirely
         sleep(15);
-        log_error("Cleanup process phase 2 timed out after 15 seconds, forcing exit");
+        log_error("Cleanup process phase 2 timed out after 15 more seconds, forcing exit");
         kill(parent_pid, SIGKILL);  // Force kill the parent process
 
         // If restart was requested, handle it here since the parent was killed
@@ -1818,7 +1906,19 @@ cleanup:
 static void check_and_ensure_services(void) {
     // CRITICAL FIX: Skip starting new services during shutdown
     // This prevents memory leaks caused by starting new threads during shutdown
-    if (is_shutdown_initiated()) {
+    //
+    // is_shutdown_initiated() only flips once the main loop has already
+    // exited and begun its teardown sequence -- it's still false in the gap
+    // between a restart/shutdown being requested and the main loop next
+    // checking `running`, which is exactly the gap this function can be
+    // called in. is_background_abort_requested() flips the instant a
+    // restart or shutdown is requested (see request_restart() and
+    // signal_handler()), so check it too: this loop can iterate every
+    // configured stream with a deliberate 3s stagger sleep between
+    // recording starts, which measured in production as long enough to
+    // silently absorb a "Restart LightNVR" click for the same reason the
+    // scheduled DB backup once did.
+    if (is_shutdown_initiated() || is_background_abort_requested()) {
         log_debug("Skipping service check during shutdown");
         return;
     }
@@ -1843,6 +1943,15 @@ static void check_and_ensure_services(void) {
     int recordings_started = 0;
 
     for (int i = 0; i < g_config.max_streams; i++) {
+        // Re-check between streams: this loop's per-stream stagger sleep and
+        // connection-establishment calls mean a restart/shutdown requested
+        // partway through could otherwise still wait out every remaining
+        // stream before the main loop gets a chance to notice.
+        if (is_background_abort_requested()) {
+            log_debug("Aborting periodic service check early: restart/shutdown requested");
+            return;
+        }
+
         // Log the record flag for debugging
         if (current_config->streams[i].name[0] != '\0') {
             log_info("Service check for stream %s: enabled=%d, record=%d, streaming_enabled=%d",

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -19,6 +19,7 @@
 #include <limits.h>
 #include <pthread.h>
 #include <time.h>
+#include <stdatomic.h>
 
 #include "core/version.h"
 #include "core/config.h"
@@ -86,7 +87,16 @@ void init_recordings_system(void);
 #include <fcntl.h>
 
 // Global flag for graceful shutdown
-volatile bool running = true;
+// _Atomic (not just volatile) because it's read from multiple real threads
+// now: the main loop, signal handlers, and shutdown_watchdog_thread_func()
+// below. `volatile` alone gives no atomicity or cross-thread ordering
+// guarantee in C11 -- it only prevents the compiler from caching a value in
+// a register, which is enough for the old signal-handler-only usage but not
+// for a second thread genuinely polling it concurrently. Plain `= true` /
+// `while (running)` / `running = false` usage elsewhere is unchanged and
+// still correct: C11 makes direct assignment/read of an _Atomic-qualified
+// object an implicit sequentially-consistent atomic store/load.
+_Atomic bool running = true;
 
 // Global flag for restart request (set by API handler)
 volatile bool restart_requested = false;
@@ -208,15 +218,15 @@ static void alarm_handler(int sig) {
 
 // How long a graceful shutdown gets before the watchdog force-kills the
 // process group. Must outlast the deliberate, non-abortable final backup
-// shutdown_database() takes before exiting (observed up to ~9 minutes on
-// this box's 2.6GB+ database) -- and must stay under the lightnvr.service
-// systemd override's TimeoutStopSec (600s as of 2026-09-03) so systemd never
-// has to SIGKILL first.
-// Was 570s, but a live test on 2026-09-04 showed the actual final backup
-// occasionally exceeding that (both watchdogs fired correctly, right at
-// 570s -- the collision/timing bugs were fixed, this was genuinely just not
-// enough margin above the observed ~9-9.5 minute backup duration on this
-// box's 2.6GB+ database). Bumped to give real headroom.
+// shutdown_database() takes before exiting -- on a multi-gigabyte database
+// this has been observed to take up to ~9-10 minutes in production. A
+// systemd unit wrapping this service in production MUST set TimeoutStopSec
+// comfortably above this value, or systemd will SIGKILL the process before
+// this watchdog ever gets a chance to run -- defeating the point of having
+// it. (An earlier value of 570s here was too tight: a live test showed both
+// watchdogs firing correctly right at 570s, but that was genuinely not
+// enough margin above the observed backup duration -- the collision/timing
+// bugs this file fixes were confirmed fixed, it just needed more headroom.)
 #define SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS 900
 
 // Runs for the lifetime of the process, polling `running` once a second.
@@ -238,15 +248,26 @@ static void alarm_handler(int sig) {
 // safe to call directly.
 static void *shutdown_watchdog_thread_func(void *arg) {
     (void)arg;
-    time_t shutdown_started_at = 0;
+    bool shutdown_started = false;
+    struct timespec shutdown_started_at = {0};
 
     while (1) {
         sleep(1);
 
         if (!running) {
-            if (shutdown_started_at == 0) {
-                shutdown_started_at = time(NULL);
-            } else if (time(NULL) - shutdown_started_at >= SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS) {
+            struct timespec now;
+            // CLOCK_MONOTONIC, not time(NULL)/CLOCK_REALTIME: this watchdog's
+            // whole job is to fire after a fixed amount of elapsed time, and
+            // the wall clock can jump (NTP sync, manual change) mid-shutdown.
+            // A backward jump against a CLOCK_REALTIME timestamp could make
+            // the elapsed-time computation go negative and never reach the
+            // timeout, silently disabling the one thing this thread exists
+            // to guarantee.
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            if (!shutdown_started) {
+                shutdown_started_at = now;
+                shutdown_started = true;
+            } else if (now.tv_sec - shutdown_started_at.tv_sec >= SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS) {
                 log_error("Shutdown watchdog: graceful shutdown did not complete within %d seconds, "
                           "force-killing process group", SHUTDOWN_WATCHDOG_TIMEOUT_SECONDS);
                 kill(0, SIGKILL);

--- a/src/core/shutdown_coordinator.c
+++ b/src/core/shutdown_coordinator.c
@@ -16,6 +16,21 @@
 // Global shutdown coordinator instance
 static shutdown_coordinator_t g_coordinator;
 
+// Independent of g_coordinator on purpose -- see header comment. Never reset
+// once set: the only callers (request_restart() and the shutdown signal
+// handler) set it right before the process is going to stop or re-exec
+// anyway, so there is no scenario where it needs to go back to false within
+// a process's lifetime.
+static atomic_bool g_background_abort_requested = false;
+
+void request_background_abort(void) {
+    atomic_store(&g_background_abort_requested, true);
+}
+
+bool is_background_abort_requested(void) {
+    return atomic_load(&g_background_abort_requested);
+}
+
 // Initialize the shutdown coordinator
 int init_shutdown_coordinator(void) {
     memset(&g_coordinator, 0, sizeof(shutdown_coordinator_t));

--- a/src/database/db_backup.c
+++ b/src/database/db_backup.c
@@ -141,8 +141,20 @@ static int run_integrity_check(sqlite3 *db_handle, const char *path_label) {
 
     rc = sqlite3_step(stmt);
     if (rc != SQLITE_ROW) {
-        log_error("Failed to execute integrity check for %s: %s",
-                  path_label, sqlite3_errmsg(db_handle));
+        if (rc == SQLITE_INTERRUPT) {
+            // A non-zero return from the sqlite3_progress_handler callback
+            // (progress_during_verification(), registered by the caller for
+            // an abortable backup) surfaces here as SQLITE_INTERRUPT, not a
+            // real failure -- the caller already logs its own, more specific
+            // "aborting during verification: restart/shutdown requested"
+            // warning right after this returns. Logging this as an error too
+            // would make every ordinary abort during a routine restart look
+            // like a corruption/failure event in the logs.
+            log_warn("Integrity check for %s interrupted (restart/shutdown requested)", path_label);
+        } else {
+            log_error("Failed to execute integrity check for %s: %s",
+                      path_label, sqlite3_errmsg(db_handle));
+        }
         sqlite3_finalize(stmt);
         return -1;
     }

--- a/src/database/db_backup.c
+++ b/src/database/db_backup.c
@@ -21,6 +21,7 @@
 #include "database/db_backup.h"
 #include "database/db_schema_utils.h"
 #include "core/logger.h"
+#include "core/shutdown_coordinator.h"
 
 // Flag to indicate if a backup is in progress
 static bool backup_in_progress = false;
@@ -64,10 +65,20 @@ static void release_path_cache(const char *path) {
 typedef struct {
     int fd;
     const char *path;
+    bool abortable;
 } cache_release_progress_t;
 
-static int release_cache_during_verification(void *opaque) {
+static int progress_during_verification(void *opaque) {
     cache_release_progress_t *progress = (cache_release_progress_t *)opaque;
+    /* Post-copy integrity_check scans the whole backup file page by page --
+     * on a multi-gigabyte database this alone can take as long as the copy
+     * it's verifying, with no other abort point once sqlite3_backup_finish()
+     * has run. A non-zero return here interrupts the running statement
+     * (like sqlite3_interrupt()), so this is the only way to make that scan
+     * itself responsive to a pending restart/shutdown. */
+    if (progress && progress->abortable && is_background_abort_requested()) {
+        return 1;
+    }
     if (progress && progress->fd >= 0) {
         release_file_cache(progress->fd, progress->path);
     }
@@ -148,7 +159,7 @@ static int run_integrity_check(sqlite3 *db_handle, const char *path_label) {
 }
 
 // Backup the database to a specified path
-int backup_database(const char *source_path, const char *dest_path) {
+int backup_database(const char *source_path, const char *dest_path, bool abortable) {
     int rc = -1;
     sqlite3 *source_db = NULL;
     sqlite3 *dest_db = NULL;
@@ -257,8 +268,25 @@ int backup_database(const char *source_path, const char *dest_path) {
         if (rc == SQLITE_DONE) {
             break;
         }
+
+        /* Poll for a pending restart/shutdown between batches so a large
+         * scheduled backup can never block one indefinitely -- worst case,
+         * one more batch (already in flight) finishes before this fires.
+         * Checked after the SQLITE_DONE break so a backup that already
+         * finished copying on this very batch still completes (cheap
+         * remaining work: verification + rename) instead of being thrown
+         * away. Skipped entirely when !abortable (the deliberate backup
+         * taken while already shutting down): the abort flag is already
+         * guaranteed set by the time that one runs, so checking it here
+         * would make it bail out immediately on every single shutdown and
+         * never actually produce a backup. */
+        if (abortable && is_background_abort_requested()) {
+            log_warn("Database backup aborting early: restart/shutdown requested");
+            rc = SQLITE_ABORT;
+            goto cleanup;
+        }
     }
-    
+
     // Finish the backup
     rc = sqlite3_backup_finish(backup);
     backup = NULL;
@@ -269,20 +297,28 @@ int backup_database(const char *source_path, const char *dest_path) {
 
     /* Retain the full integrity guarantee, but release clean pages as SQLite
      * scans the backup.  Without the progress callback this second full-file
-     * pass recreates the multi-gigabyte cache footprint bounded above. */
+     * pass recreates the multi-gigabyte cache footprint bounded above.
+     * Registered whenever abortable even without a cache fd, since the
+     * abort-check matters independently of the cache-release optimization. */
     cache_release_progress_t verification_progress = {
         .fd = dest_cache_fd,
         .path = temp_path,
+        .abortable = abortable,
     };
-    if (dest_cache_fd >= 0) {
+    if (dest_cache_fd >= 0 || abortable) {
         sqlite3_progress_handler(dest_db, BACKUP_VERIFY_PROGRESS_OPS,
-                                 release_cache_during_verification,
+                                 progress_during_verification,
                                  &verification_progress);
     }
     int verification_rc = run_integrity_check(dest_db, temp_path);
     sqlite3_progress_handler(dest_db, 0, NULL, NULL);
     if (verification_rc != 0) {
-        rc = SQLITE_CORRUPT;
+        if (abortable && is_background_abort_requested()) {
+            log_warn("Database backup aborting during verification: restart/shutdown requested");
+            rc = SQLITE_ABORT;
+        } else {
+            rc = SQLITE_CORRUPT;
+        }
         goto cleanup;
     }
     

--- a/src/database/db_core.c
+++ b/src/database/db_core.c
@@ -399,7 +399,7 @@ static int run_post_backup_script(const char *backup_path, const char *backup_di
     return -1;
 }
 
-static int perform_database_backup_cycle(const char *reason, bool run_post_backup_hook) {
+static int perform_database_backup_cycle(const char *reason, bool run_post_backup_hook, bool abortable) {
     char backup_dir[PATH_MAX];
     char timestamped_backup_path[PATH_MAX];
 
@@ -423,7 +423,7 @@ static int perform_database_backup_cycle(const char *reason, bool run_post_backu
         return -1;
     }
 
-    if (backup_database(db_file_path, timestamped_backup_path) != 0) {
+    if (backup_database(db_file_path, timestamped_backup_path, abortable) != 0) {
         log_error("Failed to create %s database backup", reason);
         return -1;
     }
@@ -490,7 +490,7 @@ int maybe_run_scheduled_database_backup(void) {
         return 0;
     }
 
-    if (perform_database_backup_cycle("scheduled", true) != 0) {
+    if (perform_database_backup_cycle("scheduled", true, true) != 0) {
         return -1;
     }
 
@@ -880,7 +880,7 @@ int init_database_ex(const char *db_path, unsigned flags) {
     // Create an initial backup if this is a new database
     if (is_new_database) {
         log_info("Creating initial backup of new database");
-        if (perform_database_backup_cycle("initial", true) == 0) {
+        if (perform_database_backup_cycle("initial", true, true) == 0) {
             log_info("Initial backup created successfully");
             last_backup_time = time(NULL);
         } else {
@@ -922,7 +922,12 @@ void shutdown_database(void) {
         log_info("Skipping shutdown backup (read-only initialization)");
     } else if (db != NULL && db_file_path[0] != '\0') {
         log_info("Creating final backup before shutdown");
-        if (perform_database_backup_cycle("shutdown", true) == 0) {
+        // Not abortable: this is the deliberate one-time backup taken while
+        // already shutting down, so the abort flag is already guaranteed
+        // set -- an abortable copy would bail out immediately every time
+        // and never actually produce a backup. TimeoutStopSec is sized to
+        // give this the room it needs to finish instead.
+        if (perform_database_backup_cycle("shutdown", true, false) == 0) {
             log_info("Final backup created successfully");
         } else {
             log_warn("Failed to create final backup");

--- a/src/tools/rebuild_recordings.c
+++ b/src/tools/rebuild_recordings.c
@@ -520,7 +520,13 @@ int main(int argc, const char *argv[]) {
     init_logger();
     
     // Load configuration
+    // Zero-init before use: load_default_config() (called by load_config())
+    // reads config->streams to free() any pre-existing array before
+    // allocating a new one, which is only safe if the struct starts zeroed
+    // (every other real caller uses a zero-initialized global; this tool's
+    // config is a local, so it needs an explicit memset).
     config_t config;
+    memset(&config, 0, sizeof(config));
     if (load_config(&config) != 0) {
         log_error("Failed to load configuration");
         return 1;

--- a/src/web/api_handlers_system.c
+++ b/src/web/api_handlers_system.c
@@ -22,6 +22,7 @@
 #include <dirent.h>
 #include <limits.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <sqlite3.h>
 #include <curl/curl.h>
 #include <uv.h>
@@ -1523,14 +1524,28 @@ void handle_post_system_shutdown(const http_request_t *req, http_response_t *res
     log_info("Initiating shutdown through coordinator");
     initiate_shutdown();
 
-    // Schedule shutdown with a more robust approach for MIPS systems
-    extern volatile bool running;
+    extern _Atomic bool running;
     running = false;
+    // Let a long-running background operation (e.g. a scheduled DB backup)
+    // abort promptly instead of silently blocking this shutdown until it
+    // finishes -- mirrors request_restart()'s identical call for the
+    // restart path (main.c); see shutdown_coordinator.c's header comment
+    // for why this is a separate, lighter-weight flag from
+    // initiate_shutdown() above.
+    request_background_abort();
 
-    // Set an alarm to force exit if normal shutdown doesn't work
-    // This is especially important for Linux 4.4 embedded MIPS systems
-    log_info("Setting up fallback exit timer for Linux 4.4 compatibility");
-    alarm(15); // Force exit after 15 seconds if normal shutdown fails
+    // Deliberately no local alarm()-based force-exit timer here (this used
+    // to set one, framed as "more robust for Linux 4.4 embedded MIPS
+    // systems"): alarm() is a single process-wide timer, and it would race
+    // with the many short-lived, save/restore-disposition alarm() calls
+    // hls_unified_thread.c/hls_writer.c make elsewhere in the process --
+    // whichever fires first silently cancels whatever time was left on the
+    // other, since alarm() has no pause/resume. main()'s
+    // shutdown_watchdog_thread (a plain thread polling `running`, immune to
+    // that collision) already force-kills the process group process-wide if
+    // shutdown doesn't complete in time, covering this endpoint too -- see
+    // its comment in main.c for the full story, including the live gdb
+    // trace that first caught this exact collision on the restart path.
 
     // NOTE: We previously sent SIGTERM to self here, but this was causing system-wide shutdown
     // instead of just application shutdown. This has been removed to fix that issue.

--- a/tests/database/db_backup_test.c
+++ b/tests/database/db_backup_test.c
@@ -10,17 +10,22 @@
 #include <unistd.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <sys/stat.h>
+#include <limits.h>
 
 #include "database/db_core.h"
 #include "database/db_backup.h"
 #include "core/config.h"
 #include "core/logger.h"
+#include "core/shutdown_coordinator.h"
 
 // Test database path
 #define TEST_DB_PATH "/tmp/test_db.sqlite"
 #define TEST_BACKUP_PATH "/tmp/test_db.sqlite.bak"
 #define TEST_LARGE_DB_PATH "/tmp/test_db_large.sqlite"
 #define TEST_LARGE_BACKUP_PATH "/tmp/test_db_large.sqlite.bak"
+#define TEST_ABORT_DB_PATH "/tmp/test_db_abort.sqlite"
+#define TEST_ABORT_BACKUP_PATH "/tmp/test_db_abort.sqlite.bak"
 
 // Signal handler for simulating a crash
 static void simulate_crash(int sig) {
@@ -165,7 +170,7 @@ static int corrupt_database(void) {
 // Test backup functionality
 static int test_backup(void) {
     // Create a backup of the database
-    int rc = backup_database(TEST_DB_PATH, TEST_BACKUP_PATH);
+    int rc = backup_database(TEST_DB_PATH, TEST_BACKUP_PATH, true);
     if (rc != 0) {
         printf("Failed to create backup\n");
         return -1;
@@ -221,7 +226,7 @@ static int test_large_incremental_backup(void) {
     sqlite3_close(source);
     source = NULL;
 
-    if (backup_database(TEST_LARGE_DB_PATH, TEST_LARGE_BACKUP_PATH) != 0) {
+    if (backup_database(TEST_LARGE_DB_PATH, TEST_LARGE_BACKUP_PATH, true) != 0) {
         printf("Failed to create multi-batch database backup\n");
         goto cleanup;
     }
@@ -248,6 +253,264 @@ cleanup:
     if (backup) sqlite3_close(backup);
     unlink(TEST_LARGE_DB_PATH);
     unlink(TEST_LARGE_BACKUP_PATH);
+    return result;
+}
+
+// Regression test: a stuck main loop couldn't notice a pending restart while
+// backup_database() was mid-copy on a large database, because the batch loop
+// never checked for one. This silently swallowed every "Restart LightNVR"
+// click for as long as the backup took (tens of minutes on a multi-GB
+// production database). Verifies a backup requested to abort mid-flight
+// bails out promptly and leaves no partial temp file behind, rather than
+// running to completion.
+static int test_backup_aborts_when_shutdown_requested(void) {
+    sqlite3 *source = NULL;
+    sqlite3_stmt *stmt = NULL;
+    int result = -1;
+    int rc;
+    char temp_path[PATH_MAX];
+    struct stat st;
+
+    unlink(TEST_ABORT_DB_PATH);
+    unlink(TEST_ABORT_BACKUP_PATH);
+    snprintf(temp_path, sizeof(temp_path), "%s.tmp", TEST_ABORT_BACKUP_PATH);
+    unlink(temp_path);
+
+    rc = sqlite3_open(TEST_ABORT_DB_PATH, &source);
+    if (rc != SQLITE_OK) {
+        printf("Failed to create abort-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_exec(source, "PRAGMA page_size=4096;", NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to set abort-test fixture page size: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_exec(source,
+        "CREATE TABLE payload (id INTEGER PRIMARY KEY, data BLOB);",
+        NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to create abort-test table: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_prepare_v2(source,
+        "INSERT INTO payload(data) VALUES(zeroblob(?));", -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to prepare abort-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    // Larger than one BACKUP_STEP_PAGES batch (16MB) so the abort check
+    // between batches actually gets exercised before the copy would finish.
+    sqlite3_bind_int(stmt, 1, 20 * 1024 * 1024);
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+        printf("Failed to populate abort-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    sqlite3_finalize(stmt);
+    stmt = NULL;
+    sqlite3_close(source);
+    source = NULL;
+
+    // Simulate a restart/shutdown request arriving before the backup starts.
+    request_background_abort();
+
+    rc = backup_database(TEST_ABORT_DB_PATH, TEST_ABORT_BACKUP_PATH, true);
+    if (rc == 0) {
+        printf("Backup should have aborted early but reported success\n");
+        goto cleanup;
+    }
+
+    if (stat(temp_path, &st) == 0) {
+        printf("Aborted backup left behind a temp file: %s\n", temp_path);
+        goto cleanup;
+    }
+    if (stat(TEST_ABORT_BACKUP_PATH, &st) == 0) {
+        printf("Aborted backup should not have produced a final backup file\n");
+        goto cleanup;
+    }
+
+    printf("Backup aborted early on restart/shutdown request, as expected\n");
+    result = 0;
+
+cleanup:
+    if (stmt) sqlite3_finalize(stmt);
+    if (source) sqlite3_close(source);
+    unlink(TEST_ABORT_DB_PATH);
+    unlink(TEST_ABORT_BACKUP_PATH);
+    unlink(temp_path);
+    return result;
+}
+
+// Regression test for a bug introduced by the abort check above: the
+// deliberate one-time backup taken while the process is already shutting
+// down (shutdown_database()'s "final backup") shares this same code path,
+// but the abort flag is *always* already set by the time that one runs --
+// checking it there made every graceful shutdown's final backup bail out
+// instantly and never actually produce a backup. Relies on the previous
+// test having already left the process-wide abort flag set (it's never
+// reset -- see request_background_abort()'s header comment) to prove a
+// non-abortable backup completes anyway.
+static int test_backup_completes_when_not_abortable_even_if_abort_requested(void) {
+    sqlite3 *source = NULL;
+    sqlite3_stmt *stmt = NULL;
+    int result = -1;
+    int rc;
+
+    unlink(TEST_ABORT_DB_PATH);
+    unlink(TEST_ABORT_BACKUP_PATH);
+
+    rc = sqlite3_open(TEST_ABORT_DB_PATH, &source);
+    if (rc != SQLITE_OK) {
+        printf("Failed to create not-abortable-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_exec(source, "PRAGMA page_size=4096;", NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to set not-abortable-test fixture page size: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_exec(source,
+        "CREATE TABLE payload (id INTEGER PRIMARY KEY, data BLOB);",
+        NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to create not-abortable-test table: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_prepare_v2(source,
+        "INSERT INTO payload(data) VALUES(zeroblob(?));", -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to prepare not-abortable-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    // Larger than one BACKUP_STEP_PAGES batch (16MB), so if abortable were
+    // mistakenly honored here, it would bail out before finishing.
+    sqlite3_bind_int(stmt, 1, 20 * 1024 * 1024);
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+        printf("Failed to populate not-abortable-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    sqlite3_finalize(stmt);
+    stmt = NULL;
+    sqlite3_close(source);
+    source = NULL;
+
+    if (!is_background_abort_requested()) {
+        printf("Test precondition failed: expected the abort flag to already be set\n");
+        goto cleanup;
+    }
+
+    rc = backup_database(TEST_ABORT_DB_PATH, TEST_ABORT_BACKUP_PATH, false);
+    if (rc != 0) {
+        printf("Non-abortable backup should have completed despite the pending abort request\n");
+        goto cleanup;
+    }
+    {
+        struct stat st;
+        if (stat(TEST_ABORT_BACKUP_PATH, &st) != 0 || st.st_size == 0) {
+            printf("Non-abortable backup reported success but produced no output file\n");
+            goto cleanup;
+        }
+    }
+
+    printf("Non-abortable backup completed despite a pending restart/shutdown request, as expected\n");
+    result = 0;
+
+cleanup:
+    if (stmt) sqlite3_finalize(stmt);
+    if (source) sqlite3_close(source);
+    unlink(TEST_ABORT_DB_PATH);
+    unlink(TEST_ABORT_BACKUP_PATH);
+    return result;
+}
+
+// Regression test for a bug found live in production: once the copy loop's
+// abort check lets a batch that reaches SQLITE_DONE finish (by design -- see
+// the comment in backup_database()), the *next* step is a full
+// PRAGMA integrity_check verification pass over the whole backup file. For a
+// multi-gigabyte database that scan alone can take as long as the copy it
+// verifies, and had no abort check at all -- a live gdb backtrace during a
+// stuck restart showed the main thread parked in sqlite3BtreeIntegrityCheck
+// long after the copy loop's own fix should have made it responsive.
+// Uses a single-batch fixture (under one BACKUP_STEP_PAGES) so the copy loop
+// itself reaches SQLITE_DONE without ever consulting the abort flag, forcing
+// this test to exercise the verification-phase check specifically. Relies on
+// the process-wide abort flag already being set by the earlier abort test.
+static int test_backup_aborts_during_verification_when_shutdown_requested(void) {
+    sqlite3 *source = NULL;
+    sqlite3_stmt *stmt = NULL;
+    int result = -1;
+    int rc;
+    char temp_path[PATH_MAX];
+    struct stat st;
+
+    unlink(TEST_ABORT_DB_PATH);
+    unlink(TEST_ABORT_BACKUP_PATH);
+    snprintf(temp_path, sizeof(temp_path), "%s.tmp", TEST_ABORT_BACKUP_PATH);
+    unlink(temp_path);
+
+    rc = sqlite3_open(TEST_ABORT_DB_PATH, &source);
+    if (rc != SQLITE_OK) {
+        printf("Failed to create verification-abort-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_exec(source, "PRAGMA page_size=4096;", NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to set verification-abort-test fixture page size: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    rc = sqlite3_exec(source,
+        "CREATE TABLE payload (id INTEGER PRIMARY KEY, data BLOB);",
+        NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to create verification-abort-test table: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    // Many small rows rather than one big blob: integrity_check's VM cost is
+    // dominated by per-cell/per-page bookkeeping (ordering, checksums), not
+    // raw bytes, so a cell-dense B-tree crosses BACKUP_VERIFY_PROGRESS_OPS
+    // reliably while still fitting in well under one BACKUP_STEP_PAGES batch
+    // (16MB) -- a single large blob (tried first) didn't generate enough VM
+    // ops to ever invoke the progress callback.
+    rc = sqlite3_exec(source,
+        "WITH RECURSIVE seq(x) AS ("
+        "  SELECT 1 UNION ALL SELECT x+1 FROM seq WHERE x < 300000"
+        ") INSERT INTO payload(data) SELECT randomblob(16) FROM seq;",
+        NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        printf("Failed to populate verification-abort-test fixture: %s\n", sqlite3_errmsg(source));
+        goto cleanup;
+    }
+    sqlite3_close(source);
+    source = NULL;
+
+    if (!is_background_abort_requested()) {
+        printf("Test precondition failed: expected the abort flag to already be set\n");
+        goto cleanup;
+    }
+
+    rc = backup_database(TEST_ABORT_DB_PATH, TEST_ABORT_BACKUP_PATH, true);
+    if (rc == 0) {
+        printf("Backup should have aborted during verification but reported success\n");
+        goto cleanup;
+    }
+    if (stat(temp_path, &st) == 0) {
+        printf("Backup aborted during verification left behind a temp file: %s\n", temp_path);
+        goto cleanup;
+    }
+    if (stat(TEST_ABORT_BACKUP_PATH, &st) == 0) {
+        printf("Backup aborted during verification should not have produced a final backup file\n");
+        goto cleanup;
+    }
+
+    printf("Backup aborted during post-copy verification on restart/shutdown request, as expected\n");
+    result = 0;
+
+cleanup:
+    if (stmt) sqlite3_finalize(stmt);
+    if (source) sqlite3_close(source);
+    unlink(TEST_ABORT_DB_PATH);
+    unlink(TEST_ABORT_BACKUP_PATH);
+    unlink(temp_path);
     return result;
 }
 
@@ -294,7 +557,22 @@ int main(void) {
         printf("Test failed: Large incremental backup failed\n");
         return 1;
     }
-    
+
+    if (test_backup_aborts_when_shutdown_requested() != 0) {
+        printf("Test failed: Backup did not abort early on restart/shutdown request\n");
+        return 1;
+    }
+
+    if (test_backup_aborts_during_verification_when_shutdown_requested() != 0) {
+        printf("Test failed: Backup did not abort during post-copy verification on restart/shutdown request\n");
+        return 1;
+    }
+
+    if (test_backup_completes_when_not_abortable_even_if_abort_requested() != 0) {
+        printf("Test failed: Non-abortable backup did not complete despite a pending abort request\n");
+        return 1;
+    }
+
     // Corrupt the database
     if (corrupt_database() != 0) {
         printf("Test failed: Could not corrupt database\n");

--- a/tests/database/db_backup_test.c
+++ b/tests/database/db_backup_test.c
@@ -346,10 +346,10 @@ cleanup:
 // down (shutdown_database()'s "final backup") shares this same code path,
 // but the abort flag is *always* already set by the time that one runs --
 // checking it there made every graceful shutdown's final backup bail out
-// instantly and never actually produce a backup. Relies on the previous
-// test having already left the process-wide abort flag set (it's never
-// reset -- see request_background_abort()'s header comment) to prove a
-// non-abortable backup completes anyway.
+// instantly and never actually produce a backup. Sets the (idempotent,
+// never-reset -- see request_background_abort()'s header comment)
+// process-wide abort flag explicitly rather than relying on a previous
+// test having left it set, so this test doesn't depend on execution order.
 static int test_backup_completes_when_not_abortable_even_if_abort_requested(void) {
     sqlite3 *source = NULL;
     sqlite3_stmt *stmt = NULL;
@@ -394,10 +394,7 @@ static int test_backup_completes_when_not_abortable_even_if_abort_requested(void
     sqlite3_close(source);
     source = NULL;
 
-    if (!is_background_abort_requested()) {
-        printf("Test precondition failed: expected the abort flag to already be set\n");
-        goto cleanup;
-    }
+    request_background_abort();
 
     rc = backup_database(TEST_ABORT_DB_PATH, TEST_ABORT_BACKUP_PATH, false);
     if (rc != 0) {
@@ -433,8 +430,9 @@ cleanup:
 // long after the copy loop's own fix should have made it responsive.
 // Uses a single-batch fixture (under one BACKUP_STEP_PAGES) so the copy loop
 // itself reaches SQLITE_DONE without ever consulting the abort flag, forcing
-// this test to exercise the verification-phase check specifically. Relies on
-// the process-wide abort flag already being set by the earlier abort test.
+// this test to exercise the verification-phase check specifically. Sets the
+// abort flag explicitly (it's idempotent) rather than relying on an earlier
+// test having already set it, so this test doesn't depend on execution order.
 static int test_backup_aborts_during_verification_when_shutdown_requested(void) {
     sqlite3 *source = NULL;
     sqlite3_stmt *stmt = NULL;
@@ -483,10 +481,7 @@ static int test_backup_aborts_during_verification_when_shutdown_requested(void) 
     sqlite3_close(source);
     source = NULL;
 
-    if (!is_background_abort_requested()) {
-        printf("Test precondition failed: expected the abort flag to already be set\n");
-        goto cleanup;
-    }
+    request_background_abort();
 
     rc = backup_database(TEST_ABORT_DB_PATH, TEST_ABORT_BACKUP_PATH, true);
     if (rc == 0) {


### PR DESCRIPTION
## Problem

The web UI's "Restart LightNVR" button (and `systemctl stop`/`restart` generally) could silently hang for tens of minutes, or indefinitely, on an install with a large database. Root-caused via `gdb -p <pid> -batch -ex 'thread apply all bt'` on a live stuck process to four independent, stacked bugs:

1. **`maybe_run_scheduled_database_backup()`'s batched copy loop never checked for a pending restart/shutdown.** On a multi-gigabyte DB, a scheduled backup can take longer than the restart-check interval, so a restart request just sat there until the in-flight backup finished on its own — sometimes tens of minutes.
2. **`daemon.c` silently overrides `main.c`'s signal handler.** `daemonize()` installs its own `sigaction()` for `SIGTERM`/`SIGINT` *after* `main.c`'s `init_signals()` already ran — and daemon mode (`-d`) is how the systemd service always launches. So `main.c`'s handler was dead code for every real `systemctl stop`.
3. **`alarm()` is a single process-wide timer, shared with unrelated code.** Both `main.c` and `daemon.c` used `alarm()`+`SIGALRM` as a "force exit if shutdown hangs" watchdog, but `hls_unified_thread.c`/`hls_writer.c` reuse the *same* timer in ~15 places as a short per-operation timeout around individual writer/context-close calls. Any one of those firing during shutdown silently discards whatever time was left on the outer watchdog alarm (confirmed live via `gdb`: a shutdown that should have had ~570s left was killed at 45s by exactly this collision).
4. **A fourth, independent watchdog** — the fork-based cleanup timer in `main()`'s `cleanup:` block — has its own hardcoded `sleep(30)`/`sleep(15)` budget, unrelated to (and much shorter than) what a large-DB backup actually needs.

This isn't just an annoyance: a `SIGKILL` landing mid-write because of one of these premature timeouts corrupted a production database during a live investigation of this exact issue.

## Fix

- New `request_background_abort()`/`is_background_abort_requested()` in `shutdown_coordinator.c` — an independent, async-signal-safe flag, separate from the full shutdown-coordinator teardown machinery, that can be raised the instant a restart/shutdown is first requested.
- `backup_database()` takes a new `abortable` parameter. When true, it polls the flag between copy batches and during the post-copy `PRAGMA integrity_check` (via a `sqlite3_progress_handler` hook, since that pass alone can take as long as the copy on a large DB) and bails out early with no partial file left behind. The scheduled backup passes `true`; the deliberate one-time backup taken while already shutting down passes `false` (the flag is already guaranteed set by then, so an abortable copy there would never actually produce a backup).
- `daemon_signal_handler()` (the handler actually live in production) now calls `request_background_abort()` too.
- Replaced both `alarm()`-based watchdogs with a single dedicated thread (`start_shutdown_watchdog_thread()`) that polls `running` once a second and force-kills the process group after a timeout — immune to any `alarm()`/`SIGALRM` collision from the HLS writer code, since it doesn't use that timer at all.
- Bumped the fork-based cleanup watchdog's sleeps to share the same timeout budget as the thread watchdog, preserving its "still attempt `execv()` restart even after a forced kill" behavior.
- Incidentally found and fixed: `rebuild_recordings`'s local `config_t` wasn't zero-initialized before `load_config()`, which frees `config->streams` on the (safe-for-every-other-caller, zero-initialized-global) assumption that it starts zeroed.

## Testing

- New unit tests in `tests/database/db_backup_test.c`: an abortable backup aborts mid-copy with no partial file, the same for the verification pass, and a non-abortable backup completes despite a pending abort request.
- Full clean rebuild against `0.41.7` + `ctest -R db_backup` / `test_shutdown_coordinator` all green.
- Validated in production on the timeout budget: a live `systemctl stop` on a 2.6GB+/~93k-recording database completed the full final backup (~9m40s) and shut down cleanly with zero `SIGKILL`s, `PRAGMA integrity_check: ok` afterward.
- **Validated again since, under real conditions rather than a deliberate test:** a restart triggered via the actual web UI button after a power outage completed cleanly in ~8.5 minutes with no hang and no manual intervention.

## Note on the corruption incident

A `SIGKILL` mid-write during the investigation (before this fix existed) did corrupt the live DB once; recovery used SQLite's `.recover` on an isolated copy, validated, then `rebuild_recordings` to backfill the gap. No corrupted state is included in this PR — just the fix and the tests that would have caught it.

---

Implemented and tested by Claude Code (Anthropic), driven by @davlaw. I'm not a C programmer myself, so credit for the actual fix goes to Claude — I reviewed the diff and PR wording before opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)