### PR TITLE
fix(onvif): guard NULL SOAP allocations and free discovery buffers

### DIFF
--- a/src/core/path_utils.c
+++ b/src/core/path_utils.c
@@ -243,8 +243,11 @@ int chmod_recursive(const char *path, mode_t mode) {
     if (offset >= PATH_MAX) {
         // If the path is already max length, we won't be able to append anything to
         // it. In this case emit an error and return.
+        // closedir() releases the DIR and the fd it took ownership of above;
+        // close(fd) here would both leak the DIR and close the descriptor out
+        // from under it.
         log_error("Path too long to recur for chmod");
-        close(fd);
+        closedir(dir);
         return -1;
     }
     char *path_ptr = full_path + offset;

--- a/src/video/onvif_device_management.c
+++ b/src/video/onvif_device_management.c
@@ -80,11 +80,23 @@ static char* send_soap_request(const char *device_url, const char *soap_action, 
         security_header = strdup("");
         log_info("No authentication credentials provided");
     }
-    
+
+    /* onvif_create_security_header() returns NULL when it cannot obtain random
+     * bytes (e.g. /dev/urandom unavailable under fd exhaustion), and strdup()
+     * returns NULL under memory pressure. Both used to reach strlen() below. */
+    if (!security_header) {
+        log_error("Failed to create WS-Security header for device management request");
+        goto cleanup;
+    }
+
     // Try simpler SOAP envelope format for better compatibility with onvif_simple_server
     // Based on the curl example that worked
     soap_envelope = malloc(strlen(request_body) + strlen(security_header) + 1024);
-    
+    if (!soap_envelope) {
+        log_error("Failed to allocate SOAP envelope for device management request");
+        goto cleanup;
+    }
+
     // First try with simplified envelope format
     sprintf(soap_envelope,
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
@@ -130,6 +142,10 @@ static char* send_soap_request(const char *device_url, const char *soap_action, 
 
         free(soap_envelope);
         soap_envelope = malloc(strlen(request_body) + strlen(security_header) + 1024);
+        if (!soap_envelope) {
+            log_error("Failed to allocate retry SOAP envelope for device management request");
+            goto cleanup;
+        }
         sprintf(soap_envelope,
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             "<SOAP-ENV:Envelope "
@@ -179,13 +195,14 @@ static char* send_soap_request(const char *device_url, const char *soap_action, 
                   strlen(response));
     }
     
+cleanup:
     // Clean up
     curl_easy_cleanup(curl);
     curl_slist_free_all(headers);
     free(soap_envelope);
     free(security_header);
     free(chunk.memory);
-    
+
     return response;
 }
 

--- a/src/video/onvif_discovery_response.c
+++ b/src/video/onvif_discovery_response.c
@@ -351,6 +351,7 @@ int receive_discovery_responses(onvif_device_info_t *devices, int max_devices) {
         if (ret < 0) {
             log_error("Select failed: %s", strerror(errno));
             close(sock);
+            free(buffer);
             return -1;
         } else if (ret == 0) {
             // Timeout, no data available
@@ -608,6 +609,7 @@ int receive_extended_discovery_responses(onvif_device_info_t *devices, int max_d
         if (ret < 0) {
             log_error("Select failed: %s", strerror(errno));
             close(sock);
+            free(buffer);
             return count;  // Return any devices found so far
         } else if (ret == 0) {
             // Timeout, no data available

--- a/src/video/onvif_ptz.c
+++ b/src/video/onvif_ptz.c
@@ -62,8 +62,25 @@ static char* send_ptz_soap_request(const char *ptz_url, const char *soap_action,
     } else {
         security_header = strdup("");
     }
-    
+
+    /* onvif_create_security_header() returns NULL when it cannot obtain random
+     * bytes (e.g. /dev/urandom unavailable under fd exhaustion), and strdup()
+     * returns NULL under memory pressure. Both used to reach strlen() below. */
+    if (!security_header) {
+        log_error("Failed to create WS-Security header for PTZ request");
+        curl_easy_cleanup(curl);
+        free(chunk.memory);
+        return NULL;
+    }
+
     soap_envelope = malloc(strlen(request_body) + strlen(security_header) + 2048);
+    if (!soap_envelope) {
+        log_error("Failed to allocate SOAP envelope for PTZ request");
+        free(security_header);
+        curl_easy_cleanup(curl);
+        free(chunk.memory);
+        return NULL;
+    }
     sprintf(soap_envelope,
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         "<s:Envelope xmlns:s=\"http://www.w3.org/2003/05/soap-envelope\" "


### PR DESCRIPTION
Three memory-safety fixes found by running `gcc -fanalyzer` over the whole tree and hand-verifying each hit.

## 1. NULL dereference crash in ONVIF PTZ and device management

`onvif_ptz.c` and `onvif_device_management.c` did this:

```c
security_header = onvif_create_security_header(username, password);  // may return NULL
soap_envelope   = malloc(strlen(request_body) + strlen(security_header) + 2048);
sprintf(soap_envelope, ...);                                         // malloc unchecked
```

Both pointers can legitimately be NULL. `onvif_create_security_header()` returns NULL when it cannot obtain random bytes — it falls back to `fopen("/dev/urandom")`, which fails under **fd exhaustion**, so this isn't OOM-only — and the envelope `malloc` fails under memory pressure. Either one takes down the whole daemon.

What makes this more than theoretical: **`onvif_detection.c:148` and `onvif_imaging.c:110`/`:126` already perform exactly these two checks.** The hardening landed on two of the four SOAP callers and was missed on the other two. This brings them in line.

`onvif_device_management.c` has two envelope allocations (initial + retry-with-alternative-format); both are now checked. It already had a single NULL-safe cleanup block at the end of the function, so the new paths `goto cleanup` rather than duplicating it — `response` is NULL-initialised, so they return NULL as before, and `res` is not read on those paths.

## 2. 8 KB heap leak per `select()` failure in both discovery loops

`receive_discovery_responses()` and `receive_extended_discovery_responses()` both allocate an 8 KB receive buffer and free it on every exit — except the `select()` failure path, which does `close(sock); return ...;` and drops it.

Worth noting these treat *any* negative `select()` return as fatal, **`EINTR` included**, so this is reachable during normal operation in a signal-heavy process, and it accumulates because discovery runs periodically. The analyzer only flagged the second function; the first has the identical bug and is fixed too.

## 3. `DIR` leak and ownership violation in `chmod_recursive()`

On the path-too-long branch the function called `close(fd)` — despite its own comment three lines earlier stating *"fd is now owned by dir; do not close it separately"* — and never called `closedir()`. That leaks the `DIR` and closes the descriptor out from under it. Now `closedir(dir)`.

## Testing

**No new tests, deliberately.** All three are allocation/syscall failure paths that need fault injection to reach. The `chmod_recursive()` case in particular leaks *memory only* — the fd was released either way — so an fd-count regression test would pass identically with and without the fix, which would be a test that cannot fail.

Verified instead with objective before/after evidence:

- **`-fanalyzer` on the four touched files: 7 memory-safety warnings → 0.** Removed: `path_utils.c:247` leak of `dir`; `onvif_discovery_response.c:610` leak of `buffer`; `onvif_ptz.c:66,67` and `onvif_device_management.c:86,89,133` possibly-NULL arguments. Remaining warnings in those files are pre-existing and unrelated (unused statics, `-Wformat-nonliteral`, and a pre-existing `fd may be used uninitialized` at `path_utils.c:224`).
- Existing suites pass: `test_path_utils` (34), `test_onvif_discovery_response` (2), `test_onvif_soap_fault` (13).
- Full `lightnvr` target builds with no new warnings.

Happy to split this into three PRs if you'd prefer them reviewed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
